### PR TITLE
probing; increase connect and rpc timeouts of internal gRPC probes

### DIFF
--- a/pkg/health/probe/probe.go
+++ b/pkg/health/probe/probe.go
@@ -44,8 +44,8 @@ func NewGRPCHealthProbe(options ...Option) (*GrpcHealthProbe, error) {
 		cmd:         "grpc_health_probe",
 		addr:        fmt.Sprintf("-addr=%v", health.DefaultURL),
 		service:     "-service=",
-		rpcTimeout:  "-rpc-timeout=150ms",
-		connTimeout: "-connect-timeout=100ms",
+		rpcTimeout:  "-rpc-timeout=350ms",
+		connTimeout: "-connect-timeout=250ms",
 	}
 	for _, opt := range options {
 		opt(opts)


### PR DESCRIPTION
Increased connect and rpc timeouts of internal grpc-health-probes, so that containers running with lower CPU resources won't experience unnecessary probing failures.