### PR TITLE
Fix go routine leak with retry trigger

### DIFF
--- a/pkg/retry/option.go
+++ b/pkg/retry/option.go
@@ -41,8 +41,8 @@ func WithMaxAttempts(attempts uint) Option {
 // WithDelay sets a retry trigger with a 10 milliseconds delay
 // WithDelay sets the retry trigger function.
 func WithDelay(delayTime time.Duration) Option {
-	return WithRetryTrigger(func() <-chan struct{} {
-		return delay(delayTime)
+	return WithRetryTrigger(func(ctx context.Context) <-chan struct{} {
+		return delay(ctx, delayTime)
 	})
 }
 

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -17,6 +17,7 @@ limitations under the License.
 package retry
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -53,11 +54,14 @@ retry:
 			break
 		}
 
+		retryTriggerCtx, retryTriggerCancel := context.WithCancel(context.Background())
 		select {
-		case <-config.retryTriggerFunc():
+		case <-config.retryTriggerFunc(retryTriggerCtx):
 		case <-config.context.Done():
+			retryTriggerCancel()
 			break retry
 		}
+		retryTriggerCancel()
 	}
 	return errFinal
 }

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -142,3 +142,16 @@ func Test_Do_WithErrorIgnored(t *testing.T) {
 	}, retry.WithErrorIngnored(), retry.WithContext(ctx))
 	assert.Equal(t, 3, attempts)
 }
+
+func Test_Do_WithDelay_GoRoutineLeak(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	ctx, cancel := context.WithCancel(context.TODO())
+
+	go func() {
+		_ = retry.Do(func() error {
+			return errors.New("")
+		}, retry.WithErrorIngnored(), retry.WithContext(ctx), retry.WithDelay(10*time.Second))
+	}()
+	cancel()
+}

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -113,7 +113,7 @@ func Test_Do_WithRetryTrigger(t *testing.T) {
 		}
 		cancel()
 		return errors.New("")
-	}, retry.WithRetryTrigger(func() <-chan struct{} {
+	}, retry.WithRetryTrigger(func(context.Context) <-chan struct{} {
 		channel := make(chan struct{}, 1)
 		go func() {
 			<-ctx.Done()


### PR DESCRIPTION
To cast a time channel to struct channel, a new go routine is created. A select with a new ctx has been added to cancel the retry trigger if the retry function is cancelled.