### PR TITLE
NSC DNS set to 127.0.0.1:10053

### DIFF
--- a/deployments/helm/templates/load-balancer.yaml
+++ b/deployments/helm/templates/load-balancer.yaml
@@ -113,6 +113,8 @@ spec:
               value: "TRACE"
             - name: NSM_LIVENESSCHECKENABLED
               value: "false"
+            - name: NSM_LOCALDNSSERVERADDRESS
+              value: "127.0.0.1:10053"
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets


### PR DESCRIPTION
## Description

The NSC image without DNS is also available thanks to @uablrek: registry.nordix.org/cloud-native/nsm/cmd-nsc:v1.5.0-nodns

## Issue link

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [x] Yes (description required)
    - [ ] No
