### PR TITLE
Fix target ambassador close and disconnect

### DIFF
--- a/pkg/nsp/registry/sqlite/sqlite.go
+++ b/pkg/nsp/registry/sqlite/sqlite.go
@@ -81,7 +81,7 @@ func (trsql *TargetRegistrySQLite) Remove(ctx context.Context, target *nspAPI.Ta
 	trsql.mu.Lock()
 	defer trsql.mu.Unlock()
 	targetModel := NSPTargetToSQLTarget(target)
-	tx := trsql.DB.Delete(&Target{}, targetModel.ID)
+	tx := trsql.DB.Delete(targetModel)
 	if tx.Error != nil {
 		return tx.Error
 	}

--- a/pkg/target/conduit/conduit.go
+++ b/pkg/target/conduit/conduit.go
@@ -102,7 +102,8 @@ func (c *Conduit) Connect(ctx context.Context) error {
 		RequestTimeout: c.nsmConfig.RequestTimeout,
 		ConnectTo:      c.nsmConfig.ConnectTo,
 	}
-	c.networkServiceClient = client.NewSimpleNetworkServiceClient(ctx, clientConfig, c.apiClient, c.getAdditionalFunctionalities(ctx))
+	nscCtx := context.Background()
+	c.networkServiceClient = client.NewSimpleNetworkServiceClient(nscCtx, clientConfig, c.apiClient, c.getAdditionalFunctionalities(nscCtx))
 	err := c.networkServiceClient.Request(&networkservice.NetworkServiceRequest{
 		Connection: &networkservice.Connection{
 			Id:             fmt.Sprintf("%s-%s-%d", c.nsmConfig.Name, proxyNetworkServiceName, 0),

--- a/pkg/target/conduit/conduit.go
+++ b/pkg/target/conduit/conduit.go
@@ -170,7 +170,7 @@ func (c *Conduit) RemoveStream(ctx context.Context, stream types.Stream) error {
 	}
 	err := stream.Close(ctx)
 	if err != nil {
-		return nil
+		return err
 	}
 	c.streams = append(c.streams[:index], c.streams[index+1:]...)
 	return nil


### PR DESCRIPTION
Fix Delete in SQLite storage of NSP:
The previous delete method (gorm) used was returning an error
The error was not returned by the target ambassador

Fix Target ambassador disconnect:
A wrong context was used to create the Network service client
The target could not disconnect from the proxy (context cancelled)