### PR TITLE
Base image Alpine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+_output/

--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.15
+RUN apk update && apk add iproute2 tcpdump iputils
+ADD https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.2/grpc_health_probe-linux-amd64 /bin/grpc_health_probe
+RUN chmod a+x /bin/grpc_health_probe

--- a/build/ctraffic/Dockerfile
+++ b/build/ctraffic/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as build
+FROM golang:1.18.1 as build
 
 ENV GO111MODULE=on
 

--- a/build/debug/Dockerfile
+++ b/build/debug/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.15
+RUN apk update && apk add iproute2 tcpdump iputils net-tools ethtool

--- a/build/frontend/Dockerfile
+++ b/build/frontend/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.16 as build
+ARG base_image=registry.nordix.org/cloud-native/meridio/base:latest
+
+FROM golang:1.18.1 as build
 
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
@@ -10,19 +12,14 @@ WORKDIR /app
 COPY go.mod .
 RUN go mod tidy
 RUN go mod download
-RUN go get github.com/grpc-ecosystem/grpc-health-probe@v0.4.2
 COPY . .
 RUN go build -ldflags "-extldflags -static -X main.version=${meridio_version}" -o frontend ./cmd/frontend
 
 
-FROM alpine:edge
-
-RUN apk update && apk add bash net-tools iproute2 procps vim less tcpdump iputils bird
-RUN mkdir -p /run/bird && \
-	mkdir -p /etc/bird
+FROM ${base_image}
+RUN apk add bird
+RUN mkdir -p /run/bird && mkdir -p /etc/bird
 
 WORKDIR /root
 COPY --from=build /app/frontend ./
-COPY --from=build /bin/grpc-health-probe /bin/grpc_health_probe
-
 CMD ["./frontend"]

--- a/build/ipam/Dockerfile
+++ b/build/ipam/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.16 as build
+ARG base_image=registry.nordix.org/cloud-native/meridio/base:latest
+
+FROM golang:1.18.1 as build
 
 ENV GO111MODULE=on
 ARG meridio_version=0.0.0-unknown
@@ -14,22 +16,7 @@ COPY . .
 
 RUN CGO_ENABLED=1 GOOS=linux go build -ldflags "-extldflags -static -X main.version=${meridio_version}" -o ipam ./cmd/ipam
 
-FROM ubuntu:21.04 as grpc-health-probe
-
-RUN apt-get update -y
-RUN apt-get install -y wget
-WORKDIR /
-RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.2/grpc_health_probe-linux-amd64
-RUN mv grpc_health_probe-linux-amd64 /bin/grpc_health_probe
-RUN chmod +x /bin/grpc_health_probe
-
-FROM ubuntu:21.04
-
-RUN apt-get update -y
-RUN apt-get install -y iproute2 tcpdump iptables net-tools iputils-ping ipvsadm  
-
+FROM ${base_image}
 WORKDIR /root/
 COPY --from=build /app/ipam .
-COPY --from=grpc-health-probe /bin/grpc_health_probe /bin/
-
 CMD ["./ipam"]

--- a/build/load-balancer/Dockerfile
+++ b/build/load-balancer/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.16 as build
+ARG base_image=registry.nordix.org/cloud-native/meridio/base:latest
+
+FROM golang:1.18.1 as build
 ARG meridio_version=0.0.0-unknown
 ENV GO111MODULE=on
 
@@ -13,35 +15,14 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags -static -X main.version=${meridio_version}" -o load-balancer ./cmd/load-balancer
 
 FROM ubuntu:21.04 as lb-builder
-
 WORKDIR /
-RUN apt-get update -y --fix-missing
-RUN apt-get install -y wget xz-utils
-RUN wget https://github.com/Nordix/nfqueue-loadbalancer/releases/download/0.7.1/nfqlb-0.7.1.tar.xz
-RUN tar -xvf /nfqlb-0.7.1.tar.xz
-RUN mv nfqlb-0.7.1 nfqlb
+RUN apt update -y --fix-missing
+RUN apt install -y curl xz-utils
+ADD https://github.com/Nordix/nfqueue-loadbalancer/releases/download/1.0.0/nfqlb-1.0.0.tar.xz /
+RUN tar --strip-components=1 -xf /nfqlb-1.0.0.tar.xz nfqlb-1.0.0/bin/nfqlb
 
-FROM ubuntu:21.04 as grpc-health-probe
-
-RUN apt-get update -y
-RUN apt-get install -y wget
-WORKDIR /
-RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.2/grpc_health_probe-linux-amd64
-RUN mv grpc_health_probe-linux-amd64 /bin/grpc_health_probe
-RUN chmod +x /bin/grpc_health_probe
-
-FROM ubuntu:21.04
-
-RUN apt-get update -y
-run apt-get install -y libmnl-dev
-run apt-get install -y libnetfilter-queue-dev
-RUN apt-get install -y iproute2 tcpdump iptables net-tools iputils-ping ipvsadm netcat nftables
-
+FROM ${base_image}
 WORKDIR /root/
 COPY --from=build /app/load-balancer .
-COPY --from=lb-builder /nfqlb /nfqlb
-COPY --from=grpc-health-probe /bin/grpc_health_probe /bin/
-
-ENV PATH="/nfqlb/bin:${PATH}"
-
+COPY --from=lb-builder /bin/nfqlb /bin/nfqlb
 CMD ["./load-balancer"]

--- a/build/load-balancer/Dockerfile
+++ b/build/load-balancer/Dockerfile
@@ -14,10 +14,8 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags -static -X main.version=${meridio_version}" -o load-balancer ./cmd/load-balancer
 
-FROM ubuntu:21.04 as lb-builder
+FROM ${base_image} as lb-builder
 WORKDIR /
-RUN apt update -y --fix-missing
-RUN apt install -y curl xz-utils
 ADD https://github.com/Nordix/nfqueue-loadbalancer/releases/download/1.0.0/nfqlb-1.0.0.tar.xz /
 RUN tar --strip-components=1 -xf /nfqlb-1.0.0.tar.xz nfqlb-1.0.0/bin/nfqlb
 

--- a/build/nsp/Dockerfile
+++ b/build/nsp/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.17.6 as build
+ARG base_image=registry.nordix.org/cloud-native/meridio/base:latest
+
+FROM golang:1.18.1 as build
 
 ARG meridio_version=0.0.0-unknown
 ENV GO111MODULE=on
@@ -14,22 +16,7 @@ COPY . .
 
 RUN CGO_ENABLED=1 GOOS=linux go build -ldflags "-extldflags -static -X main.version=${meridio_version}" -o nsp ./cmd/nsp
 
-FROM ubuntu:21.04 as grpc-health-probe
-
-RUN apt-get update -y
-RUN apt-get install -y wget
-WORKDIR /
-RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.2/grpc_health_probe-linux-amd64
-RUN mv grpc_health_probe-linux-amd64 /bin/grpc_health_probe
-RUN chmod +x /bin/grpc_health_probe
-
-FROM ubuntu:21.04
-
-RUN apt-get update -y
-RUN apt-get install -y iproute2 tcpdump iptables net-tools iputils-ping ipvsadm  
-
+FROM ${base_image}
 WORKDIR /root/
 COPY --from=build /app/nsp .
-COPY --from=grpc-health-probe /bin/grpc_health_probe /bin/
-
 CMD ["./nsp"]

--- a/build/proxy/Dockerfile
+++ b/build/proxy/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.16 as build
+ARG base_image=registry.nordix.org/cloud-native/meridio/base:latest
+
+FROM golang:1.18.1 as build
 
 ARG meridio_version=0.0.0-unknown
 ENV GO111MODULE=on
@@ -14,22 +16,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags -static -X main.version=${meridio_version}" -o proxy ./cmd/proxy
 
-FROM ubuntu:21.04 as grpc-health-probe
-
-RUN apt-get update -y
-RUN apt-get install -y wget
-WORKDIR /
-RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.2/grpc_health_probe-linux-amd64
-RUN mv grpc_health_probe-linux-amd64 /bin/grpc_health_probe
-RUN chmod +x /bin/grpc_health_probe
-
-FROM ubuntu:21.04
-
-RUN apt-get update -y
-RUN apt-get install -y iproute2 tcpdump iptables net-tools iputils-ping ipvsadm netcat
-
+FROM ${base_image}
 WORKDIR /root/
 COPY --from=build /app/proxy .
-COPY --from=grpc-health-probe /bin/grpc_health_probe /bin/
-
 CMD ["./proxy"]

--- a/build/tapa/Dockerfile
+++ b/build/tapa/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.16 as build
+ARG base_image=registry.nordix.org/cloud-native/meridio/base:latest
+
+FROM golang:1.18.1 as build
 
 ARG meridio_version=0.0.0-unknown
 ENV GO111MODULE=on
@@ -14,22 +16,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags -static -X main.version=${meridio_version}" -o tapa ./cmd/tapa
 
-FROM ubuntu:21.04 as grpc-health-probe
-
-RUN apt-get update -y
-RUN apt-get install -y wget
-WORKDIR /
-RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.2/grpc_health_probe-linux-amd64
-RUN mv grpc_health_probe-linux-amd64 /bin/grpc_health_probe
-RUN chmod +x /bin/grpc_health_probe
-
-FROM ubuntu:21.04
-
-RUN apt-get update -y
-RUN apt-get install -y iproute2 tcpdump iptables net-tools iputils-ping ipvsadm netcat
-
+FROM ${base_image}
 WORKDIR /root/
 COPY --from=build /app/tapa .
-COPY --from=grpc-health-probe /bin/grpc_health_probe /bin/
-
 CMD ["./tapa"]

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,0 +1,149 @@
+#! /bin/sh
+##
+## build.sh --
+##   Build script for https://github.com/Nordix/Meridio.
+##
+##   This script builds the Meridio images using the go environment on
+##   your host, as opposed to build in Docker as the Makefile
+##   does. This simplify repeated builds for development and tests.
+##   And it's way faster!
+##
+## Commands;
+##
+
+prg=$(basename $0)
+dir=$(dirname $0); dir=$(readlink -f $dir); dir=$(readlink -f $dir/..)
+tmp=/tmp/${prg}_$$
+
+die() {
+    echo "ERROR: $*" >&2
+    rm -rf $tmp
+    exit 1
+}
+help() {
+    grep '^##' $0 | cut -c3-
+    rm -rf $tmp
+    exit 0
+}
+test -n "$1" || help
+echo "$1" | grep -qi "^help\|-h" && help
+
+log() {
+	echo "$prg: $*" >&2
+}
+dbg() {
+	test -n "$__verbose" && echo "$prg: $*" >&2
+}
+
+##  env
+##    Print environment.
+##
+cmd_env() {
+	test -n "$__out" || __out=$(readlink -f $dir/_output)
+	test -n "$__targets" || __targets="load-balancer proxy tapa ipam nsp frontend"
+	test -n "$__registry" || __registry=registry.nordix.org/cloud-native/meridio
+	test -n "$__version" || __version=local
+	test -n "$__nfqlb" || __nfqlb=1.0.0
+	test -n "$ARCHIVE" || ARCHIVE=$HOME/Downloads
+	test "$cmd" = "env" && set | grep -E '^(__.*|ARCHIVE)='
+}
+
+##  base_image
+##    Build the base image
+cmd_base_image() {
+	cmd_env
+	local base=$(grep base_image= $dir/hack/host-build/Dockerfile.default | cut -d= -f2)
+	local dockerfile=$dir/build/base/Dockerfile
+	mkdir -p $tmp
+	docker build -t $base -f $dockerfile $tmp || die "docker build $base"
+	echo $base
+}
+##  binaries [targets...]
+##    Build binaries. Build in Meridio/_output
+cmd_binaries() {
+	cmd_env
+	cd $dir
+	mkdir -p $__out
+	test -n "$1" && __targets="$@"
+	local gitver=$(git describe --dirty --tags)
+	local n cmds cgo
+	for n in $__targets; do
+		if echo $n | grep -qE 'ipam|nsp'; then
+			# Requires CGO_ENABLED=1
+			cgo="$cgo $dir/cmd/$n"
+		else
+			cmds="$cmds $dir/cmd/$n"
+		fi
+	done
+	if test -n "$cmds"; then
+		CGO_ENABLED=0 GOOS=linux go build -o $__out \
+			-ldflags "-extldflags -static -X main.version=$gitver" $cmds \
+			|| die "go build $cmds"
+	fi
+	if test -n "$cgo"; then
+		mkdir -p $tmp
+		if ! CGO_ENABLED=1 GOOS=linux go build -o $__out \
+			-ldflags "-extldflags -static -X main.version=$gitver" \
+			$cgo > $tmp/out 2>&1; then
+			cat $tmp/out
+			die "go build $cgo"
+		fi
+	fi
+	strip $__out/*
+}
+##  images [--registry=] [--version=] [targets...]
+##    Build docker images.
+cmd_images() {
+	test -n "$1" && __targets="$@"
+	cmd_binaries
+	local n dockerfile x
+	for n in $__targets; do
+		x=$__out/$n
+		test -x $x || die "Not built [$x]"
+		rm -rf $tmp; mkdir -p $tmp/root
+		cp $x $tmp/root
+		if test "$n" = "load-balancer"; then
+			mkdir -p $ARCHIVE
+			local ar=$ARCHIVE/nfqlb-$__nfqlb.tar.xz
+			if ! test -r $ar; then
+				local url=https://github.com/Nordix/nfqueue-loadbalancer/releases/download
+				curl -L $url/$__nfqlb/nfqlb-$__nfqlb.tar.xz > $ar || die Curl
+			fi
+			tar -C $tmp --strip-components=1 -xf $ar nfqlb-$__nfqlb/bin/nfqlb \
+				|| die "tar $ar"
+		fi
+		dockerfile=$dir/hack/host-build/Dockerfile.$n
+		test -r $dockerfile \
+			|| dockerfile=$dir/hack/host-build/Dockerfile.default
+		sed -e "s,/start-command,/$n," < $dockerfile > $tmp/Dockerfile
+		docker build -t $__registry/$n:$__version $tmp \
+			|| die "docker build $n"
+	done
+}
+
+##
+# Get the command
+cmd=$1
+shift
+grep -q "^cmd_$cmd()" $0 $hook || die "Invalid command [$cmd]"
+
+while echo "$1" | grep -q '^--'; do
+    if echo $1 | grep -q =; then
+	o=$(echo "$1" | cut -d= -f1 | sed -e 's,-,_,g')
+	v=$(echo "$1" | cut -d= -f2-)
+	eval "$o=\"$v\""
+    else
+	o=$(echo "$1" | sed -e 's,-,_,g')
+	eval "$o=yes"
+    fi
+    shift
+done
+unset o v
+long_opts=`set | grep '^__' | cut -d= -f1`
+
+# Execute command
+trap "die Interrupted" INT TERM
+cmd_$cmd "$@"
+status=$?
+rm -rf $tmp
+exit $status

--- a/hack/host-build/Dockerfile.default
+++ b/hack/host-build/Dockerfile.default
@@ -1,0 +1,4 @@
+ARG base_image=registry.nordix.org/cloud-native/meridio/base:1.0.0
+FROM ${base_image}
+COPY . .
+CMD ["/root/start-command"]

--- a/hack/host-build/Dockerfile.frontend
+++ b/hack/host-build/Dockerfile.frontend
@@ -1,0 +1,6 @@
+ARG base_image=registry.nordix.org/cloud-native/meridio/base:1.0.0
+FROM ${base_image}
+RUN apk add bird
+RUN mkdir -p /run/bird && mkdir -p /etc/bird
+COPY . .
+CMD ["/root/start-command"]

--- a/hack/host-build/Dockerfile.load-balancer
+++ b/hack/host-build/Dockerfile.load-balancer
@@ -1,0 +1,5 @@
+ARG base_image=registry.nordix.org/cloud-native/meridio/base:1.0.0
+FROM ${base_image}
+RUN apk add nftables
+COPY . .
+CMD ["/root/start-command"]


### PR DESCRIPTION
Use [Alpine Linux](https://www.alpinelinux.org/) as base for Meridio images.

Before Ubuntu 21 was used for most images, which is unnecessary fat and is not LTS. Build on a standardized base simplifies handling and a possible switch to a distroless image later on.

The image used as base for all Meridio images may look something like;
```
FROM alpine:3.15
RUN apk update && apk add iproute2
ADD https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.2/grpc_health_probe-linux-amd64 /bin/grpc_health_probe
RUN chmod a+x /bin/grpc_health_probe
```

### Debug image

A Meridio "debug" image will be created that can be loaded as a K8s [ephemeral container](https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/). It will contain necessary debug tools.
