### PR TITLE
Use different external interace name when VLAN ID=0

### DIFF
--- a/deployments/helm/templates/_helpers.tpl
+++ b/deployments/helm/templates/_helpers.tpl
@@ -45,7 +45,11 @@ Set IP Family
 {{- end -}}
 
 {{- define "meridio.vlan.extInterfaceName" -}}
+{{- if .Values.vlan.id }}
 {{- printf "ext-vlan.%d" ( .Values.vlan.id | int ) -}}
+{{- else -}}
+{{- printf "ext" -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "meridio.vrrps" -}}


### PR DESCRIPTION
In case VLAN ID=0 NSM won't create a VLAN subinterface.
In fact, the base interface might not even be a VLAN interface.
So let Remote VLAN NSE create an interace with the name "ext"
in such cases.

Testing VLAN ID=0 requires NSM 1.4.0-rc.1: https://github.com/Nordix/Meridio/pull/231

Also, prior to starting NSM vpp forwarders the device selector config map must be updated to contain the VLAN interface(s) to be used.

**Example:**
```
# adjust device selector config map then deploy NSM
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: device-selector
data:
  selector: "---\ninterfaces:\n
    \  - name: eth0\n
    \    matches:\n
    \       - labelSelector:\n
    \          - via: eth0\n
    \  - name: eth1.200\n
    \    matches:\n
    \       - labelSelector:\n
    \          - via: eth1.200\n
    \  - name: eth1\n
    \    matches:\n
    \       - labelSelector:\n
    \          - via: eth1\n     \n"

# start trench-a based on host interface eth1.200
helm install Meridio/deployments/helm/ --generate-name --namespace default --set trench.name=trench-a --set vlan.interface=eth1.200,vlan.id=0 --set ipFamily=dualstack
```

**Note**: Occasionally vpp "fails to learn" all the interfaces in the device selector config map (seems more common when device selector contains more interfaces). In which case the external interface won't be created in the _fe_ container.
Check the interfaces by entering the vpp forwarder container and then fetching the known interfaces through vppcli:
```
kubectl exec -ti -n nsm forwarder-vpp-269t2 -- bash
root@vm-001:/# vppctl show interface
              Name               Idx    State  MTU (L3/IP4/IP6/MPLS)     Counter          Count     
host-eth1                         1      up     1500/1500/1500/1500 rx packets                 31071
                                                                    rx bytes                11605708
                                                                    drops                      31071
                                                                    ip4                        14128
                                                                    ip6                         2543
local0                            0     down          0/0/0/0       

kubectl exec -ti -n nsm forwarder-vpp-w7xkx -- bash
root@vm-001:/# vppctl show interface
              Name               Idx    State  MTU (L3/IP4/IP6/MPLS)     Counter          Count     
host-eth0.200                     1      up     1500/1500/1500/1500 
host-eth1                         5      up     1500/1500/1500/1500 rx packets                  2871
                                                                    rx bytes                 1183370
                                                                    tx packets                     2
                                                                    tx bytes                      84
                                                                    drops                       2871
                                                                    ip4                         1215
                                                                    ip6                          207
host-eth1.200                     2      up     1500/1500/1500/1500 
host-eth2                         4      up     1500/1500/1500/1500 rx packets                     1
                                                                    rx bytes                      70
                                                                    drops                          1
host-eth2.200                     3      up     1500/1500/1500/1500 
local0                            0     down          0/0/0/0       


```