### PR TITLE
Fix ginkgo and kind binary path in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ lint: golangci-lint ## Run linter against code.
 
 .PHONY: e2e
 e2e: ginkgo ## Run the E2E tests.
-	ginkgo -v --focus=$(E2E_FOCUS) --seed=$(E2E_SEED) --repeat=0 --timeout=1h ./test/e2e/... -- $(E2E_PARAMETERS)
+	$(GINKGO) -v --focus=$(E2E_FOCUS) --seed=$(E2E_SEED) --repeat=0 --timeout=1h ./test/e2e/... -- $(E2E_PARAMETERS)
 
 .PHONY: test
 test: ## Run the Unit tests.

--- a/docs/demo/scripts/kind/Makefile
+++ b/docs/demo/scripts/kind/Makefile
@@ -107,7 +107,7 @@ kind-config: ## Print the Kind cluster config
 .PHONY: kind-create
 kind-create: temp-dir kind kind-delete ## Create the Kind cluster
 	$(MAKE) -s kind-config > $(TEMP_DIR)/kind-config.yaml ; \
-	kind create cluster --config $(TEMP_DIR)/kind-config.yaml ; \
+	$(KIND) create cluster --config $(TEMP_DIR)/kind-config.yaml ; \
 	rm $(TEMP_DIR)/kind-config.yaml
 
 .PHONY: kind-gateways
@@ -125,7 +125,7 @@ kind-delete-gateways: ## Delete the Kind gateways
 
 .PHONY: kind-delete
 kind-delete-cluster: ## Delete the Kind cluster
-	kind delete cluster
+	$(KIND) delete cluster
 
 .PHONY: clean
 clean: kind-delete-cluster kind-delete-gateways ## Delete the Kind cluster and the Kind gateways


### PR DESCRIPTION
## Description

Fix ginkgo and kind binary path in Makefiles
https://jenkins.nordix.org/blue/organizations/jenkins/meridio-e2e-test-kind/activity

## Issue link

/

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [x] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
