### PR TITLE
Improved TG/GW for Kind

### DIFF
--- a/docs/demo/scripts/kind/bird/bird-gw.conf
+++ b/docs/demo/scripts/kind/bird/bird-gw.conf
@@ -65,7 +65,6 @@ protocol bgp GW4 from LINK {
 	local port 10179 as 4248829953;
 	neighbor range 0.0.0.0/0 port 10179 as 8103;
 	dynamic name "GW4_";
-	interface "vlan0";
 	ipv4 {
 		import all;			# expecting VIP addresses from the nFE peer
 		export filter default_v4;	# push only default route to the nFE peer
@@ -76,7 +75,6 @@ protocol bgp GW6 from LINK {
 	local port 10179 as 4248829953;
 	neighbor range 0::/0 port 10179 as 8103;
 	dynamic name "GW6_";
-	interface "vlan0";
 	ipv6 {
 		import all;			# expecting VIP addresses from the nFE peer
 		export filter default_v6;	# push only default route to the nFE peer


### PR DESCRIPTION
## Description

* 3 VLANs per GW/TG
   * trench-a: 100, 101, 102
   * trench-b: 200, 201, 202
   * trench-c: 300, 301, 302
   * vlan0: `169.254.100.150/24`, `100:100::150/64`
   * vlan1: `169.254.101.150/24`, `100:101::150/64`
   * vlan2: `169.254.102.150/24`, `100:102::150/64`
* BGP conf to accept any interface
* New prompt

## Issue link

/

## Checklist

- Purpose
    - [ ] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [x] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
