### PR TITLE
fe; decreased log level of announcing fe service to nsp

### DIFF
--- a/cmd/frontend/internal/frontend/notify.go
+++ b/cmd/frontend/internal/frontend/notify.go
@@ -38,15 +38,13 @@ import (
 
 // TODO: add context to nspClient calls so that they could be cancelled
 // TODO: must denounce FE upon its shutdown (make sure it won't block forever e.g. in case NSP is no longer available)
-// TODO: NSP must be improved to somehow learn if source of a Register event has disappeared (check NSM registry for clue)
-// (maybe introduce timed Register that requires registration)
 // TODO: maybe introduce update target through new context keyword, indicating nsp to replace found item with new one
 func announceFrontend(targetRegistryClient nspAPI.TargetRegistryClient) error {
 	hn, _ := os.Hostname()
 	targetContext := map[string]string{
 		types.IdentifierKey: hn,
 	}
-	logrus.Infof("announceFrontend: hostname: %v, targetType: %v", hn, nspAPI.Target_FRONTEND)
+	logrus.Tracef("announceFrontend: hostname: %v, targetType: %v", hn, nspAPI.Target_FRONTEND)
 	_, err := targetRegistryClient.Register(context.Background(), &nspAPI.Target{
 		Ips:     []string{hn},
 		Type:    nspAPI.Target_FRONTEND,

--- a/cmd/frontend/internal/frontend/service.go
+++ b/cmd/frontend/internal/frontend/service.go
@@ -319,6 +319,7 @@ func (fes *FrontEndService) Monitor(ctx context.Context) error {
 					if noConnectivity {
 						noConnectivity = false
 						health.SetServingStatus(ctx, health.EgressSvc, true)
+						logrus.Infof("FrontEndService: announce frontend")
 						if err := announceFrontend(fes.targetRegistryClient); err != nil {
 							logrus.Infof("FrontEndService: failed to announce frontend connectivity (err: %v)", err)
 						}

--- a/pkg/proxy/health/client.go
+++ b/pkg/proxy/health/client.go
@@ -50,7 +50,7 @@ func (h *healthServiceClient) Request(ctx context.Context, request *networkservi
 
 	if err == nil {
 		h.mu.Lock()
-		logrus.Debugf("HealthServiceClient:Request id=%v", id)
+		logrus.Tracef("HealthServiceClient:Request id=%v", id)
 		h.connIds[id] = struct{}{}
 		health.SetServingStatus(ctx, health.EgressSvc, true)
 		h.mu.Unlock()
@@ -62,7 +62,7 @@ func (h *healthServiceClient) Request(ctx context.Context, request *networkservi
 // Close -
 func (h *healthServiceClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
 	h.mu.Lock()
-	logrus.Debugf("HealthServiceClient:Close id=%v", conn.Id)
+	logrus.Tracef("HealthServiceClient:Close id=%v", conn.Id)
 	delete(h.connIds, conn.Id)
 	if len(h.connIds) == 0 {
 		logrus.Debugf("HealthServiceClient:Close No conns left!")


### PR DESCRIPTION
Due to the recently introduced KeepAlive mechanism for NSP Target registry
the periodic refresh (to announce FE availibilty) lead to excess logging.