### PR TITLE
Fix TAPA unit test

### DIFF
--- a/pkg/ambassador/tap/conduit/manager_test.go
+++ b/pkg/ambassador/tap/conduit/manager_test.go
@@ -33,7 +33,7 @@ import (
 	"go.uber.org/goleak"
 )
 
-var timeout = 50 * time.Millisecond
+var timeout = 500 * time.Millisecond
 
 func Test_Manager_Run_Stop(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })


### PR DESCRIPTION
The delay to retry to open after an error received is hardcoded to 50ms. And the const timeout value for the open was set to 50ms, so the Test_Manager_Retry_Open test function could not always pass.