### PR TITLE
frontend; process BGP params in configmap

### DIFF
--- a/docs/demo/xcluster.md
+++ b/docs/demo/xcluster.md
@@ -59,7 +59,10 @@ make docker-build docker-push IMG="registry.nordix.org/meridio/meridio-operator:
 
 Deploy Meridio-Operator
 ```
+# install most recent cert-manager
 kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
+# alternatively install a specific version of cert-manager (useful when running with private docker registry)
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.1/cert-manager.yaml
 # deploy operator image (irrespective of the registry type)
 make deploy IMG="registry.nordix.org/meridio/meridio-operator:v0.0.1"
 ```
@@ -116,6 +119,12 @@ metadata:
   name: gateway1
 spec:
   address: 169.254.100.254
+  bgp:
+    local-asn: 8103
+    remote-asn: 4248829953
+    hold-time: "3s"
+    local-port: 10179
+    remote-port: 10179
 ---
 apiVersion: meridio.nordix.org/v1alpha1
 kind: Gateway
@@ -126,6 +135,12 @@ metadata:
   name: gateway2
 spec:
   address: fe80::beef
+  bgp:
+    local-asn: 8103
+    remote-asn: 4248829953
+    hold-time: "3s"
+    local-port: 10179
+    remote-port: 10179
 ---
 apiVersion: meridio.nordix.org/v1alpha1
 kind: Gateway
@@ -136,6 +151,12 @@ metadata:
   name: gateway3
 spec:
   address: 169.254.100.253
+  bgp:
+    local-asn: 8103
+    remote-asn: 4248829953
+    hold-time: "3s"
+    local-port: 10179
+    remote-port: 10179
 ---
 apiVersion: meridio.nordix.org/v1alpha1
 kind: Gateway
@@ -146,6 +167,12 @@ metadata:
   name: gateway4
 spec:
   address: fe80::beee
+  bgp:
+    local-asn: 8103
+    remote-asn: 4248829953
+    hold-time: "3s"
+    local-port: 10179
+    remote-port: 10179
 EOF
 
 # add Vips
@@ -196,7 +223,7 @@ helm install examples/target/common/ --generate-name
 
 Install targets connected to trench-a
 ```
-helm install examples/target/helm/ --generate-name --set applicationName=target-a --set default.trench.name=trench-a --set configMapName=meridio-configuration
+helm install examples/target/helm/ --generate-name --set applicationName=target-a --set default.trench.name=trench-a --set configMapName=meridio-configuration --set networkService=lb-fe
 ```
 
 ## Traffic

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/networkservicemesh/api v1.0.0
 	github.com/networkservicemesh/sdk v1.0.0
 	github.com/networkservicemesh/sdk-sriov v1.0.0
-	github.com/nordix/meridio-operator v0.0.0-20210805145341-52782b7d5ca8
+	github.com/nordix/meridio-operator v0.0.0-20210823114908-9c4d92ddee94
 	github.com/open-policy-agent/opa v0.30.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -645,8 +645,8 @@ github.com/networkservicemesh/sdk-sriov v1.0.0 h1:pGJOi+lKjm5Isd5T5IxQeO/uLaMi9n
 github.com/networkservicemesh/sdk-sriov v1.0.0/go.mod h1:udmRPb0Bepel/ftsjQ1RMeWgTUh7KecmrrDHIjezM+Y=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nordix/meridio-operator v0.0.0-20210805145341-52782b7d5ca8 h1:Si0sC6HxAQ6PhgcDnNePkcgu3Q2fuSgJZz+KYArN+hk=
-github.com/nordix/meridio-operator v0.0.0-20210805145341-52782b7d5ca8/go.mod h1:+6ONpt/tecB7DiyMpBTd1Xc3D7fOPdmAG2IyXxLYOF4=
+github.com/nordix/meridio-operator v0.0.0-20210823114908-9c4d92ddee94 h1:jj8DFJ/Kb/qYULEoZ1g7xM35J9cA5GY83kELCWlVtsM=
+github.com/nordix/meridio-operator v0.0.0-20210823114908-9c4d92ddee94/go.mod h1:+6ONpt/tecB7DiyMpBTd1Xc3D7fOPdmAG2IyXxLYOF4=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=


### PR DESCRIPTION
The configmap can hold Gateway specific BGP details
(e.g. ASN, ports, holdtime), that must be read by the
frontend to generate proper BGP config for BIRD.