### PR TITLE
E2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ VERSION_NSP ?= $(VERSION)
 VERSION_CTRAFFIC ?= $(VERSION)
 VERSION_FRONTEND ?= $(VERSION)
 
+E2E_FOCUS ?= ""
+TRAFFIC_GENERATOR_CMD ?= "docker exec -i {trench}"
+
 REGISTRY ?= localhost:5000/meridio
 
 .PHONY: all
@@ -75,9 +78,13 @@ default: load-balancer proxy target ipam nsp ctraffic frontend
 lint: 
 	golangci-lint run ./...
 
+.PHONY: e2e
+e2e: 
+	ginkgo --failFast --focus=$(E2E_FOCUS) ./test/e2e/... -- -traffic-generator-cmd=$(TRAFFIC_GENERATOR_CMD)
+
 .PHONY: test
 test: 
-	go test ./...
+	go test -v ./... -short
 
 .PHONY: check
 check: lint test

--- a/deployments/helm/templates/_helpers.tpl
+++ b/deployments/helm/templates/_helpers.tpl
@@ -61,7 +61,7 @@ Set IP Family
 {{- end -}}
 
 {{- define "meridio.vlan.networkServiceName" -}}
-{{- printf "%s.%s" .Values.vlan.networkServiceName .Release.Namespace -}}
+{{- printf "%s.%s.%s" .Values.vlan.networkServiceName .Values.trench.name .Release.Namespace -}}
 {{- end -}}
 
 {{- define "meridio.vrrps" -}}

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,46 @@
+# Development
+
+## Testing
+
+### E2E tests
+
+#### Tools
+
+- ginkgo - https://onsi.github.io/ginkgo/#getting-ginkgo
+
+#### Environment
+
+Before executing the tests, this environment should be deployed:
+- 1 Host for each trench with the network interface configured and ctraffic available
+- 2 Worker nodes
+- NSM 1.0
+- Spire configured for NSM, the trench-a and the trench-b
+- 2 identical trenches ("trench-a" and "trench-b") running in namespace "red"
+    - 2 LBs
+    - 4 Targets
+    - 2 VIPs
+        - 20.0.0.1/32
+        - 2000::1/128
+On kind, this environment can be deployed by following the steps described in the [demo instructions](https://github.com/Nordix/Meridio/tree/master/docs/demo/).
+
+#### Test Execution
+
+Run all e2e tests:
+```
+make e2e
+```
+
+By default, the traffic is sent from a container named with the name of the trench ("docker exec -i {trench}"). This can be changed by using the TRAFFIC_GENERATOR_CMD env variable in the Makefile.
+```
+make e2e TRAFFIC_GENERATOR_CMD="docker exec -i {trench}"
+```
+
+To execute a single test, the E2E_FOCUS env variable in the Makefile can be used:
+```
+make e2e E2E_FOCUS="Attractor"
+```
+4 test suites are available:
+- IngressTraffic
+- MultiTrenches
+- Scaling
+- Target

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -3,5 +3,7 @@
 ## Table of contents
 
 * [Overview](overview.md)
+* [Development](development.md)
+* [Operator](https://github.com/Nordix/Meridio-Operator)
 * [Google Drive](https://drive.google.com/drive/folders/1ZSAzXkk13_LJnTDGPLC8OR-zlEYdCV2D?usp=sharing)
-* [pkg.go.dev](https://pkg.go.dev/github.com/nordix/meridio#readme-meridio)
+* [pkg.go.dev](https://pkg.go.dev/github.com/nordix/meridio)

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,8 @@ require (
 	github.com/networkservicemesh/sdk v1.0.0
 	github.com/networkservicemesh/sdk-sriov v1.0.0
 	github.com/nordix/meridio-operator v0.0.0-20210823114908-9c4d92ddee94
+	github.com/onsi/ginkgo v1.16.4
+	github.com/onsi/gomega v1.15.0
 	github.com/open-policy-agent/opa v0.30.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -277,6 +277,7 @@ github.com/edwarnicke/grpcfd v0.1.0/go.mod h1:rHihB9YvNMixz8rS+ZbwosI2kj65VLkeyY
 github.com/edwarnicke/serialize v0.0.0-20200705214914-ebc43080eecf/go.mod h1:XvbCO/QGsl3X8RzjBMoRpkm54FIAZH5ChK2j+aox7pw=
 github.com/edwarnicke/serialize v1.0.7 h1:geX8vmyu8Ij2S5fFIXjy9gBDkKxXnrMIzMoDvV0Ddac=
 github.com/edwarnicke/serialize v1.0.7/go.mod h1:y79KgU2P7ALH/4j37uTSIdNavHFNttqN7pzO6Y8B2aw=
+github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -372,6 +373,7 @@ github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus v0.0.0-20151105175453-c7fdd8b5cd55/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
@@ -520,6 +522,7 @@ github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmK
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.10 h1:6q5mVkdH/vYmqngx7kZQTjJ5HRsx+ImorDIEQ+beJgc=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
@@ -604,6 +607,7 @@ github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:F
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/mna/pigeon v0.0.0-20180808201053-bb0192cfc2ae/go.mod h1:Iym28+kJVnC1hfQvv5MUtI6AiFFzvQjHcvI4RFTG/04=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mount v0.2.0 h1:WhCW5B355jtxndN5ovugJlMFJawbUODuW8fSnEH6SSM=
 github.com/moby/sys/mount v0.2.0/go.mod h1:aAivFE2LB3W4bACsUXChRHQ0qKWsetY4Y9V7sxOougM=
@@ -648,6 +652,9 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nordix/meridio-operator v0.0.0-20210823114908-9c4d92ddee94 h1:jj8DFJ/Kb/qYULEoZ1g7xM35J9cA5GY83kELCWlVtsM=
 github.com/nordix/meridio-operator v0.0.0-20210823114908-9c4d92ddee94/go.mod h1:+6ONpt/tecB7DiyMpBTd1Xc3D7fOPdmAG2IyXxLYOF4=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -663,6 +670,8 @@ github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
+github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -670,6 +679,8 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.15.0 h1:WjP/FQ/sk43MRmnEcT+MlDw2TFvkrXlprrPST/IudjU=
+github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/open-policy-agent/opa v0.16.1/go.mod h1:P0xUE/GQAAgnvV537GzA0Ikw4+icPELRT327QJPkaKY=
 github.com/open-policy-agent/opa v0.30.1 h1:L8d1DuFyva7E+l6fX5SQktCdAT5TqdXv62LzDs0rcP0=
@@ -1038,6 +1049,7 @@ golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210224082022-3d97a244fca7/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
@@ -1129,6 +1141,7 @@ golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201202213521-69691e467435/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1220,6 +1233,7 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
@@ -1369,6 +1383,7 @@ gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76
 gopkg.in/square/go-jose.v2 v2.4.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
 gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright (c) 2021 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/nordix/meridio/test/e2e/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes"
+)
+
+var trafficGeneratorCMD string
+
+const (
+	timeout              = time.Minute * 3
+	interval             = time.Second * 2
+	trench               = "trench-a"
+	targetDeploymentName = "target-a"
+	namespace            = "red"
+	networkServiceName   = "load-balancer"
+	port                 = "5000"
+	ipv4                 = "20.0.0.1"
+	ipv6                 = "[2000::1]"
+	numberOfTargets      = 4
+	ipPort               = "20.0.0.1:5000"
+	trenchB              = "trench-b"
+)
+
+var (
+	clientset *kubernetes.Clientset
+)
+
+func init() {
+	flag.StringVar(&trafficGeneratorCMD, "traffic-generator-cmd", "docker exec -i {trench}", "Command to use to connect to the traffic generator. All occurences of '{trench}' will be replaced with the trench name.")
+}
+
+func TestE2e(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "E2e Suite")
+}
+
+var _ = BeforeSuite(func() {
+	var err error
+	clientset, err = utils.GetClientSet()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/test/e2e/ingress_traffic_test.go
+++ b/test/e2e/ingress_traffic_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright (c) 2021 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"fmt"
+
+	"github.com/nordix/meridio/test/e2e/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IngressTraffic", func() {
+
+	Context("When trench 'trench-a' is deployed in namespace 'red' with 2 VIP addresses (20.0.0.1:5000, [2000::1]:5000) and 4 target pods running ctraffic", func() {
+
+		var (
+			lostConnections    map[string]int
+			lastingConnections map[string]int
+			vip                string
+		)
+
+		JustBeforeEach(func() {
+			var err error
+			ipPort := fmt.Sprintf("%s:%s", vip, port)
+			lastingConnections, lostConnections, err = utils.SendTraffic(trafficGeneratorCMD, trench, namespace, ipPort, 400, 100)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		When("sending traffic to a registered IPv4", func() {
+			BeforeEach(func() {
+				vip = ipv4
+			})
+			It("should receive the traffic correctly", func() {
+				By("Checking if all targets have receive traffic with no traffic interruption (no lost connection)")
+				Expect(len(lostConnections)).To(Equal(0))
+				Expect(len(lastingConnections)).To(Equal(4))
+			})
+		})
+
+		When("sending traffic to a registered IPv6", func() {
+			BeforeEach(func() {
+				vip = ipv6
+			})
+			It("should receive the traffic correctly", func() {
+				By("Checking if all targets have receive traffic with no traffic interruption (no lost connection)")
+				Expect(len(lostConnections)).To(Equal(0))
+				Expect(len(lastingConnections)).To(Equal(4))
+			})
+		})
+
+	})
+
+})

--- a/test/e2e/multi_trenches_test.go
+++ b/test/e2e/multi_trenches_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright (c) 2021 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nordix/meridio/test/e2e/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("MultiTrenches", func() {
+
+	Context("With two trenches (trench-a and trench-b) deployed in namespace 'red' containing both 2 VIP addresses (20.0.0.1:5000, [2000::1]:5000) and 4 target pods in each trench running ctraffic", func() {
+
+		var (
+			targetPod *v1.Pod
+		)
+
+		BeforeEach(func() {
+			if targetPod != nil {
+				return
+			}
+			listOptions := metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("app=%s", targetDeploymentName),
+			}
+			pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), listOptions)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(pods.Items)).To(BeNumerically(">", 0))
+			targetPod = &pods.Items[0]
+		})
+
+		When("traffic is sent on 2 trenches at the same time with the same VIP address", func() {
+			var (
+				trenchALastingConns map[string]int
+				trenchALostConns    map[string]int
+				trenchBLastingConns map[string]int
+				trenchBLostConns    map[string]int
+			)
+
+			BeforeEach(func() {
+				trenchADone := make(chan bool)
+				var trenchAErr error
+				trenchBDone := make(chan bool)
+				var trenchBErr error
+				go func() {
+					trenchALastingConns, trenchALostConns, trenchAErr = utils.SendTraffic(trafficGeneratorCMD, trench, namespace, ipPort, 400, 100)
+					trenchADone <- true
+				}()
+				go func() {
+					trenchBLastingConns, trenchBLostConns, trenchBErr = utils.SendTraffic(trafficGeneratorCMD, trenchB, namespace, ipPort, 400, 100)
+					trenchBDone <- true
+				}()
+				<-trenchADone
+				<-trenchBDone
+				Expect(trenchAErr).NotTo(HaveOccurred())
+				Expect(trenchBErr).NotTo(HaveOccurred())
+			})
+
+			It("should be possible to send traffic on the 2 trenches using the same VIP", func() {
+				Expect(len(trenchALostConns)).To(Equal(0))
+				Expect(len(trenchALastingConns)).To(Equal(4))
+				Expect(len(trenchBLostConns)).To(Equal(0))
+				Expect(len(trenchBLastingConns)).To(Equal(4))
+			})
+		})
+
+		When("a target disconnects from a trench and connect to another one", func() {
+			BeforeEach(func() {
+				_, err := utils.PodExec(targetPod, "ctraffic", []string{"./target-client", "disconnect", "-ns", networkServiceName, "-t", trench})
+				Expect(err).NotTo(HaveOccurred())
+				_, err = utils.PodExec(targetPod, "ctraffic", []string{"./target-client", "connect", "-ns", networkServiceName, "-t", trenchB})
+				Expect(err).NotTo(HaveOccurred())
+				_, err = utils.PodExec(targetPod, "ctraffic", []string{"./target-client", "request", "-ns", networkServiceName, "-t", trenchB})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				_, err := utils.PodExec(targetPod, "ctraffic", []string{"./target-client", "connect", "-ns", networkServiceName, "-t", trench})
+				Expect(err).NotTo(HaveOccurred())
+				_, err = utils.PodExec(targetPod, "ctraffic", []string{"./target-client", "request", "-ns", networkServiceName, "-t", trench})
+				Expect(err).NotTo(HaveOccurred())
+				_, err = utils.PodExec(targetPod, "ctraffic", []string{"./target-client", "disconnect", "-ns", networkServiceName, "-t", trenchB})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should receive the traffic on the other trench", func() {
+				By("Verifying trench-a has only 3 targets")
+				lastingConn, lostConn, err := utils.SendTraffic(trafficGeneratorCMD, trench, namespace, ipPort, 400, 100)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(lostConn)).To(Equal(0))
+				Expect(len(lastingConn)).To(Equal(3))
+
+				By("Verifying trench-b has only 5 targets")
+				lastingConn, lostConn, err = utils.SendTraffic(trafficGeneratorCMD, trenchB, namespace, ipPort, 400, 100)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(lostConn)).To(Equal(0))
+				Expect(len(lastingConn)).To(Equal(5))
+			})
+		})
+
+	})
+})

--- a/test/e2e/scaling_test.go
+++ b/test/e2e/scaling_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright (c) 2021 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nordix/meridio/test/e2e/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Scaling", func() {
+
+	Context("When trench 'trench-a' is deployed in namespace 'red' with 2 VIP addresses (20.0.0.1:5000, [2000::1]:5000) and 4 target pods running ctraffic", func() {
+
+		var (
+			replicas int
+			scale    *autoscalingv1.Scale
+		)
+
+		BeforeEach(func() {
+			replicas = numberOfTargets
+			scale = &autoscalingv1.Scale{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      targetDeploymentName,
+					Namespace: namespace,
+				},
+				Spec: autoscalingv1.ScaleSpec{
+					Replicas: int32(replicas),
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			scale.Spec.Replicas = int32(replicas)
+			_, err := clientset.AppsV1().Deployments(namespace).UpdateScale(context.Background(), targetDeploymentName, scale, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() bool {
+				deployment, err := clientset.AppsV1().Deployments(namespace).Get(context.Background(), targetDeploymentName, metav1.GetOptions{})
+				if err != nil {
+					return false
+				}
+				listOptions := metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("app=%s", targetDeploymentName),
+				}
+				pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), listOptions)
+				if err != nil {
+					return false
+				}
+				return len(pods.Items) == int(deployment.Status.Replicas) && deployment.Status.ReadyReplicas == deployment.Status.Replicas
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		AfterEach(func() {
+			scale.Spec.Replicas = numberOfTargets
+			_, err := clientset.AppsV1().Deployments(namespace).UpdateScale(context.Background(), targetDeploymentName, scale, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() bool {
+				deployment, err := clientset.AppsV1().Deployments(namespace).Get(context.Background(), targetDeploymentName, metav1.GetOptions{})
+				if err != nil {
+					return false
+				}
+				listOptions := metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("app=%s", targetDeploymentName),
+				}
+				pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), listOptions)
+				if err != nil {
+					return false
+				}
+				return len(pods.Items) == int(deployment.Status.Replicas) && deployment.Status.ReadyReplicas == deployment.Status.Replicas
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		When("scaling targets down", func() {
+			BeforeEach(func() {
+				replicas = 3
+			})
+			It("should receive the traffic correctly", func() {
+				By("Checking if all targets have receive traffic with no traffic interruption (no lost connection)")
+				lastingConnections, lostConnections, err := utils.SendTraffic(trafficGeneratorCMD, trench, namespace, ipPort, 400, 100)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(lostConnections)).To(Equal(0))
+				Expect(len(lastingConnections)).To(Equal(replicas))
+			})
+		})
+
+		When("scaling targets up", func() {
+			BeforeEach(func() {
+				replicas = 5
+			})
+			It("should receive the traffic correctly", func() {
+				By("Waiting for the new targets to be registered")
+				time.Sleep(20 * time.Second)
+				By("Checking if all targets have receive traffic with no traffic interruption (no lost connection)")
+				lastingConnections, lostConnections, err := utils.SendTraffic(trafficGeneratorCMD, trench, namespace, ipPort, 400, 100)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(lostConnections)).To(Equal(0))
+				Expect(len(lastingConnections)).To(Equal(replicas))
+			})
+		})
+
+	})
+
+})

--- a/test/e2e/target_test.go
+++ b/test/e2e/target_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright (c) 2021 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nordix/meridio/test/e2e/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Target", func() {
+
+	Context("With one trench (trench-a) deployed in namespace red containing 2 VIP addresses (20.0.0.1:5000, [2000::1]:5000) and 4 target pods running ctraffic", func() {
+
+		var (
+			targetPod *v1.Pod
+		)
+
+		BeforeEach(func() {
+			if targetPod != nil {
+				return
+			}
+			listOptions := metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("app=%s", targetDeploymentName),
+			}
+			pods, err := clientset.CoreV1().Pods(namespace).List(context.Background(), listOptions)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(pods.Items)).To(BeNumerically(">", 0))
+			targetPod = &pods.Items[0]
+		})
+
+		Describe("Stream", func() {
+			When("a target is opening a stream", func() {
+				var (
+					err error
+				)
+
+				BeforeEach(func() {
+					_, err = utils.PodExec(targetPod, "ctraffic", []string{"./target-client", "close", "-ns", networkServiceName, "-t", trench})
+					Expect(err).NotTo(HaveOccurred())
+					_, err = utils.PodExec(targetPod, "ctraffic", []string{"./target-client", "request", "-ns", networkServiceName, "-t", trench})
+				})
+
+				It("should be able to receive traffic", func() {
+					By("Checking if there is no error")
+					Expect(err).NotTo(HaveOccurred())
+
+					By("Checking if the target is receiving the traffic")
+					lastingConn, lostConn, err := utils.SendTraffic(trafficGeneratorCMD, trench, namespace, ipPort, 400, 100)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(len(lostConn)).To(Equal(0))
+					Expect(len(lastingConn)).To(Equal(numberOfTargets))
+
+					By("Checking if the target has a new network interface")
+					targetHasNetworkInterface, err := utils.PodHasNetworkInterface(targetPod, "ctraffic", "nsc")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(targetHasNetworkInterface).To(BeTrue())
+				})
+			})
+
+			When("a target is closing a stream", func() {
+				var (
+					err error
+				)
+
+				BeforeEach(func() {
+					_, err = utils.PodExec(targetPod, "ctraffic", []string{"./target-client", "close", "-ns", networkServiceName, "-t", trench})
+				})
+
+				AfterEach(func() {
+					_, err := utils.PodExec(targetPod, "ctraffic", []string{"./target-client", "request", "-ns", networkServiceName, "-t", trench})
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should still be connected to the conduit/trench but should not be able receive traffic", func() {
+					By("Checking if there is no error")
+					Expect(err).NotTo(HaveOccurred())
+
+					By("Checking if the target is not receiving the traffic")
+					lastingConn, lostConn, err := utils.SendTraffic(trafficGeneratorCMD, trench, namespace, ipPort, 400, 100)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(len(lostConn)).To(Equal(0))
+					Expect(len(lastingConn)).To(Equal(numberOfTargets - 1))
+
+					By("Checking if the network interface is still in the target")
+					targetHasNetworkInterface, err := utils.PodHasNetworkInterface(targetPod, "ctraffic", "nsc")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(targetHasNetworkInterface).To(BeTrue())
+				})
+			})
+		})
+
+		Describe("Conduit/Trench", func() {
+			When("a target is connecting to a conduit/trench", func() {
+				var (
+					err error
+				)
+
+				BeforeEach(func() {
+					_, err = utils.PodExec(targetPod, "ctraffic", []string{"./target-client", "disconnect", "-ns", networkServiceName, "-t", trench})
+					Expect(err).NotTo(HaveOccurred())
+					_, err = utils.PodExec(targetPod, "ctraffic", []string{"./target-client", "connect", "-ns", networkServiceName, "-t", trench})
+				})
+
+				AfterEach(func() {
+					_, err := utils.PodExec(targetPod, "ctraffic", []string{"./target-client", "request", "-ns", networkServiceName, "-t", trench})
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should have a new network interface", func() {
+					By("Checking if there is no error")
+					Expect(err).NotTo(HaveOccurred())
+
+					By("Checking if the target has a new network interface")
+					targetHasNetworkInterface, err := utils.PodHasNetworkInterface(targetPod, "ctraffic", "nsc")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(targetHasNetworkInterface).To(BeTrue())
+				})
+			})
+
+			When("a target is disconnecting from a conduit/trench", func() {
+				var (
+					err error
+				)
+
+				BeforeEach(func() {
+					_, err = utils.PodExec(targetPod, "ctraffic", []string{"./target-client", "disconnect", "-ns", networkServiceName, "-t", trench})
+				})
+
+				AfterEach(func() {
+					_, err := utils.PodExec(targetPod, "ctraffic", []string{"./target-client", "connect", "-ns", networkServiceName, "-t", trench})
+					Expect(err).NotTo(HaveOccurred())
+					_, err = utils.PodExec(targetPod, "ctraffic", []string{"./target-client", "request", "-ns", networkServiceName, "-t", trench})
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should no longer have the network interface and should not receive traffic anymore", func() {
+					By("Checking if there is no error")
+					Expect(err).NotTo(HaveOccurred())
+
+					By("Checking if the target is not receiving the traffic")
+					lastingConn, lostConn, err := utils.SendTraffic(trafficGeneratorCMD, trench, namespace, ipPort, 400, 100)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(len(lostConn)).To(Equal(0))
+					Expect(len(lastingConn)).To(Equal(numberOfTargets - 1))
+
+					By("Checking if the target no longer has the new network interface")
+					targetHasNetworkInterface, err := utils.PodHasNetworkInterface(targetPod, "ctraffic", "nsc")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(targetHasNetworkInterface).To(BeFalse())
+				})
+			})
+		})
+
+	})
+
+})

--- a/test/e2e/utils/kubernetes.go
+++ b/test/e2e/utils/kubernetes.go
@@ -1,0 +1,113 @@
+/*
+Copyright (c) 2021 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/client-go/util/homedir"
+)
+
+func GetConfig() (*rest.Config, error) {
+	kubeconfig := filepath.Join(homedir.HomeDir(), ".kube", "config")
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+func GetClientSet() (*kubernetes.Clientset, error) {
+	config, err := GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return clientset, nil
+}
+
+func PodExec(pod *v1.Pod, container string, command []string) (string, error) {
+	clientCfg, err := GetConfig()
+	if err != nil {
+		logrus.Errorf("Unable to get clientCfg: %v", err)
+	}
+	clientSet, err := GetClientSet()
+	if err != nil {
+		logrus.Errorf("Unable to get clientSet: %v", err)
+	}
+
+	req := clientSet.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(pod.Namespace).
+		SubResource("exec")
+	scheme := runtime.NewScheme()
+	err = corev1.AddToScheme(scheme)
+	if err != nil {
+		return "", err
+	}
+
+	parameterCodec := runtime.NewParameterCodec(scheme)
+	req.VersionedParams(&corev1.PodExecOptions{
+		Command:   command,
+		Container: container,
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}, parameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(clientCfg, "POST", req.URL())
+	if err != nil {
+		return "", err
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  nil,
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+	if err != nil {
+		return "", fmt.Errorf("%w; %s", err, stderr.String())
+	}
+
+	return stdout.String(), nil
+}
+
+func PodHasNetworkInterface(pod *v1.Pod, container string, interfaceSubName string) (bool, error) {
+	interfaces, err := PodExec(pod, "ctraffic", []string{"ip", "-o", "link", "show"})
+	if err != nil {
+		return false, err
+	}
+	return strings.Contains(interfaces, "nsc"), nil
+}

--- a/test/e2e/utils/trafficgenerator.go
+++ b/test/e2e/utils/trafficgenerator.go
@@ -1,0 +1,79 @@
+/*
+Copyright (c) 2021 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type lostConnections map[string]int
+type lastingConnections map[string]int
+
+func SendTraffic(trafficGeneratorCMD string, trench string, namespace string, vip string, nconn int, rate int) (lastingConnections, lostConnections, error) {
+	hostcmd := trafficGeneratorHostCommand(trafficGeneratorCMD, trench)
+	ctrafficcmd := ctrafficClientCommand(vip, nconn, rate)
+	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("%s %s", hostcmd, ctrafficcmd))
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w; %s", err, stderr.String())
+	}
+	lastingConn, lostConn := analyzeTraffic(stdout.Bytes())
+	return lastingConn, lostConn, nil
+}
+
+func trafficGeneratorHostCommand(trafficGeneratorCMD string, trench string) string {
+	return strings.ReplaceAll(trafficGeneratorCMD, "{trench}", trench)
+}
+
+func ctrafficClientCommand(vip string, nconn int, rate int) string {
+	return fmt.Sprintf("ctraffic -address %s -nconn %d -rate %d -stats all", vip, nconn, rate)
+}
+
+func analyzeTraffic(ctrafficOutput []byte) (lastingConnections, lostConnections) {
+	var data map[string]interface{}
+	if err := json.Unmarshal(ctrafficOutput, &data); err != nil {
+		panic(err)
+	}
+	lastingConn := lastingConnections{}
+	lostConn := lostConnections{}
+	connStats := data["ConnStats"].([]interface{})
+	for _, conn := range connStats {
+		connStat := conn.(map[string]interface{})
+		if connStat == nil || connStat["Host"] == nil || connStat["Err"] == nil {
+			continue
+		}
+		host := connStat["Host"].(string)
+		err := connStat["Err"].(string)
+		if host == "" {
+			continue
+		}
+		if err == "" {
+			lastingConn[host]++
+		} else {
+			lostConn[host]++
+		}
+	}
+	return lastingConn, lostConn
+}


### PR DESCRIPTION
ginkgo and gomega are used to run e2e tests
make file has now 2 rules to run the tests:
- make test: runs the short tests (e.g.: /cmd/... ; /pkg/...)
- make e2e: runs the tests in /test/e2e

e2e tests:
- [x] IngressTraffic - Sends TCP traffic in Ipv4 and IPv6 from the Gateway via ctraffic and checks if the traffic has been received correctly.
- [x] Target - Checks if the features request/close a stream and connect/disconnect a trench are working correctly on a target.
- [x] Multi-trenches - Checks if traffic can be sent to 2 trenches at the same time using the same VIP
- [x] Scaling - Checks if scale-in and scale-out are working as intended