### PR TITLE
Ambassador API documentation + vlan forwarder fix

### DIFF
--- a/api/target/target.proto
+++ b/api/target/target.proto
@@ -21,25 +21,53 @@ option go_package = "github.com/nordix/meridio/api/target";
 import "google/protobuf/empty.proto";
 
 service Ambassador {
+    // Connect to a conduit, so a new interface will be created.
+    // The Ambassador will also connect to the trench the 
+    // conduit belongs to. And, the VIPs will be added to 
+    // the loopback interface.
     rpc Connect(Conduit) returns (google.protobuf.Empty) {}
+    // Disconnect from a conduit, so the interface will be removed.
+    // The Ambassador will also close the streams which are opened
+    // in the conduit. It will disconnect the target from the trench.
+    // And, the VIPs will be removed from the loopback interface.
     rpc Disconnect(Conduit) returns (google.protobuf.Empty) {}
+    // WatchConduits will, first, returns all conduits connected with
+    // "Connect" as event status, and then, will send an event on each 
+    // conduit connection/disconnection.
     rpc WatchConduits(google.protobuf.Empty) returns (stream ConduitEvent) {}
 
+    // Request to a stream, so the identifier will be registered
+    // in the NSP service, the LBs will start load-balancing the
+    // traffic to the target.
     rpc Request(Stream) returns (google.protobuf.Empty) {}
+    // Close a stream, so the identifier will be unregistered
+    // in the NSP service, the LBs will stop load-balancing the
+    // traffic to the target.
     rpc Close(Stream) returns (google.protobuf.Empty) {}
+    // WatchStreams will, first, returns all streams opened with "Request"
+    // as event status, and then, will send an event on each stream
+    // request/close.
     rpc WatchStreams(google.protobuf.Empty) returns (stream StreamEvent) {}
 }
 
 message Trench {
+    // Name of the trench
     string name = 1;
 }
 
+// The message contains the properties of a conduit
 message Conduit {
+    // Name of the service
+    // The name will be compiled using the proxy and the trench name
+    // e.g.: load-balancer with the proxy used in trench-a will 
+    // become proxy.load-balancer.trench-a
     string networkServiceName = 1;
+    // Trench the conduit belongs to
     Trench trench = 2;
 }
 
 message Stream {
+    // Conduit the stream belongs to
     Conduit conduit = 1;
 }
 

--- a/docs/demo/deployments/nsm-vlan/templates/forwarder-vlan.yaml
+++ b/docs/demo/deployments/nsm-vlan/templates/forwarder-vlan.yaml
@@ -2,21 +2,21 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: forwarder-kernel
+  name: forwarder-vlan
   labels:
-    app: forwarder-kernel
+    app: forwarder-vlan
 spec:
   selector:
     matchLabels:
-      app: forwarder-kernel
+      app: forwarder-vlan
   template:
     metadata:
       labels:
-        app: forwarder-kernel
+        app: forwarder-vlan
     spec:
       hostNetwork: true
       containers:
-        - name: forwarder-kernel
+        - name: forwarder-vlan
           image: registry.nordix.org/cloud-native/nsm/forwarder-vlan:latest
           imagePullPolicy: {{ .Values.pullPolicy }}
           securityContext:
@@ -35,7 +35,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: NSM_LABELS
-              value: forwarder:forwarder-kernel
+              value: forwarder:forwarder-vlan
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -96,12 +96,12 @@ func (lb *LoadBalancer) GetTargets() []*Target {
 }
 
 func (lb *LoadBalancer) activateIdentifier(identifier int) error {
-	_, err := exec.Command("nfqlb", "activate", fmt.Sprintf("--index=%s", strconv.Itoa(identifier)), strconv.Itoa(identifier)).Output()
+	_, err := exec.Command("nfqlb", "activate", fmt.Sprintf("--index=%s", strconv.Itoa(identifier-1)), strconv.Itoa(identifier)).Output()
 	return err
 }
 
 func (lb *LoadBalancer) deactivateIdentifier(identifier int) error {
-	_, err := exec.Command("nfqlb", "deactivate", fmt.Sprintf("--index=%s", strconv.Itoa(identifier))).Output()
+	_, err := exec.Command("nfqlb", "deactivate", fmt.Sprintf("--index=%s", strconv.Itoa(identifier-1))).Output()
 	return err
 }
 
@@ -122,7 +122,7 @@ func (lb *LoadBalancer) configure() error {
 }
 
 func (lb *LoadBalancer) desactivateAll() error {
-	for i := 0; i < lb.n; i++ {
+	for i := 1; i <= lb.n; i++ {
 		err := lb.deactivateIdentifier(i)
 		if err != nil {
 			return err

--- a/pkg/target/conduit.go
+++ b/pkg/target/conduit.go
@@ -156,7 +156,7 @@ func (c *Conduit) request() error {
 		Connection: &networkservice.Connection{
 			Id:             fmt.Sprintf("%s-%s-%d", c.GetConfig().nsmConfig.Name, proxyNetworkServiceName, 0),
 			NetworkService: proxyNetworkServiceName,
-			Labels:         make(map[string]string),
+			Labels:         map[string]string{"forwarder": "forwarder-vpp"},
 			Payload:        payload.Ethernet,
 		},
 		MechanismPreferences: []*networkservice.Mechanism{


### PR DESCRIPTION
- Ambassador API documentation 
- The label forwarder was missing in the target request.
- The kernel forwarder in the NSM helm chart has been renamed to forwarder-vlan
- Fix nfqlb index:
  - The minimum value of the index in nfqlb is 0 (instead of 1) and the maximum is 99 (instead of 100).
  - The identifier is now equal to the index - 1 (index in nfqlb). The fwmark and identifer have not changed, the min is still 1 and the max 100.