### PR TITLE
Structured logging; logs to stdout

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -127,6 +127,7 @@ func newLogger(level string) logr.Logger {
 	zc.EncoderConfig.EncodeTime = timeEncoder
 	zc.EncoderConfig.EncodeLevel = levelEncoder
 	zc.Encoding = "json"
+	zc.OutputPaths = []string{"stdout"}
 	z, err := zc.Build()
 	if err != nil {
 		panic(fmt.Sprintf("Can't create a zap logger (%v)?", err))


### PR DESCRIPTION
## Description
The logs were directed to stderr, but should go to stdout.

Test with `go test` redirects stderr to stdout which is a lesson to learn for future testing.

## Issue link
#253

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [ ] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [ ] No
