### PR TITLE
fe; BIRD needs CAP_NET_RAW to use SO_BINDTODEVICE

### DIFF
--- a/build/frontend/Dockerfile
+++ b/build/frontend/Dockerfile
@@ -35,6 +35,6 @@ COPY --from=build /app/frontend ./
 # Permissions for logging to file (bird) and interaction between bird and frontend
 # can be secured by writable volume mounts and by usage of "fsGroup".
 RUN setcap 'cap_net_admin+ep' ./frontend \
-  && setcap 'cap_net_admin,cap_net_bind_service+ep' /usr/sbin/bird
+  && setcap 'cap_net_admin,cap_net_bind_service,cap_net_raw+ep' /usr/sbin/bird
 USER ${UID}:${UID}
 CMD ["./frontend"]

--- a/deployments/helm/templates/load-balancer.yaml
+++ b/deployments/helm/templates/load-balancer.yaml
@@ -188,8 +188,8 @@ spec:
               add:
               - NET_ADMIN
               - NET_BIND_SERVICE
-              - DAC_OVERRIDE
               - NET_RAW
+              - DAC_OVERRIDE
               - SYS_PTRACE
       securityContext:
         fsGroup: {{.Values.fsGroup }}

--- a/docs/front-end.md
+++ b/docs/front-end.md
@@ -85,3 +85,4 @@ Sysctl: net.ipv4.conf.all.rp_filter=0 |
 Sysctl: net.ipv4.conf.default.rp_filter=0 | 
 NET_ADMIN | The frontend creates IP rules to handle outbound traffic from VIP sources. BIRD interacts with kernel routing tables.
 NET_BIND_SERVICE | Allows BIRD to bind to privileged ports depending on the config (for example to BGP port 173).
+NET_RAW | Allows BIRD to use the SO_BINDTODEVICE socket option.


### PR DESCRIPTION
## Description
Capability CAP_NET_RAW applied to bird binary in frontend image.
Said capability is required by Bird to use SO_BINDTODEVICE socket option when running as non-root.

## Issue link
https://github.com/Nordix/Meridio/issues/271

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [x] Yes (description required)
      In our case the Operator already passes NET_RAW capability because of some debug tools.
    - [ ] No
