### PR TITLE
deployment; remote vlan nse does not need to communicate with NSMgr

### DIFF
--- a/deployments/helm/templates/nse-vlan.yaml
+++ b/deployments/helm/templates/nse-vlan.yaml
@@ -62,9 +62,6 @@ spec:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets
               readOnly: true
-            - name: nsm-socket
-              mountPath: /var/lib/networkservicemesh
-              readOnly: false
           resources:
             requests:
               cpu: 200m
@@ -76,7 +73,3 @@ spec:
           hostPath:
             path: /run/spire/sockets
             type: Directory
-        - name: nsm-socket
-          hostPath:
-            path: /var/lib/networkservicemesh
-            type: DirectoryOrCreate


### PR DESCRIPTION
## Description
Remove nsm-sock hostPath volume from Remote VLAN NSE. It does not need to contact NSMgr, instead
communicates with NSM registry.

## Issue link
NA

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [x] Yes (description required)
      Respective template must be updated to remove the hostPath.
    - [ ] No
