### PR TITLE
Remove hostport from the NSE-VLAN container

### DIFF
--- a/deployments/helm/templates/nse-vlan.yaml
+++ b/deployments/helm/templates/nse-vlan.yaml
@@ -27,7 +27,6 @@ spec:
 {{include "meridio.livenessProbe" (dict "component" .Values.vlanNSE "root" $) | indent 12 }}
           ports:
             - containerPort: 5003
-              hostPort: 5003
           securityContext:
             runAsNonRoot: true
             runAsUser: {{ .Values.vlanNSE.userId }}


### PR DESCRIPTION
## Description

This hostport is not needed. If we have it, it will limit the number of trench we could have in a kubernetes. The max number of trench will be equal to the number of kubernetes worker node.

## Issue link

/

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [x] Yes (description required)
    - [ ] No
