### PR TITLE
Fix a segv in NSMLogger.WithFields()

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -196,7 +196,9 @@ func (l *nsmLogger) Object(k, v interface{}) {
 	l.z.Info("Object", zap.Any(fmt.Sprintf("%v", k), v))
 }
 func (l *nsmLogger) WithField(key, value interface{}) nsmlog.Logger {
+	z := l.z.With(zap.Any(fmt.Sprintf("%v", key), value))
 	return &nsmLogger{
-		z: l.z.With(zap.Any(fmt.Sprintf("%v", key), value)),
+		z: z,
+		s: z.Sugar(),
 	}
 }

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -78,6 +78,7 @@ func TestNSMLogger(t *testing.T) {
 	if nsmlogger == nil {
 		return
 	}
+	nsmlogger.WithField("scope", "x").Info("Hello")
 	nsmlogger.Info("one", "two", "three")
 	nsmlogger.Infof("%v, %v, %v", "one", "two", "three")
 	nsmlogger.Object(44, "Key is an int")


### PR DESCRIPTION
## Description

When testing https://github.com/networkservicemesh/sdk/pull/1348 with the `NSMLogger` an un-initiated Sugar logger (the `s` field) caused a segv. This PR initiates the field and adds a unit-test that would segv without it.

## Issue link

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [x] Unit test
    - [ ] E2E Test
    - [ ] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
