### PR TITLE
Add missing kind-delete-cluster pre-target

### DIFF
--- a/docs/demo/scripts/kind/Makefile
+++ b/docs/demo/scripts/kind/Makefile
@@ -124,7 +124,7 @@ kind-delete-gateways: ## Delete the Kind gateways
 	docker rm trench-c
 
 .PHONY: kind-delete
-kind-delete-cluster: ## Delete the Kind cluster
+kind-delete-cluster: kind ## Delete the Kind cluster
 	$(KIND) delete cluster
 
 .PHONY: clean


### PR DESCRIPTION
## Description

Add missing kind-delete-cluster pre-target

## Issue link

/

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [x] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
