### PR TITLE
Run VLAN NSE,NSC as non-root

### DIFF
--- a/deployments/helm/templates/load-balancer.yaml
+++ b/deployments/helm/templates/load-balancer.yaml
@@ -120,6 +120,17 @@ spec:
             - name: nsm-socket
               mountPath: /var/lib/networkservicemesh
               readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: {{ .Values.vlanNSC.userId }}
+            runAsGroup: {{ .Values.vlanNSC.userId }}
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+              - all
+              add:
+              - DAC_OVERRIDE
+              - NET_RAW
         - name: fe
           image: {{ .Values.registry }}/{{ .Values.organization }}/{{ .Values.frontEnd.image }}:{{ .Values.frontEnd.version }}
           imagePullPolicy: {{ .Values.pullPolicy }}

--- a/deployments/helm/templates/nse-vlan.yaml
+++ b/deployments/helm/templates/nse-vlan.yaml
@@ -29,7 +29,13 @@ spec:
             - containerPort: 5003
               hostPort: 5003
           securityContext:
+            runAsNonRoot: true
+            runAsUser: {{ .Values.vlanNSE.userId }}
+            runAsGroup: {{ .Values.vlanNSE.userId }}
             readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+              - all
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -99,10 +99,12 @@ vlanNSE:
   probe:
     addr: :5003
     spiffe: true
+  userId: 10000
 
 vlanNSC:
   image: cmd-nsc
   version: v1.4.0
+  userId: 10000
 
 vlan:
   networkServiceName: external-vlan


### PR DESCRIPTION
## Description
VLAN NSE does not require any changes or capabilities to run as non-root.

NSC requires CAP_DAC_OVERRIDE to write to nsm-sock, and optionally CAP_NET_RAW
to use ping from the container.
The Dockerfile has been changed accordingly: https://github.com/Nordix/nsm-cmd-nsc/tree/privileges

## Issue link
https://github.com/Nordix/Meridio/issues/15

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [x] Yes (description required)
      Respective template yaml files must be updated.
    - [ ] No
