### PR TITLE
Fix Load-balancer resiliency

### DIFF
--- a/cmd/proxy/internal/service/client.go
+++ b/cmd/proxy/internal/service/client.go
@@ -32,6 +32,7 @@ import (
 	"github.com/nordix/meridio/cmd/proxy/internal/client"
 	"github.com/nordix/meridio/cmd/proxy/internal/config"
 	"github.com/nordix/meridio/pkg/nsm"
+	"github.com/nordix/meridio/pkg/nsm/fullmeshtracker"
 	"github.com/nordix/meridio/pkg/nsm/ipcontext"
 	"github.com/nordix/meridio/pkg/proxy"
 	proxyHealth "github.com/nordix/meridio/pkg/proxy/health"
@@ -62,6 +63,7 @@ func GetNSC(ctx context.Context,
 		ipcontext.NewClient(p),
 		interfaceMonitorClient,
 		proxyHealth.NewClient(),
+		fullmeshtracker.NewClient(),
 	)
 	fullMeshClient := client.NewFullMeshNetworkServiceClient(ctx, clientConfig, additionalFunctionality)
 

--- a/pkg/kernel/fwmark.go
+++ b/pkg/kernel/fwmark.go
@@ -56,6 +56,8 @@ func (fwmr *FWMarkRoute) Verify() bool {
 }
 
 func (fwmr *FWMarkRoute) configure() error {
+	_ = fwmr.Delete()
+
 	rule := netlink.NewRule()
 	rule.Table = fwmr.tableID
 	rule.Mark = fwmr.fwmark

--- a/pkg/nsm/fullmeshtracker/client.go
+++ b/pkg/nsm/fullmeshtracker/client.go
@@ -1,0 +1,61 @@
+/*
+Copyright (c) 2022 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fullmeshtracker
+
+import (
+	"context"
+	"sync"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+)
+
+type fullMeshTrackerClient struct {
+	m sync.Map // key: connId, value: NSE-Name
+}
+
+// NewClient implements NetworkServiceClient to track the connections and the NSE name requested
+// in order to prevent NSM from selecting the NSE. In case a NSC wants to connect to a specific NSE
+// and that NSE has a problem (crash...), NSM will remove the NSE name from the connection to select a new one.
+// This chain element will remember the NSE name and add it again, so the connection will always be to the
+// originally selected NSE.
+func NewClient() networkservice.NetworkServiceClient {
+	return &fullMeshTrackerClient{}
+}
+
+// Request stores the NSE name if not previously saved. If it is previously saved, then it loads it to
+// add it to the connection.
+func (fmtc *fullMeshTrackerClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
+	nseName, exists := fmtc.m.Load(request.Connection.Id)
+	if exists {
+		request.Connection.NetworkServiceEndpointName = nseName.(string)
+	} else {
+		fmtc.m.Store(request.Connection.Id, request.Connection.NetworkServiceEndpointName)
+	}
+	return next.Client(ctx).Request(ctx, request, opts...)
+}
+
+// Close -
+// TODO: remove NSE from the map when they are removed (real close)
+func (fmtc *fullMeshTrackerClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
+	_, err := next.Client(ctx).Close(ctx, conn, opts...)
+	return &emptypb.Empty{}, err
+}


### PR DESCRIPTION
If the LB restarts, the rules and routes will remain in pod. So, before adding a target rule and route, the previous one are now removed.

New chain element for the full mesh client tracking the connection and the associated NSE name. So, if the connection has a problem (e.g. NSE Crash), NSM will set the connection to the same NSE and won't try to find a new one.

TODO: remove NSE from the map when they are removed (real close). This could be done using the NSM registry with the find function to remove the no longer existing NSEs from the map.

Issue: #225 