### PR TITLE
Add Security scan tools + fix CVEs

### DIFF
--- a/build/base-image/Dockerfile
+++ b/build/base-image/Dockerfile
@@ -4,5 +4,5 @@ RUN apk update && apk add iproute2 tcpdump iputils net-tools \
   && setcap 'cap_sys_ptrace,cap_dac_override+ep' /bin/netstat \
   && setcap 'cap_net_raw+ep' /bin/ping \
   && setcap 'cap_net_raw+ep' /usr/bin/tcpdump
-ADD https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.2/grpc_health_probe-linux-amd64 /bin/grpc_health_probe
+ADD https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.12/grpc_health_probe-linux-amd64 /bin/grpc_health_probe
 RUN chmod a+x /bin/grpc_health_probe


### PR DESCRIPTION
## Description

* Update grpc health probe binary in base image
* Makefile silent make command
* Add Grype, Trivy and Nancy as security scanner tool

CVEs:
CVE-2022-27191 // grpc_health_probe
CVE-2015-5237  // false-positive (protobuf) - https://github.com/anchore/grype/issues/558
CVE-2021-33194 // grpc_health_probe
CVE-2022-33082 // Will be fixed in NSM 1.6
CVE-2021-44716 // from ctraffic and mconnect + grpc_health_probe
CVE-2022-28946 // Will be fixed in NSM 1.6
CVE-2021-22570 // false-positive (protobuf) - https://github.com/anchore/grype/issues/558
CVE-2021-38561 // grpc_health_probe

New Makefile commands:
```
make grype
make trivy
make nancy
```

## Issue link

/

## Checklist

- Purpose
    - [x] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [x] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
