### PR TITLE
lb; add nftables to image

### DIFF
--- a/build/debug/Dockerfile
+++ b/build/debug/Dockerfile
@@ -1,8 +1,9 @@
 FROM alpine:3.15
-RUN apk update && apk add iproute2 tcpdump iputils net-tools ethtool \
+RUN apk update && apk add iproute2 tcpdump iputils net-tools ethtool nftables \
   && setcap 'cap_sys_ptrace,cap_dac_override+ep' /sbin/ss \
   && setcap 'cap_sys_ptrace,cap_dac_override+ep' /bin/netstat \
   && setcap 'cap_net_raw+ep' /bin/ping \
   && setcap 'cap_net_raw+ep' /usr/bin/tcpdump \
   && setcap 'cap_net_admin+ep' /sbin/ip \
+  && setcap 'cap_net_admin+ep' /usr/sbin/nft \
   && chmod u+s /usr/sbin/ethtool

--- a/build/load-balancer/Dockerfile
+++ b/build/load-balancer/Dockerfile
@@ -26,6 +26,7 @@ FROM ${base_image}
 ARG USER
 ARG UID
 ARG HOME
+RUN apk add nftables
 RUN addgroup --gid $UID $USER \
   && adduser $USER --home $HOME --uid $UID -G $USER --disabled-password \
   && chown -R :root "${HOME}" && chmod -R g+s=u "${HOME}"
@@ -35,6 +36,7 @@ COPY --from=lb-builder /bin/nfqlb /bin/nfqlb
 # cap_dac_override required by non-root user because of nsm-socket hostPath file permissions
 # (while file permissions of hostPath unix spire-agent-socket grant "write" access for "others")
 RUN setcap 'cap_net_admin,cap_dac_override+ep' ./load-balancer \
-  && chown root:root /bin/nfqlb && setcap 'cap_net_admin,cap_ipc_lock,cap_ipc_owner+ep' /bin/nfqlb
+  && chown root:root /bin/nfqlb && setcap 'cap_net_admin,cap_ipc_lock,cap_ipc_owner+ep' /bin/nfqlb \
+  && setcap 'cap_net_admin+ep' /usr/sbin/nft
 USER ${UID}:${UID}
 CMD ["./load-balancer"]


### PR DESCRIPTION
## Description
Nftables user space tool was missing from load-balancer image.

## Issue link
NA

## Checklist

- Purpose
    - [x ] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [ x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [ x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [ x] No
