### PR TITLE
Upgrade to nfqlb-1.1.3

### DIFF
--- a/build/stateless-lb/Dockerfile
+++ b/build/stateless-lb/Dockerfile
@@ -19,8 +19,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags -static -X main.vers
 
 FROM ${base_image} as lb-builder
 WORKDIR /
-ADD https://github.com/Nordix/nfqueue-loadbalancer/releases/download/1.1.2/nfqlb-1.1.2.tar.xz /
-RUN tar --strip-components=1 -xf /nfqlb-1.1.2.tar.xz nfqlb-1.1.2/bin/nfqlb
+ADD https://github.com/Nordix/nfqueue-loadbalancer/releases/download/1.1.3/nfqlb-1.1.3.tar.xz /
+RUN tar --strip-components=1 -xf /nfqlb-1.1.3.tar.xz nfqlb-1.1.3/bin/nfqlb
 
 FROM ${base_image}
 ARG USER


### PR DESCRIPTION
## Description

The fix for ref-counters in nfqlb-1.1.2 was too simplistic and causes a short break when the flow doesn't exist on update, because of the delete/re-create approach.

nfqlb-1.1.3 also includes a fix for a similar problem when the flow "target" (which is the load-balancer/stream in Meridio).

## Issue link

https://github.com/Nordix/nfqueue-loadbalancer/issues/12

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [ ] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [ ] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
