### PR TITLE
Enable readOnlyRootFilesystem=true

### DIFF
--- a/cmd/frontend/internal/env/config.go
+++ b/cmd/frontend/internal/env/config.go
@@ -19,22 +19,24 @@ package env
 import "time"
 
 type Config struct {
-	VRRPs             []string      `default:"" desc:"VRRP IP addresses to be used as next-hops for static default routes" envconfig:"VRRPS"`
-	ExternalInterface string        `default:"ext-vlan" desc:"External interface to start BIRD on" split_words:"true"`
-	BirdConfigPath    string        `default:"/etc/bird" desc:"Path to place bird config files" split_words:"true"`
-	LocalAS           string        `default:"8103" desc:"Local BGP AS number" envconfig:"LOCAL_AS"`
-	RemoteAS          string        `default:"4248829953" desc:"Local BGP AS number" envconfig:"REMOTE_AS"`
-	BGPLocalPort      string        `default:"10179" desc:"Local BGP server port" envconfig:"BGP_LOCAL_PORT"`
-	BGPRemotePort     string        `default:"10179" desc:"Remote BGP server port" envconfig:"BGP_REMOTE_PORT"`
-	BGPHoldTime       string        `default:"3" desc:"Seconds to wait for a Keepalive message from peer before considering the connection stale" envconfig:"BGP_HOLD_TIME"`
-	TableID           int           `default:"4096" desc:"OS Kernel routing table ID BIRD syncs the routes with" envconfig:"TABLE_ID"`
-	ECMP              bool          `default:"false" desc:"Enable ECMP towards next-hops of avaialble gateways" envconfig:"ECMP"`
-	DropIfNoPeer      bool          `default:"false" desc:"Install default blackhole route with high metric into routing table TableID" split_words:"true"`
-	LogBird           bool          `default:"false" desc:"Add important bird log snippets to our log" split_words:"true"`
-	Namespace         string        `default:"default" desc:"Namespace the pod is running on" split_words:"true"`
-	NSPService        string        `default:"nsp-service-trench-a:7778" desc:"IP (or domain) and port of the NSP Service" split_words:"true"`
-	TrenchName        string        `default:"default" desc:"Name of the Trench the frontend is associated with" split_words:"true"`
-	AttractorName     string        `default:"default" desc:"Name of the Attractor the frontend is associated with" split_words:"true"`
-	LogLevel          string        `default:"DEBUG" desc:"Log level" split_words:"true"`
-	NSPEntryTimeout   time.Duration `default:"30s" desc:"Timeout of the entries" envconfig:"nsp_entry_timeout"`
+	VRRPs                 []string      `default:"" desc:"VRRP IP addresses to be used as next-hops for static default routes" envconfig:"VRRPS"`
+	ExternalInterface     string        `default:"ext-vlan" desc:"External interface to start BIRD on" split_words:"true"`
+	BirdConfigPath        string        `default:"/etc/bird" desc:"Path to place bird config files" split_words:"true"`
+	BirdCommunicationSock string        `default:"/var/run/bird/bird.ctl" desc:"Use given filename for a socket to communicate with birdc" split_words:"true"`
+	BirdLogFileSize       int           `default:"20000" desc:"File size in bytes of the local BIRD log file (and log backup file)" split_words:"true"`
+	LocalAS               string        `default:"8103" desc:"Local BGP AS number" envconfig:"LOCAL_AS"`
+	RemoteAS              string        `default:"4248829953" desc:"Local BGP AS number" envconfig:"REMOTE_AS"`
+	BGPLocalPort          string        `default:"10179" desc:"Local BGP server port" envconfig:"BGP_LOCAL_PORT"`
+	BGPRemotePort         string        `default:"10179" desc:"Remote BGP server port" envconfig:"BGP_REMOTE_PORT"`
+	BGPHoldTime           string        `default:"3" desc:"Seconds to wait for a Keepalive message from peer before considering the connection stale" envconfig:"BGP_HOLD_TIME"`
+	TableID               int           `default:"4096" desc:"OS Kernel routing table ID BIRD syncs the routes with" envconfig:"TABLE_ID"`
+	ECMP                  bool          `default:"false" desc:"Enable ECMP towards next-hops of avaialble gateways" envconfig:"ECMP"`
+	DropIfNoPeer          bool          `default:"false" desc:"Install default blackhole route with high metric into routing table TableID" split_words:"true"`
+	LogBird               bool          `default:"false" desc:"Add important bird log snippets to our log" split_words:"true"`
+	Namespace             string        `default:"default" desc:"Namespace the pod is running on" split_words:"true"`
+	NSPService            string        `default:"nsp-service-trench-a:7778" desc:"IP (or domain) and port of the NSP Service" split_words:"true"`
+	TrenchName            string        `default:"default" desc:"Name of the Trench the frontend is associated with" split_words:"true"`
+	AttractorName         string        `default:"default" desc:"Name of the Attractor the frontend is associated with" split_words:"true"`
+	LogLevel              string        `default:"DEBUG" desc:"Log level" split_words:"true"`
+	NSPEntryTimeout       time.Duration `default:"30s" desc:"Timeout of the entries" envconfig:"nsp_entry_timeout"`
 }

--- a/cmd/proxy/internal/client/utils.go
+++ b/cmd/proxy/internal/client/utils.go
@@ -25,7 +25,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/heal"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/sendfd"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/connectioncontext/dnscontext"
 	"github.com/nordix/meridio/pkg/nsm"
 )
 
@@ -46,8 +45,6 @@ func expirationTimeIsNull(expirationTime *timestamp.Timestamp) bool {
 func newClient(ctx context.Context, name string, nsmAPIClient *nsm.APIClient, additionalFunctionality ...networkservice.NetworkServiceClient) networkservice.NetworkServiceClient {
 	additionalFunctionality = append(additionalFunctionality,
 		sendfd.NewClient(),
-		dnscontext.NewClient(dnscontext.WithChainContext(ctx)),
-		// excludedprefixes.NewClient(),
 	)
 
 	return client.NewClient(ctx,

--- a/cmd/tapa/main.go
+++ b/cmd/tapa/main.go
@@ -37,7 +37,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/kernel"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/sendfd"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/connectioncontext/dnscontext"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 	ambassadorAPI "github.com/nordix/meridio/api/ambassador/v1"
@@ -141,8 +140,6 @@ func main() {
 			kernelmech.MECHANISM: chain.NewNetworkServiceClient(kernel.NewClient(kernel.WithInterfaceName("nsc"))),
 		}),
 		sendfd.NewClient(),
-		dnscontext.NewClient(dnscontext.WithChainContext(ctx)),
-		// excludedprefixes.NewClient(),
 	}
 
 	networkServiceClient := client.NewClient(ctx,

--- a/deployments/helm/templates/ipam.yaml
+++ b/deployments/helm/templates/ipam.yaml
@@ -56,6 +56,8 @@ spec:
               value: "{{ .Values.subnetPool.nodePrefixLength.ipv6 }}"
             - name: IPAM_IP_FAMILY
               value: "{{ .Values.ipFamily }}"
+          securityContext:
+            readOnlyRootFilesystem: true
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets
@@ -63,11 +65,17 @@ spec:
             - name: ipam-data
               mountPath: /run/ipam/data
               readOnly: false
+            - name: tmp
+              mountPath: /tmp
+              readOnly: false
       volumes:
         - name: spire-agent-socket
           hostPath:
             path: /run/spire/sockets
             type: Directory
+        - name: tmp
+          emptyDir:
+            medium: Memory
   volumeClaimTemplates:
     - metadata:
         name: ipam-data

--- a/deployments/helm/templates/load-balancer.yaml
+++ b/deployments/helm/templates/load-balancer.yaml
@@ -75,7 +75,11 @@ spec:
             - name: nsm-socket
               mountPath: /var/lib/networkservicemesh
               readOnly: false
+            - name: tmp-lb
+              mountPath: /tmp
+              readOnly: false
           securityContext:
+            readOnlyRootFilesystem: true
             capabilities:
               add: ["NET_ADMIN"]
         - name: nsc
@@ -139,7 +143,20 @@ spec:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets
               readOnly: true
+            - name: tmp-fe
+              mountPath: /tmp
+              readOnly: false
+            - name: run
+              mountPath: /var/run/bird
+              readOnly: false
+            - name: etc
+              mountPath: /etc/bird
+              readOnly: false
+            - name: log
+              mountPath: /var/log
+              readOnly: false
           securityContext:
+            readOnlyRootFilesystem: true
             capabilities:
               add: ["NET_ADMIN"]
       volumes:
@@ -151,3 +168,18 @@ spec:
           hostPath:
             path: /var/lib/networkservicemesh
             type: DirectoryOrCreate
+        - name: tmp-lb
+          emptyDir:
+            medium: Memory
+        - name: tmp-fe
+          emptyDir:
+            medium: Memory
+        - name: run
+          emptyDir:
+            medium: Memory
+        - name: etc
+          emptyDir:
+            medium: Memory
+        - name: log
+          emptyDir:
+            medium: Memory

--- a/deployments/helm/templates/nse-vlan.yaml
+++ b/deployments/helm/templates/nse-vlan.yaml
@@ -28,6 +28,8 @@ spec:
           ports:
             - containerPort: 5003
               hostPort: 5003
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock

--- a/deployments/helm/templates/nsp.yaml
+++ b/deployments/helm/templates/nsp.yaml
@@ -41,6 +41,8 @@ spec:
               value: {{ template "meridio.configuration" . }}
             - name: NSP_DATASOURCE
               value: /run/nsp/data/registry.db
+          securityContext:
+            readOnlyRootFilesystem: true
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets
@@ -48,11 +50,17 @@ spec:
             - name: nsp-data
               mountPath: /run/nsp/data
               readOnly: false
+            - name: tmp
+              mountPath: /tmp
+              readOnly: false
       volumes:
         - name: spire-agent-socket
           hostPath:
             path: /run/spire/sockets
             type: Directory
+        - name: tmp
+          emptyDir:
+            medium: Memory
   volumeClaimTemplates:
     - metadata:
         name: nsp-data

--- a/deployments/helm/templates/proxy.yaml
+++ b/deployments/helm/templates/proxy.yaml
@@ -80,7 +80,11 @@ spec:
             - name: nsm-socket
               mountPath: /var/lib/networkservicemesh
               readOnly: true
+            - name: tmp
+              mountPath: /tmp
+              readOnly: false
           securityContext:
+            readOnlyRootFilesystem: true
             capabilities:
               add: ["NET_ADMIN"]
       volumes:
@@ -92,3 +96,6 @@ spec:
           hostPath:
             path: /var/lib/networkservicemesh
             type: DirectoryOrCreate
+        - name: tmp
+          emptyDir:
+            medium: Memory

--- a/examples/target/helm/templates/target.yaml
+++ b/examples/target/helm/templates/target.yaml
@@ -49,6 +49,8 @@ spec:
 {{ tpl (toYaml .Values.readinessProbe) . | indent 12 }}
           livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 12 }}
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock
@@ -84,6 +86,9 @@ spec:
             - name: meridio-socket
               mountPath: /var/lib/meridio
               readOnly: false
+            - name: tmp
+              mountPath: /tmp
+              readOnly: false
       volumes:
         - name: spire-agent-socket
           hostPath:
@@ -95,3 +100,6 @@ spec:
             type: DirectoryOrCreate
         - name: meridio-socket
           emptyDir: {}
+        - name: tmp
+          emptyDir:
+            medium: Memory


### PR DESCRIPTION
- /tmp is provided through an emptyDir volume to host unix listeners
  (e.g. probes, NSM listenOn socket)
- removed NSM dnscontext client chain element as it required write
  access e.g. to /etc/resolv.conf, /etc/coredns/Corefile
- BIRD: emptyDir volumes
  - to write routing config (under etc/bird/)
  - to create unix socket to communicate with birdc (changed path
    from default /run/bird.ctl to /run/bird/bird.ctl)
  - to write log file and its backup (2 x 20 kbyte by default
    under /var/log/)

NSM NSC is not changed. (It uses dnscontext client, but currently
there's no way to change resolv.conf path in the NSC. However,
failure to writing resolv.conf won't result in a fatal error, so
readOnlyRootFilesystem=true could be set if really needed.)

Remote VLAN NSE works with readOnlyRootFilesystem=true without problems.
(No guarantees for future releases though.)

Note: Set 'medium' of emptyDir volumes to 'Memory'. Thus get mounted as tmpfs.
Meaning they contribute to the containers' memory consumption. (Must be
considered when setting memory resource requests/limits.)