### PR TITLE
mconnect in target example container and GW/TG

### DIFF
--- a/build/ctraffic/Dockerfile
+++ b/build/ctraffic/Dockerfile
@@ -15,14 +15,18 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o target
 
 FROM ubuntu:21.04
 
-RUN apt-get update -y --fix-missing
-RUN apt-get install -y iproute2 tcpdump iptables net-tools iputils-ping ipvsadm netcat wget screen
+RUN apt-get update -y --fix-missing \
+  && apt-get install -y iproute2 tcpdump iptables net-tools iputils-ping ipvsadm netcat wget screen conntrack xz-utils
 
 WORKDIR /root/
 
-RUN wget https://github.com/Nordix/ctraffic/releases/download/v1.6.0/ctraffic.gz
-RUN gunzip ctraffic.gz 
-RUN chmod u+x ctraffic
+ADD https://github.com/Nordix/ctraffic/releases/download/v1.7.0/ctraffic.gz ctraffic.gz
+RUN gunzip ctraffic.gz \
+  && chmod u+x ctraffic
+
+ADD https://github.com/Nordix/mconnect/releases/download/v2.2.0/mconnect.xz mconnect.xz
+RUN unxz mconnect.xz \
+  && chmod u+x mconnect
 
 COPY --from=build /app/target-client .
 

--- a/deployments/helm/templates/config.yaml
+++ b/deployments/helm/templates/config.yaml
@@ -27,6 +27,7 @@ data:
         - 0:0:0:0:0:0:0:0/0
       destination-port-ranges:
         - 5000
+        - 4000
       source-port-ranges:
         - 1024-65535
       protocols:
@@ -40,6 +41,7 @@ data:
         - 0:0:0:0:0:0:0:0/0
       destination-port-ranges:
         - 5000
+        - 4000
       source-port-ranges:
         - 1024-65535
       protocols:

--- a/docs/demo/scripts/kind/Dockerfile
+++ b/docs/demo/scripts/kind/Dockerfile
@@ -1,17 +1,21 @@
 FROM ubuntu:21.04
 
-RUN apt-get update -y --fix-missing
-RUN apt-get install -y iproute2 tcpdump iptables net-tools iputils-ping ipvsadm netcat wget bird2 ethtool
+RUN apt-get update -y --fix-missing\
+  && apt-get install -y iproute2 tcpdump iptables net-tools iputils-ping ipvsadm netcat wget bird2 ethtool conntrack xz-utils
 
 WORKDIR /root/
 
-RUN wget https://github.com/Nordix/ctraffic/releases/download/v1.7.0/ctraffic.gz
-RUN gunzip ctraffic.gz 
-RUN chmod u+x ctraffic
-RUN mv ctraffic /usr/bin/
+ADD https://github.com/Nordix/ctraffic/releases/download/v1.7.0/ctraffic.gz ctraffic.gz
+RUN gunzip ctraffic.gz \
+  && chmod u+x ctraffic \
+  && mv ctraffic /usr/bin/
 
-RUN mkdir -p /etc/bird/
-RUN mkdir -p /run/bird
+ADD https://github.com/Nordix/mconnect/releases/download/v2.2.0/mconnect.xz mconnect.xz
+RUN unxz mconnect.xz \
+  && chmod u+x mconnect \
+  && mv mconnect /usr/bin/ \
+  && mkdir -p /etc/bird/ \
+  && mkdir -p /run/bird
 
 COPY docs/demo/scripts/kind/bird/bird-common.conf /etc/bird/
 COPY docs/demo/scripts/kind/bird/bird-gw.conf /etc/bird/

--- a/examples/target/helm/templates/target.yaml
+++ b/examples/target/helm/templates/target.yaml
@@ -27,6 +27,11 @@ spec:
               screen -d -m bash -c "./ctraffic -server -address [::]:5002" ; 
               screen -d -m bash -c "./ctraffic -server -udp -address [::]:5003" ; 
               screen -d -m bash -c "./ctraffic -server -udp -address [::]:5004" ; 
+              screen -d -m bash -c "./mconnect -server -address [::]:4000" ; 
+              screen -d -m bash -c "./mconnect -server -address [::]:4001" ; 
+              screen -d -m bash -c "./mconnect -server -address [::]:4002" ; 
+              screen -d -m bash -c "./mconnect -server -udp -address [::]:4003" ; 
+              screen -d -m bash -c "./mconnect -server -udp -address [::]:4004" ; 
               tail -f /dev/null
           command:
             - /bin/bash


### PR DESCRIPTION
## Description
[mconnect](https://github.com/Nordix/mconnect) and [ctraffic](https://github.com/Nordix/ctraffic) will now be available in the target and in the Kind GW/TG

ctraffic is listen on:
- TCP:
  - 5000
  - 5001
  - 5002
- UDP:
  - 5003
  - 5004
 
mconnect is listen on:
- TCP:
  - 4000
  - 4001
  - 4002
- UDP:
  - 4003
  - 4004
## Issue link
/

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
