### PR TITLE
proxy; align Conduit MTU

### DIFF
--- a/cmd/proxy/internal/service/client.go
+++ b/cmd/proxy/internal/service/client.go
@@ -33,6 +33,7 @@ import (
 	"github.com/nordix/meridio/cmd/proxy/internal/config"
 	"github.com/nordix/meridio/pkg/nsm"
 	"github.com/nordix/meridio/pkg/nsm/ipcontext"
+	"github.com/nordix/meridio/pkg/nsm/mtu"
 	"github.com/nordix/meridio/pkg/proxy"
 	proxyHealth "github.com/nordix/meridio/pkg/proxy/health"
 	"github.com/sirupsen/logrus"
@@ -61,6 +62,7 @@ func GetNSC(ctx context.Context,
 		}),
 		ipcontext.NewClient(p),
 		interfaceMonitorClient,
+		mtu.NewMtuClient(uint32(config.MTU)),
 		proxyHealth.NewClient(),
 	)
 	fullMeshClient := client.NewFullMeshNetworkServiceClient(ctx, clientConfig, additionalFunctionality)

--- a/cmd/proxy/internal/service/server.go
+++ b/cmd/proxy/internal/service/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/nordix/meridio/pkg/nsm"
 	"github.com/nordix/meridio/pkg/nsm/endpoint"
 	"github.com/nordix/meridio/pkg/nsm/ipcontext"
+	"github.com/nordix/meridio/pkg/nsm/mtu"
 	"github.com/nordix/meridio/pkg/nsm/service"
 	"github.com/nordix/meridio/pkg/proxy"
 	"github.com/sirupsen/logrus"
@@ -55,6 +56,7 @@ func StartNSE(ctx context.Context,
 		}),
 		ipcontext.NewServer(p),
 		interfaceMonitorServer,
+		mtu.NewMtuServer(uint32(config.MTU)),
 		sendfd.NewServer(),
 	}
 

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -83,6 +83,9 @@ func main() {
 		logrus.Fatalf("%v", err)
 	}
 	logrus.Infof("rootConf: %+v", config)
+	if err := config.IsValid(); err != nil {
+		logrus.Fatalf("%v", err)
+	}
 	ctx = setLogging(ctx, &config)
 
 	// create and start health server
@@ -156,6 +159,7 @@ func main() {
 		ServiceName:      config.ServiceName,
 		MaxTokenLifetime: config.MaxTokenLifetime,
 		Labels:           labels,
+		MTU:              config.MTU,
 	}
 	interfaceMonitorServer := interfacemonitor.NewServer(interfaceMonitor, p, netUtils)
 	ep := service.StartNSE(ctx, endpointConfig, nsmAPIClient, p, interfaceMonitorServer)

--- a/deployments/helm/templates/proxy.yaml
+++ b/deployments/helm/templates/proxy.yaml
@@ -71,6 +71,8 @@ spec:
               value: {{ .Values.maxTokenLifetime }}
             - name: NSM_LOG_LEVEL
               value: "DEBUG"
+            - name: NSM_MTU
+              value: "1500"
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets

--- a/pkg/endpoint/config.go
+++ b/pkg/endpoint/config.go
@@ -24,4 +24,5 @@ type Config struct {
 	ServiceName      string
 	Labels           map[string]string
 	MaxTokenLifetime time.Duration
+	MTU              int
 }

--- a/pkg/nsm/mtu/client.go
+++ b/pkg/nsm/mtu/client.go
@@ -1,0 +1,51 @@
+/*
+Copyright (c) 2022 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtu
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"google.golang.org/grpc"
+)
+
+// mtuClient adds proposed MTU to the Request. To be used by NSC.
+// Won't take effect, if NSM cannot fit the proposed MTU considering
+// the chosen mechanism and the underlying network infrastructure.
+type mtuClient struct {
+	mtu uint32
+}
+
+func NewMtuClient(mtu uint32) networkservice.NetworkServiceClient {
+	return &mtuClient{
+		mtu: mtu,
+	}
+}
+
+func (m *mtuClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (conn *networkservice.Connection, err error) {
+	if request.GetConnection().GetContext() == nil {
+		request.GetConnection().Context = &networkservice.ConnectionContext{}
+	}
+	request.GetConnection().GetContext().MTU = m.mtu
+	return next.Client(ctx).Request(ctx, request, opts...)
+}
+
+func (m *mtuClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
+	return next.Client(ctx).Close(ctx, conn, opts...)
+}

--- a/pkg/nsm/mtu/server.go
+++ b/pkg/nsm/mtu/server.go
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2022 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtu
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+)
+
+// mtuServer adds proposed MTU to the Request. To be used by NSE.
+// Won't take effect, if NSM cannot fit the proposed MTU considering
+// the chosen mechanism and the underlying network infrastructure.
+type mtuServer struct {
+	mtu uint32
+}
+
+func NewMtuServer(mtu uint32) networkservice.NetworkServiceServer {
+	return &mtuServer{
+		mtu: mtu,
+	}
+}
+
+func (m *mtuServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
+	if request.GetConnection().GetContext() == nil {
+		request.GetConnection().Context = &networkservice.ConnectionContext{}
+	}
+	request.GetConnection().GetContext().MTU = m.mtu
+	return next.Server(ctx).Request(ctx, request)
+}
+
+func (m *mtuServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
+	return next.Server(ctx).Close(ctx, conn)
+}


### PR DESCRIPTION
Proxy as a center of TAPA-Proxy and Proxy-LB xconnects
changes Network Service Requests by adding MTU (retrieved
through environment variable).

This approach does not require additional privileges on the TAPA side.
(Also, on the Operator side similarly to Resource Management by implementing a dedicated annotation the MTU value could be set through Conduit CR.)