### PR TITLE
New configmap version support in helm chart

### DIFF
--- a/deployments/helm/templates/_helpers.tpl
+++ b/deployments/helm/templates/_helpers.tpl
@@ -3,15 +3,6 @@
 {{/*
 Set IP Family
 */}}
-{{- define "meridio.vips" -}}
-{{- if eq .Values.ipFamily "dualstack" -}}
-{{- (printf "%s,%s" .Values.vip.ipv4 .Values.vip.ipv6) -}}
-{{- else if eq .Values.ipFamily "ipv6" -}}
-{{- printf .Values.vip.ipv6 -}}
-{{- else -}}
-{{- printf .Values.vip.ipv4 -}}
-{{- end -}}
-{{- end -}}
 
 {{- define "meridio.subnetPool.prefixes" -}}
 {{- if eq .Values.ipFamily "dualstack" -}}
@@ -71,10 +62,6 @@ Set IP Family
 
 {{- define "meridio.vlan.networkServiceName" -}}
 {{- printf "%s.%s" .Values.vlan.networkServiceName .Release.Namespace -}}
-{{- end -}}
-
-{{- define "meridio.gateways" -}}
-{{- join "," .Values.vlan.fe.gateway }}
 {{- end -}}
 
 {{- define "meridio.vrrps" -}}

--- a/deployments/helm/templates/config.yaml
+++ b/deployments/helm/templates/config.yaml
@@ -4,9 +4,21 @@ kind: ConfigMap
 metadata:
   name: {{ template "meridio.configuration" . }}
 data:
-  meridio.conf: |
-    vips: [{{ template "meridio.vips" . }}]
-    gateways: [{{ template "meridio.gateways" . }}]
+  gateways: |
+    items:
+    {{- range .Values.vlan.fe.gateways }}
+    - name: {{ .name }}
+      address: {{ .address }}
+      ip-family: {{ .ipFamily }}
+      bfd: {{ .bfd }}
+      protocol: {{ .protocol }}
+    {{- end }} 
+  vips: |
+    items:
+    {{- range .Values.vips }}
+    - name: {{ .name }}
+      address: {{ .address }}
+    {{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deployments/helm/templates/proxy.yaml
+++ b/deployments/helm/templates/proxy.yaml
@@ -53,8 +53,6 @@ spec:
               value: unix:///var/lib/networkservicemesh/nsm.io.sock
             - name: NSM_SERVICE_NAME
               value: {{ template "meridio.proxy.networkServiceName" . }}
-            - name: NSM_VIPS
-              value: {{ template "meridio.vips" . }}
             - name: NSM_SUBNET_POOLS
               value: {{ template "meridio.subnetPool.prefixes" . }}
             - name: NSM_SUBNET_PREFIX_LENGTHS

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -45,9 +45,11 @@ nsp:
 
 ipFamily: ipv4 # ipv4 / ipv6 / dualstack
 
-vip:
-  ipv4: 20.0.0.1/32
-  ipv6: 2000::1/128
+vips:
+  - name: vip1
+    address: 20.0.0.1/32
+  - name: vip2
+    address: 2000::1/128
 
 subnetPool:
   ipv4: 172.16.0.0/16
@@ -67,12 +69,18 @@ vlan:
   ipv4Prefix: 169.254.100.0/24
   ipv6Prefix: 100:100::/64
   fe:
-      gateway:
-        - 169.254.100.254/24
-        - fe80::beef/64
-        - 169.254.100.253/24
-        - fe80::beee/64
-      vrrp:
+    gateways:
+      - name: gateway1
+        address: 169.254.100.150
+        ipFamily: ipv4
+        bfd: false
+        protocol: bgp
+      - name: gateway2
+        address: 100:100::150
+        ipFamily: ipv6
+        bfd: false
+        protocol: bgp
+    vrrp:
 #        - 169.254.100.252/24
 #        - fe80::beed/64
 

--- a/examples/target/helm/templates/target.yaml
+++ b/examples/target/helm/templates/target.yaml
@@ -21,7 +21,7 @@ spec:
           image: {{ .Values.registry }}/{{ .Values.organization }}/{{ .Values.ctraffic.image }}:{{ .Values.ctraffic.version }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           args:
-            - ./target-client connect -ns {{ .Values.lb }} -t {{ .Values.default.trench.name }} ; ./target-client request -ns {{ .Values.lb }} -t {{ .Values.default.trench.name  }} ; ./ctraffic -server -address [::]:5000
+            - ./target-client connect -ns {{ .Values.networkService }} -t {{ .Values.default.trench.name }} ; ./target-client request -ns {{ .Values.networkService }} -t {{ .Values.default.trench.name  }} ; ./ctraffic -server -address [::]:5000
           command:
             - /bin/bash
             - -c

--- a/examples/target/helm/values.yaml
+++ b/examples/target/helm/values.yaml
@@ -9,7 +9,7 @@ applicationName: target-a
 
 configMapName: meridio-configuration
 
-lb: lb-fe
+networkService: load-balancer
 
 default:
   trench: 


### PR DESCRIPTION
Support of the new configmap version
Fix: network service name in target helm chart
Unsed VIPs in proxy helm chart removed