### PR TITLE
Non root user

### DIFF
--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -1,4 +1,8 @@
 FROM alpine:3.15
-RUN apk update && apk add iproute2 tcpdump iputils
+RUN apk update && apk add iproute2 tcpdump iputils net-tools \
+  && setcap 'cap_sys_ptrace,cap_dac_override+ep' /sbin/ss \
+  && setcap 'cap_sys_ptrace,cap_dac_override+ep' /bin/netstat \
+  && setcap 'cap_net_raw+ep' /bin/ping \
+  && setcap 'cap_net_raw+ep' /usr/bin/tcpdump
 ADD https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.2/grpc_health_probe-linux-amd64 /bin/grpc_health_probe
 RUN chmod a+x /bin/grpc_health_probe

--- a/build/ctraffic/Dockerfile
+++ b/build/ctraffic/Dockerfile
@@ -1,3 +1,7 @@
+ARG USER=tapa-user
+ARG UID=10006
+ARG HOME=/home/${USER}
+
 FROM golang:1.18.1 as build
 
 ENV GO111MODULE=on
@@ -15,19 +19,33 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o target
 
 FROM ubuntu:21.04
 
-RUN apt-get update -y --fix-missing \
-  && apt-get install -y iproute2 tcpdump iptables net-tools iputils-ping ipvsadm netcat wget screen conntrack xz-utils
+ARG USER
+ARG UID
+ARG HOME
 
-WORKDIR /root/
+RUN apt-get update -y --fix-missing \
+  && apt-get install -y iproute2 tcpdump net-tools iputils-ping netcat wget screen xz-utils strace \
+  && setcap 'cap_sys_ptrace,cap_dac_override+ep' /usr/bin/ss \
+  && setcap 'cap_sys_ptrace,cap_dac_override+ep' /usr/bin/netstat \
+  && setcap 'cap_net_raw+ep' /usr/bin/ping \
+  && setcap 'cap_net_raw+ep' /usr/sbin/tcpdump \
+  && setcap 'cap_sys_ptrace+ep' /usr/bin/strace
+
+RUN groupadd --gid $UID $USER \
+  && useradd $USER --create-home --home-dir $HOME --no-log-init --uid $UID --gid $UID \
+  && chown -R :root "${HOME}" && chmod -R g+s=u "${HOME}"
+
+WORKDIR $HOME
 
 ADD https://github.com/Nordix/ctraffic/releases/download/v1.7.0/ctraffic.gz ctraffic.gz
 RUN gunzip ctraffic.gz \
-  && chmod u+x ctraffic
+  && chmod a+x ctraffic
 
 ADD https://github.com/Nordix/mconnect/releases/download/v2.2.0/mconnect.xz mconnect.xz
 RUN unxz mconnect.xz \
-  && chmod u+x mconnect
+  && chmod a+x mconnect
 
 COPY --from=build /app/target-client .
 
+USER ${UID}:${UID}
 CMD ./ctraffic -server -address [::]:5000

--- a/build/debug/Dockerfile
+++ b/build/debug/Dockerfile
@@ -1,2 +1,8 @@
 FROM alpine:3.15
-RUN apk update && apk add iproute2 tcpdump iputils net-tools ethtool
+RUN apk update && apk add iproute2 tcpdump iputils net-tools ethtool \
+  && setcap 'cap_sys_ptrace,cap_dac_override+ep' /sbin/ss \
+  && setcap 'cap_sys_ptrace,cap_dac_override+ep' /bin/netstat \
+  && setcap 'cap_net_raw+ep' /bin/ping \
+  && setcap 'cap_net_raw+ep' /usr/bin/tcpdump \
+  && setcap 'cap_net_admin+ep' /sbin/ip \
+  && chmod u+s /usr/sbin/ethtool

--- a/build/frontend/Dockerfile
+++ b/build/frontend/Dockerfile
@@ -1,4 +1,7 @@
 ARG base_image=registry.nordix.org/cloud-native/meridio/base:latest
+ARG USER=meridio
+ARG UID=10001
+ARG HOME=/home/${USER}
 
 FROM golang:1.18.1 as build
 
@@ -17,9 +20,21 @@ RUN go build -ldflags "-extldflags -static -X main.version=${meridio_version}" -
 
 
 FROM ${base_image}
+ARG USER
+ARG UID
+ARG HOME
 RUN apk add bird
 RUN mkdir -p /run/bird && mkdir -p /etc/bird
-
-WORKDIR /root
+RUN addgroup --gid $UID $USER \
+  && adduser $USER --home $HOME --uid $UID -G $USER --disabled-password \
+  && chown -R :root "${HOME}" && chmod -R g+s=u "${HOME}"
+WORKDIR $HOME
 COPY --from=build /app/frontend ./
+# note: File permissions of unix spire-agent-socket grant "write" access for "others",
+# thus cap_dac_override is not required by this hostPath.
+# Permissions for logging to file (bird) and interaction between bird and frontend
+# can be secured by writable volume mounts and by usage of "fsGroup".
+RUN setcap 'cap_net_admin+ep' ./frontend \
+  && setcap 'cap_net_admin,cap_net_bind_service+ep' /usr/sbin/bird
+USER ${UID}:${UID}
 CMD ["./frontend"]

--- a/build/ipam/Dockerfile
+++ b/build/ipam/Dockerfile
@@ -1,4 +1,7 @@
 ARG base_image=registry.nordix.org/cloud-native/meridio/base:latest
+ARG USER=meridio
+ARG UID=10004
+ARG HOME=/home/${USER}
 
 FROM golang:1.18.1 as build
 
@@ -17,6 +20,24 @@ COPY . .
 RUN CGO_ENABLED=1 GOOS=linux go build -ldflags "-extldflags -static -X main.version=${meridio_version}" -o ipam ./cmd/ipam
 
 FROM ${base_image}
-WORKDIR /root/
+ARG USER
+ARG UID
+ARG HOME
+RUN addgroup --gid $UID $USER \
+  && adduser $USER --home $HOME --uid $UID -G $USER --disabled-password \
+  && chown -R :root "${HOME}" && chmod -R g+s=u "${HOME}"
+WORKDIR $HOME
 COPY --from=build /app/ipam .
+# note: To run as non-root user, cap_dac_override file capability might be required in case hostPath
+# volumes are used where the mounted contents file permissions do not allow "others" the required
+# access modes (or permissions weren't adjusted by some other means).
+# For example, hostPath unix spire-agent-socket's file permissions grant "write" access for "others", thus
+# cap_dac_override is not needed by the nsp binary.
+# Similarly in development environments (e.g. Kind, xcluster) in case of Rancher's Local Path based
+# persistent storage the mounted directory's file permissions will allow 'rwx' access for "others".
+# Yet, if the persistent storage file already exists when for example upgrading from a root user
+# deployment (or simply the user id changes), access problems might arise in case of hostPath based
+# persistent storage solutions. Otherwise e.g. "fsGroup" should secure access through group ownership.
+#RUN setcap 'cap_dac_override+ep' ./ipam
+USER ${UID}:${UID}
 CMD ["./ipam"]

--- a/build/load-balancer/Dockerfile
+++ b/build/load-balancer/Dockerfile
@@ -1,4 +1,7 @@
 ARG base_image=registry.nordix.org/cloud-native/meridio/base:latest
+ARG USER=meridio
+ARG UID=10002
+ARG HOME=/home/${USER}
 
 FROM golang:1.18.1 as build
 ARG meridio_version=0.0.0-unknown
@@ -20,7 +23,18 @@ ADD https://github.com/Nordix/nfqueue-loadbalancer/releases/download/1.0.0/nfqlb
 RUN tar --strip-components=1 -xf /nfqlb-1.0.0.tar.xz nfqlb-1.0.0/bin/nfqlb
 
 FROM ${base_image}
-WORKDIR /root/
+ARG USER
+ARG UID
+ARG HOME
+RUN addgroup --gid $UID $USER \
+  && adduser $USER --home $HOME --uid $UID -G $USER --disabled-password \
+  && chown -R :root "${HOME}" && chmod -R g+s=u "${HOME}"
+WORKDIR $HOME
 COPY --from=build /app/load-balancer .
 COPY --from=lb-builder /bin/nfqlb /bin/nfqlb
+# cap_dac_override required by non-root user because of nsm-socket hostPath file permissions
+# (while file permissions of hostPath unix spire-agent-socket grant "write" access for "others")
+RUN setcap 'cap_net_admin,cap_dac_override+ep' ./load-balancer \
+  && chown root:root /bin/nfqlb && setcap 'cap_net_admin,cap_ipc_lock,cap_ipc_owner+ep' /bin/nfqlb
+USER ${UID}:${UID}
 CMD ["./load-balancer"]

--- a/build/nsp/Dockerfile
+++ b/build/nsp/Dockerfile
@@ -1,4 +1,7 @@
 ARG base_image=registry.nordix.org/cloud-native/meridio/base:latest
+ARG USER=meridio
+ARG UID=10003
+ARG HOME=/home/${USER}
 
 FROM golang:1.18.1 as build
 
@@ -17,6 +20,24 @@ COPY . .
 RUN CGO_ENABLED=1 GOOS=linux go build -ldflags "-extldflags -static -X main.version=${meridio_version}" -o nsp ./cmd/nsp
 
 FROM ${base_image}
-WORKDIR /root/
+ARG USER
+ARG UID
+ARG HOME
+RUN addgroup --gid $UID $USER \
+  && adduser $USER --home $HOME --uid $UID -G $USER --disabled-password \
+  && chown -R :root "${HOME}" && chmod -R g+s=u "${HOME}"
+WORKDIR $HOME
 COPY --from=build /app/nsp .
+# note: To run as non-root user, cap_dac_override file capability might be required in case hostPath
+# volumes are used where the mounted contents file permissions do not allow "others" the required
+# access modes (or permissions weren't adjusted by some other means).
+# For example, hostPath unix spire-agent-socket's file permissions grant "write" access for "others", thus
+# cap_dac_override is not needed by the nsp binary.
+# Similarly in development environments (e.g. Kind, xcluster) in case of Rancher's Local Path based
+# persistent storage the mounted directory's file permissions will allow 'rwx' access for "others".
+# Yet, if the persistent storage file already exists when for example upgrading from a root user
+# deployment (or simply the user id changes), access problems might arise in case of hostPath based
+# persistent storage solutions. Otherwise e.g. "fsGroup" should secure access through group ownership.
+#RUN setcap 'cap_dac_override+ep' ./nsp
+USER ${UID}:${UID}
 CMD ["./nsp"]

--- a/build/proxy/Dockerfile
+++ b/build/proxy/Dockerfile
@@ -1,4 +1,7 @@
 ARG base_image=registry.nordix.org/cloud-native/meridio/base:latest
+ARG USER=meridio
+ARG UID=10005
+ARG HOME=/home/${USER}
 
 FROM golang:1.18.1 as build
 
@@ -17,6 +20,16 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags -static -X main.version=${meridio_version}" -o proxy ./cmd/proxy
 
 FROM ${base_image}
-WORKDIR /root/
+ARG USER
+ARG UID
+ARG HOME
+RUN addgroup --gid $UID $USER \
+  && adduser $USER --home $HOME --uid $UID -G $USER --disabled-password \
+  && chown -R :root "${HOME}" && chmod -R g+s=u "${HOME}"
+WORKDIR $HOME
 COPY --from=build /app/proxy .
+# cap_dac_override required by non-root user because of nsm-socket hostPath file permissions
+# (while file permissions of hostPath unix spire-agent-socket grant "write" access for "others")
+RUN setcap 'cap_net_admin,cap_dac_override+ep' ./proxy
+USER ${UID}:${UID}
 CMD ["./proxy"]

--- a/build/tapa/Dockerfile
+++ b/build/tapa/Dockerfile
@@ -1,4 +1,7 @@
 ARG base_image=registry.nordix.org/cloud-native/meridio/base:latest
+ARG USER=tapa
+ARG UID=10005
+ARG HOME=/home/${USER}
 
 FROM golang:1.18.1 as build
 
@@ -17,6 +20,16 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags -static -X main.version=${meridio_version}" -o tapa ./cmd/tapa
 
 FROM ${base_image}
-WORKDIR /root/
+ARG USER
+ARG UID
+ARG HOME
+RUN addgroup --gid $UID $USER \
+  && adduser $USER --home $HOME --uid $UID -G $USER --disabled-password \
+  && chown -R :root "${HOME}" && chmod -R g+s=u "${HOME}"
+WORKDIR $HOME
 COPY --from=build /app/tapa .
+# cap_dac_override required by non-root user because of nsm-socket hostPath file permissions
+# (while file permissions of hostPath unix spire-agent-socket grant "write" access for "others")
+RUN setcap 'cap_dac_override+ep' ./tapa
+USER ${UID}:${UID}
 CMD ["./tapa"]

--- a/cmd/tapa/main.go
+++ b/cmd/tapa/main.go
@@ -159,6 +159,9 @@ func main() {
 	if err != nil {
 		logrus.Fatalf("error listening on unix socket: %v", err)
 	}
+	if err := os.Chmod(config.Socket, os.ModePerm); err != nil {
+		logrus.Errorf("error changing unix socket permission: %v", err)
+	}
 	s := grpc.NewServer()
 	defer s.Stop()
 

--- a/deployments/helm/templates/ipam.yaml
+++ b/deployments/helm/templates/ipam.yaml
@@ -57,7 +57,15 @@ spec:
             - name: IPAM_IP_FAMILY
               value: "{{ .Values.ipFamily }}"
           securityContext:
+            runAsNonRoot: true
             readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+              - all
+              add:
+              - DAC_OVERRIDE
+              - NET_RAW
+              - SYS_PTRACE
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets
@@ -68,6 +76,9 @@ spec:
             - name: tmp
               mountPath: /tmp
               readOnly: false
+      securityContext:
+        fsGroup: {{.Values.fsGroup }}
+        fsGroupChangePolicy: "OnRootMismatch"
       volumes:
         - name: spire-agent-socket
           hostPath:

--- a/deployments/helm/templates/load-balancer.yaml
+++ b/deployments/helm/templates/load-balancer.yaml
@@ -79,9 +79,18 @@ spec:
               mountPath: /tmp
               readOnly: false
           securityContext:
+            runAsNonRoot: true
             readOnlyRootFilesystem: true
             capabilities:
-              add: ["NET_ADMIN"]
+              drop:
+              - all
+              add:
+              - NET_ADMIN
+              - DAC_OVERRIDE
+              - IPC_LOCK
+              - IPC_OWNER
+              - NET_RAW
+              - SYS_PTRACE
         - name: nsc
           image: {{ .Values.registry }}/cloud-native/nsm/{{ .Values.vlanNSC.image }}:{{ .Values.vlanNSC.version }}
           imagePullPolicy: {{ .Values.pullPolicy }}
@@ -158,9 +167,20 @@ spec:
               mountPath: /var/log
               readOnly: false
           securityContext:
+            runAsNonRoot: true
             readOnlyRootFilesystem: true
             capabilities:
-              add: ["NET_ADMIN"]
+              drop:
+              - all
+              add:
+              - NET_ADMIN
+              - NET_BIND_SERVICE
+              - DAC_OVERRIDE
+              - NET_RAW
+              - SYS_PTRACE
+      securityContext:
+        fsGroup: {{.Values.fsGroup }}
+        fsGroupChangePolicy: "OnRootMismatch"
       volumes:
         - name: spire-agent-socket
           hostPath:

--- a/deployments/helm/templates/nsp.yaml
+++ b/deployments/helm/templates/nsp.yaml
@@ -42,7 +42,15 @@ spec:
             - name: NSP_DATASOURCE
               value: /run/nsp/data/registry.db
           securityContext:
+            runAsNonRoot: true
             readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+              - all
+              add:
+              - DAC_OVERRIDE
+              - NET_RAW
+              - SYS_PTRACE
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets
@@ -53,6 +61,9 @@ spec:
             - name: tmp
               mountPath: /tmp
               readOnly: false
+      securityContext:
+        fsGroup: {{.Values.fsGroup }}
+        fsGroupChangePolicy: "OnRootMismatch"
       volumes:
         - name: spire-agent-socket
           hostPath:

--- a/deployments/helm/templates/proxy.yaml
+++ b/deployments/helm/templates/proxy.yaml
@@ -84,9 +84,19 @@ spec:
               mountPath: /tmp
               readOnly: false
           securityContext:
+            runAsNonRoot: true
             readOnlyRootFilesystem: true
             capabilities:
-              add: ["NET_ADMIN"]
+              drop:
+              - all
+              add:
+              - NET_ADMIN
+              - DAC_OVERRIDE
+              - NET_RAW
+              - SYS_PTRACE
+      securityContext:
+        fsGroup: {{.Values.fsGroup }}
+        fsGroupChangePolicy: "OnRootMismatch"
       volumes:
         - name: spire-agent-socket
           hostPath:

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -6,6 +6,7 @@ tag: latest
 pullPolicy: IfNotPresent
 
 maxTokenLifetime: 10m
+fsGroup: 3000
 
 nsm:
   namespace: nsm

--- a/docs/load-balancer.md
+++ b/docs/load-balancer.md
@@ -59,4 +59,7 @@ Sysctl: net.ipv4.fib_multipath_hash_policy=1 |
 Sysctl: net.ipv6.fib_multipath_hash_policy=1 | 
 Sysctl: net.ipv4.conf.all.rp_filter=0 | 
 Sysctl: net.ipv4.conf.default.rp_filter=0 | 
-NET_ADMIN | 
+NET_ADMIN | The load balancer configures IP rules and IP routes to steer packets (processed by [nfqueue-loadbalancer program](https://github.com/Nordix/nfqueue-loadbalancer)) to targets. The user space load balancer program relies on [libnetfilter_queue](https://netfilter.org/projects/libnetfilter_queue).
+DAC_OVERRIDE | The load balancer requires access to a unix socket provided by a hostPath volume to interact with NSM.
+IPC_LOCK | The user space load balancer program uses shared memory.
+IPC_OWNER | The user space load balancer program uses shared memory.

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -72,3 +72,4 @@ Sysctl: net.ipv6.fib_multipath_hash_policy=1 |
 Sysctl: net.ipv4.conf.all.rp_filter=0 | 
 Sysctl: net.ipv4.conf.default.rp_filter=0 | 
 NET_ADMIN | The proxy creates IP rules, IP routes, bridge interfaces and modifies NSM interfaces to link them to bridge interfaces.
+DAC_OVERRIDE | The proxy requires access to a unix socket provided by a hostPath volume to interact with NSM.

--- a/docs/tapa.md
+++ b/docs/tapa.md
@@ -80,4 +80,6 @@ TODO
 
 ## Privileges
 
-No privileges required.
+Name | Description
+--- | ---
+DAC_OVERRIDE | The TAPA requires access to a unix socket provided by a hostPath volume to interact with NSM.

--- a/docs/user-application.md
+++ b/docs/user-application.md
@@ -26,13 +26,25 @@ Here is the minimal TAPA container specification required:
     - name: meridio-socket
       mountPath: /var/lib/meridio
       readOnly: false
+    - name: tmp
+      mountPath: /tmp
+      readOnly: false
+  securityContext:
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+      - all
+      add:
+      - DAC_OVERRIDE
 ```
 
 Additional configuration via environment variables can be found on the [TAPA Configuration](tapa.md#configuration) documentation page.
 
 ### Volumes
 
-Three Volumes must be added to the pod. Spire and NSM are required to access the socket files to communicate with the APIs. And the Meridio volume provides a socket file user container can use to communicate with the TAPA API.
+Four Volumes must be added to the pod. Spire and NSM are required to access the socket files to communicate with the APIs. And the Meridio volume provides a socket file user container can use to communicate with the TAPA API.
+If readOnlyRootFilesystem is enabled, the tmp volume provides a writable mount to create the health server socket that can be used by liveness, startup probes.
 
 ```yaml
 volumes:
@@ -46,6 +58,9 @@ volumes:
       type: DirectoryOrCreate
   - name: meridio-socket
     emptyDir: {}
+  - name: tmp
+    emptyDir:
+      medium: Memory
 ```
 
 ## Example

--- a/examples/target/helm/templates/target.yaml
+++ b/examples/target/helm/templates/target.yaml
@@ -37,7 +37,14 @@ spec:
             - /bin/bash
             - -c
           securityContext:
-            privileged: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+              - all
+              add:
+              - DAC_OVERRIDE  # required by debug tools netstat, ss
+              - NET_RAW  # required by debug tools tcpdump, ping
+              - SYS_PTRACE  # required by debug tools netstat, ss to list process names/ids, and by strace
           env:
             - name: MERIDIO_AMBASSADOR_SOCKET
               value: unix:///var/lib/meridio/ambassador.sock
@@ -55,7 +62,15 @@ spec:
           livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 12 }}
           securityContext:
+            runAsNonRoot: true
             readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+              - all
+              add:
+              - DAC_OVERRIDE  # required by tapa to access nsm-socket and by debug tools netstat, ss
+              - NET_RAW  # required by debug tools tcpdump, ping
+              - SYS_PTRACE  # required by debug tools netstat, ss to list process names/ids
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock
@@ -94,6 +109,9 @@ spec:
             - name: tmp
               mountPath: /tmp
               readOnly: false
+      securityContext:
+        fsGroup: {{.Values.fsGroup }}  # provides tapa users with access to ambassador unix socket (to be used in case of old tapa images not setting proper permissions)
+        fsGroupChangePolicy: "OnRootMismatch"
       volumes:
         - name: spire-agent-socket
           hostPath:

--- a/examples/target/helm/values.yaml
+++ b/examples/target/helm/values.yaml
@@ -8,6 +8,7 @@ pullPolicy: IfNotPresent
 applicationName: target-a
 
 configMapName: meridio-configuration
+fsGroup: 3000
 
 default:
   ambassadorSock: /var/lib/meridio/ambassador.sock


### PR DESCRIPTION
## Description

## Issue link

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [x] Yes (description required)
    Meridio images now contain a numeric user that a container will be started with by default. Use "runAsUser: 0" to keep running as root.
    - [] No
- Introduce changes in the Operator 
    - [x] Yes (description required)
    Deployment templates are modified to provide the required securityContext (runAsNonRoot and capabilities)
    - [ ] No
