### PR TITLE
fe; fix external connectivity condition check

### DIFF
--- a/cmd/frontend/service.go
+++ b/cmd/frontend/service.go
@@ -51,7 +51,7 @@ type connectivityStatus struct {
 }
 
 func (cs *connectivityStatus) noConnectivity() bool {
-	return cs.status&NoConfig != 0 || (cs.status&NoIPv4Config == 0 && cs.status&IPv4Up == 0) || (cs.status&NoIPv6Config == 0 && cs.status&IPv6Up == 0)
+	return cs.status&NoConfig == NoConfig || (cs.status&NoIPv4Config == 0 && cs.status&IPv4Up == 0) || (cs.status&NoIPv6Config == 0 && cs.status&IPv6Up == 0)
 }
 
 func (cs *connectivityStatus) anyGatewayDown() bool {


### PR DESCRIPTION
When either IPv4 or IPv6 connectivity is not configured,
but external connectivity is OK, then announce respective
frontend to NSP.