### PR TITLE
Retry pkg

### DIFF
--- a/pkg/retry/config.go
+++ b/pkg/retry/config.go
@@ -1,0 +1,59 @@
+/*
+Copyright (c) 2021-2022 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"context"
+	"time"
+)
+
+// RetryTrigger is the function definition specifying when the Do
+// function should continue in an new attempt.
+type RetryTrigger func() <-chan struct{}
+
+// RetryCondition is the function definition specifying if the Do
+// function should continue in an new attempt or not.
+type RetryCondition func(error) bool
+
+type Config struct {
+	context            context.Context
+	retryTriggerFunc   RetryTrigger
+	retryConditionFunc RetryCondition
+}
+
+func newConfig() *Config {
+	return &Config{
+		context: context.Background(),
+		retryTriggerFunc: func() <-chan struct{} {
+			return delay(10 * time.Millisecond)
+		},
+		retryConditionFunc: defaultRetryCondition,
+	}
+}
+
+func defaultRetryCondition(err error) bool {
+	return err != nil
+}
+
+func delay(d time.Duration) <-chan struct{} {
+	channel := make(chan struct{}, 1)
+	go func() {
+		<-time.After(d)
+		channel <- struct{}{}
+	}()
+	return channel
+}

--- a/pkg/retry/option.go
+++ b/pkg/retry/option.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2021-2022 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"context"
+	"time"
+)
+
+type Option func(*Config)
+
+// WithMaxAttempts specifies the maximum number of attempts/retries
+// If no error is returned by the retryable function, then the
+// retries will finished before the number of max attempts is reached.
+// WithMaxAttempts sets the retry condition function.
+func WithMaxAttempts(attempts uint) Option {
+	var currentAttempt uint = 0
+	return WithRetryCondition(func(err error) bool {
+		if currentAttempt >= attempts {
+			return false
+		}
+		currentAttempt++
+		return defaultRetryCondition(err)
+	})
+}
+
+// WithDelay sets a retry trigger with a 10 milliseconds delay
+// WithDelay sets the retry trigger function.
+func WithDelay(delayTime time.Duration) Option {
+	return WithRetryTrigger(func() <-chan struct{} {
+		return delay(delayTime)
+	})
+}
+
+func WithContext(ctx context.Context) Option {
+	return func(c *Config) {
+		c.context = ctx
+	}
+}
+
+// WithRetryCondition sets the retry condition function.
+func WithRetryCondition(retryCondition RetryCondition) Option {
+	return func(c *Config) {
+		c.retryConditionFunc = retryCondition
+	}
+}
+
+// WithRetryTrigger sets the retry trigger function.
+func WithRetryTrigger(retryTrigger RetryTrigger) Option {
+	return func(c *Config) {
+		c.retryTriggerFunc = retryTrigger
+	}
+}
+
+// WithErrorIngnored will not stop the loop if no error is returned by
+// the retryable function.
+// WithErrorIngnored sets the retry condition function.
+func WithErrorIngnored() Option {
+	return WithRetryCondition(func(err error) bool {
+		return true
+	})
+}

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2021-2022 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"fmt"
+)
+
+// Function definition to be executed and retried.
+type RetryableFunc func() error
+
+// Do runs the function passed in parameter (retryableFunc) until the
+// retry condition is fulfilled or until the context is Done.
+// The following options are supported:
+// - Retry condition: condition for retries to terminate (e.g. retryableFunc has not returned any error, max attempts...)
+// - Retry trigger: trigger to continue in the next try (e.g. Delay, an system event...)
+// - Context: context that can be used to terminate the function
+// By default, these options are applied:
+// - Retry condition: retryableFunc has not returned any error
+// - Retry trigger: 10 milliseconds delay
+// - Context: empty context
+func Do(retryableFunc RetryableFunc, options ...Option) error {
+	config := newConfig()
+	for _, opt := range options {
+		opt(config)
+	}
+
+	var errFinal error
+
+retry:
+	for {
+		err := retryableFunc()
+
+		if err != nil {
+			errFinal = fmt.Errorf("%w; %v", errFinal, err) // todo
+		}
+
+		if !config.retryConditionFunc(err) {
+			break
+		}
+
+		select {
+		case <-config.retryTriggerFunc():
+		case <-config.context.Done():
+			break retry
+		}
+	}
+	return errFinal
+}

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright (c) 2021-2022 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nordix/meridio/pkg/retry"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
+)
+
+func Test_Do_NoError(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	attempts := 0
+	err := retry.Do(func() error {
+		attempts++
+		return nil
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, attempts)
+}
+
+func Test_Do_Failed(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	attempts := 0
+	err := retry.Do(func() error {
+		attempts++
+		return errors.New("")
+	}, retry.WithDelay(1*time.Nanosecond), retry.WithMaxAttempts(10))
+	assert.NotNil(t, err)
+	assert.Equal(t, 11, attempts) // 11: first attempt + retries
+}
+
+func Test_Do_SeveralAttempts(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	attempts := 0
+	err := retry.Do(func() error {
+		attempts++
+		if attempts == 5 {
+			return nil
+		}
+		return errors.New("")
+	}, retry.WithDelay(1*time.Nanosecond), retry.WithMaxAttempts(10))
+	assert.NotNil(t, err)
+	assert.Equal(t, 5, attempts)
+}
+
+func Test_Do_Context(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	ctx, cancel := context.WithCancel(context.TODO())
+
+	attempts := 0
+	err := retry.Do(func() error {
+		attempts++
+		if attempts == 5 {
+			cancel()
+		}
+		return errors.New("")
+	}, retry.WithDelay(1*time.Nanosecond), retry.WithContext(ctx))
+	assert.NotNil(t, err)
+	assert.Equal(t, 5, attempts)
+}
+
+func Test_Do_WithRetryCondition(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	attempts := 0
+	err := retry.Do(func() error {
+		attempts++
+		if attempts >= 2 {
+			return errors.New("abc")
+		}
+		return errors.New("")
+	}, retry.WithRetryCondition(func(err error) bool {
+		return err.Error() != "abc"
+	}))
+	assert.NotNil(t, err)
+	assert.Equal(t, 2, attempts)
+}
+
+func Test_Do_WithRetryTrigger(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	ctx, cancel := context.WithCancel(context.TODO())
+
+	attempts := 0
+	err := retry.Do(func() error {
+		attempts++
+		if attempts == 2 {
+			return nil
+		}
+		cancel()
+		return errors.New("")
+	}, retry.WithRetryTrigger(func() <-chan struct{} {
+		channel := make(chan struct{}, 1)
+		go func() {
+			<-ctx.Done()
+			channel <- struct{}{}
+		}()
+		return channel
+	}))
+	assert.NotNil(t, err)
+	assert.Equal(t, 2, attempts)
+}
+
+func Test_Do_WithErrorIgnored(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	ctx, cancel := context.WithCancel(context.TODO())
+
+	attempts := 0
+	_ = retry.Do(func() error {
+		attempts++
+		if attempts == 2 {
+			return nil
+		} else if attempts == 3 {
+			cancel()
+		}
+		return errors.New("")
+	}, retry.WithErrorIngnored(), retry.WithContext(ctx))
+	assert.Equal(t, 3, attempts)
+}


### PR DESCRIPTION
The Retry pkg is a common pkg which can be used for all functions which could need a retry mechanism, for instance, the LB component needs to watch the target using the NSP service, but if the service goes down, the LB would need to call the NSP service again.

* Allows the configuration of the retry trigger (can be a delay, a system event...)
* Allows the configuration of the retry condition (can be a maximum of attempts, depends on the error returned by the retryable func...)
* Allows the configuration of the context

issue: #147 