### PR TITLE
Monitor NSP and IPAM client connection state changes

### DIFF
--- a/cmd/frontend/internal/config/config.go
+++ b/cmd/frontend/internal/config/config.go
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2022 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"github.com/nordix/meridio/cmd/frontend/internal/env"
+	"google.golang.org/grpc"
+)
+
+type Config struct {
+	*env.Config
+	NSPConn *grpc.ClientConn
+}

--- a/cmd/frontend/internal/frontend/service.go
+++ b/cmd/frontend/internal/frontend/service.go
@@ -30,32 +30,19 @@ import (
 
 	nspAPI "github.com/nordix/meridio/api/nsp/v1"
 	"github.com/nordix/meridio/cmd/frontend/internal/bird"
+	feConfig "github.com/nordix/meridio/cmd/frontend/internal/config"
 	"github.com/nordix/meridio/cmd/frontend/internal/connectivity"
-	"github.com/nordix/meridio/cmd/frontend/internal/env"
 	"github.com/nordix/meridio/cmd/frontend/internal/utils"
 	"github.com/nordix/meridio/pkg/health"
 	"github.com/nordix/meridio/pkg/retry"
-	"github.com/nordix/meridio/pkg/security/credentials"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
-	"google.golang.org/grpc"
 )
 
 // FrontEndService -
-func NewFrontEndService(c *env.Config) *FrontEndService {
+func NewFrontEndService(ctx context.Context, c *feConfig.Config) *FrontEndService {
 	logrus.Infof("NewFrontEndService")
-
-	conn, err := grpc.Dial(c.NSPService,
-		grpc.WithTransportCredentials(
-			credentials.GetClient(context.Background()),
-		),
-		grpc.WithDefaultCallOptions(
-			grpc.WaitForReady(true),
-		))
-	if err != nil {
-		logrus.Errorf("grpc.Dial err: %v", err)
-	}
-	targetRegistryClient := nspAPI.NewTargetRegistryClient(conn)
+	targetRegistryClient := nspAPI.NewTargetRegistryClient(c.NSPConn)
 
 	birdConfFile := c.BirdConfigPath + "/bird-fe-meridio.conf"
 	frontEndService := &FrontEndService{

--- a/cmd/nsp/main.go
+++ b/cmd/nsp/main.go
@@ -131,6 +131,7 @@ func main() {
 	grpc_health_v1.RegisterHealthServer(server, healthServer)
 
 	listener, err := net.Listen("tcp", fmt.Sprintf("[::]:%s", config.Port))
+	logrus.Infof("NSP Service: Start the service (port: %v)", config.Port)
 	if err != nil {
 		logrus.Fatalf("NSP Service: failed to listen: %v", err)
 	}

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -57,9 +57,7 @@ ipam:
   serviceName: ipam-service
   probe:
     readiness:
-      service: ""
-      addr: :7777
-      spiffe: true
+      service: "Readiness"
 
 nsp:
   image: nsp

--- a/pkg/health/connection/connection.go
+++ b/pkg/health/connection/connection.go
@@ -1,0 +1,82 @@
+/*
+Copyright (c) 2022 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connection
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nordix/meridio/pkg/health"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+)
+
+type gRPCConnectionStateMonitor struct {
+	healthService string
+	*grpc.ClientConn
+}
+
+// Monitor -
+// Monitors connection state changes and updates respective health service through context.
+// Currently only gRPC connection is supported, which relies on EXPERIMENTAL API.
+func Monitor(ctx context.Context, healthService string, cc interface{}) error {
+	switch cc := cc.(type) {
+	case *grpc.ClientConn:
+		m := gRPCConnectionStateMonitor{
+			healthService: healthService,
+			ClientConn:    cc,
+		}
+		go func() {
+			defer logrus.Debugf("Connection monitor exit (%s)", m.healthService)
+			for {
+				s := m.GetState()
+				health.SetServingStatus(ctx, m.healthService, s == connectivity.Ready)
+				logrus.Tracef("Connection (%s) state %s", m.healthService, s)
+
+				// Note: gRPC will NOT establish underlying transport connection except for the
+				// initial "dial" or unless the user tries to send sg and there's no backing connection.
+				// Therefore trigger transport connect if gRPC connection state is Idle for 3 seconds,
+				// to avoid the health service from getting stuck in NOT_SERVING if the user "remains silent"
+				// for too long.
+				waitCtx := ctx
+				if s == connectivity.Idle {
+					// TODO: configurable timeout
+					timeoutCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+					waitCtx = timeoutCtx
+					defer cancel()
+				}
+				// Block until connection state changes
+				if !m.WaitForStateChange(waitCtx, s) {
+					// context got timeout or canceled
+					select {
+					case <-ctx.Done():
+						// main context done
+						return
+					default:
+						// timeout; try re-connect
+						m.Connect()
+					}
+				}
+			}
+		}()
+		return nil
+	default:
+		return fmt.Errorf("unknown connection")
+	}
+}

--- a/pkg/health/const.go
+++ b/pkg/health/const.go
@@ -27,6 +27,8 @@ const (
 )
 
 const (
+	IPAMSvc              string = "IPAM"
+	IPAMCliSvc           string = "IPAMCli"
 	NSPCliSvc            string = "NSPCli"
 	EgressSvc            string = "Egress"
 	NSMEndpointSvc       string = "NSMEndpoint"
@@ -35,6 +37,7 @@ const (
 	FlowSvc              string = "Flow"
 )
 
-var LbReadinessServices []string = []string{NSPCliSvc, NSMEndpointSvc, EgressSvc, StreamSvc, FlowSvc}
-var FeReadinessServices []string = []string{NSPCliSvc, TargetRegistryCliSvc, EgressSvc}
-var ProxyReadinessServices []string = []string{NSPCliSvc, NSMEndpointSvc, EgressSvc}
+var LBReadinessServices []string = []string{NSPCliSvc, NSMEndpointSvc, EgressSvc, StreamSvc, FlowSvc}
+var FEReadinessServices []string = []string{NSPCliSvc, TargetRegistryCliSvc, EgressSvc}
+var ProxyReadinessServices []string = []string{IPAMCliSvc, NSPCliSvc, NSMEndpointSvc, EgressSvc}
+var IPAMReadinessServices []string = []string{NSPCliSvc, IPAMSvc}

--- a/pkg/ipam/server.go
+++ b/pkg/ipam/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nordix/meridio/pkg/ipam/trench"
 	"github.com/nordix/meridio/pkg/ipam/types"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -39,7 +40,7 @@ type IpamServer struct {
 // NewIpam -
 func NewServer(datastore string,
 	trenchName string,
-	nspService string,
+	nspConn *grpc.ClientConn,
 	cidrs map[ipamAPI.IPFamily]string,
 	prefixLengths map[ipamAPI.IPFamily]*types.PrefixLengths) (ipamAPI.IpamServer, error) {
 	is := &IpamServer{
@@ -62,7 +63,7 @@ func NewServer(datastore string,
 		is.Trenches[ipFamily] = newTrench
 		trenchWatchers = append(trenchWatchers, newTrench)
 	}
-	conduitWatcher, err := trench.NewConduitWatcher(context.TODO(), nspService, trenchName, trenchWatchers)
+	conduitWatcher, err := trench.NewConduitWatcher(context.TODO(), nspConn, trenchName, trenchWatchers)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ipam/trench/watcher.go
+++ b/pkg/ipam/trench/watcher.go
@@ -24,7 +24,6 @@ import (
 	nspAPI "github.com/nordix/meridio/api/nsp/v1"
 	"github.com/nordix/meridio/pkg/ipam/types"
 	"github.com/nordix/meridio/pkg/retry"
-	"github.com/nordix/meridio/pkg/security/credentials"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 )
@@ -41,17 +40,7 @@ type TrenchWatcher interface {
 	RemoveConduit(ctx context.Context, name string) error
 }
 
-func NewConduitWatcher(ctx context.Context, nspService string, trenchName string, trenchWatchers []TrenchWatcher) (*ConduitWatcher, error) {
-	nspConn, err := grpc.Dial(nspService,
-		grpc.WithTransportCredentials(
-			credentials.GetClient(context.Background()),
-		),
-		grpc.WithDefaultCallOptions(
-			grpc.WaitForReady(true),
-		))
-	if err != nil {
-		return nil, err
-	}
+func NewConduitWatcher(ctx context.Context, nspConn *grpc.ClientConn, trenchName string, trenchWatchers []TrenchWatcher) (*ConduitWatcher, error) {
 	configurationManagerClient := nspAPI.NewConfigurationManagerClient(nspConn)
 
 	cw := &ConduitWatcher{

--- a/pkg/nsm/client.go
+++ b/pkg/nsm/client.go
@@ -157,6 +157,9 @@ func (apiClient *APIClient) Delete() {
 		logrus.Infof("apiClient: Delete")
 		apiClient.cancel()
 	}
+	if apiClient.GRPCClient != nil {
+		apiClient.GRPCClient.Close()
+	}
 }
 
 // NewAPIClient -


### PR DESCRIPTION
## Description
Allow monitoring gRPC connection state changes e.g for IPAM and NSP clients, and adjust probe state respectively through context.

This might help in detecting connectivity issues affecting NSP or IPAM services.

The monitoring is lightweight meaning it works solely on the gRPC connection state maintained locally by the grpc pkg, no network traffic is involved. (Some grpc API functions marked as experimental were used, which might change in the future.)

## Issue link
#245 

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [x] Yes (description required)
      Readiness probe update for IPAM.
    - [] No
