### PR TITLE
Add E2E tests badges

### DIFF
--- a/docs/test.md
+++ b/docs/test.md
@@ -2,6 +2,18 @@
 
 ## E2E Tests
 
+[![meridio-e2e-kind-meridio](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild/badge/icon?config=meridio-e2e-kind-meridio)](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild)
+
+[![meridio-e2e-kind-tapa](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild/badge/icon?config=meridio-e2e-kind-tapa)](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild)
+
+[![meridio-e2e-kind-nsm](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild/badge/icon?config=meridio-e2e-kind-nsm)](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild)
+
+[![meridio-e2e-kind-ip-family](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild/badge/icon?config=meridio-e2e-kind-ip-family)](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild)
+
+[![meridio-e2e-kind-kubernetes](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild/badge/icon?config=meridio-e2e-kind-kubernetes)](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild)
+
+(These reports are for the last 1000 test runs only)
+
 ### Environment / Framework
 
 #### Initial Deployment


### PR DESCRIPTION
## Description

The tests are now running in the CI:
https://jenkins.nordix.org/blue/organizations/jenkins/meridio-e2e-test-kind/activity/
This PR adds the badges in the documentation reporting the 1000 latest e2e test runs. 

[![meridio-e2e-kind-meridio](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild/badge/icon?config=meridio-e2e-kind-meridio)](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild)

[![meridio-e2e-kind-tapa](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild/badge/icon?config=meridio-e2e-kind-tapa)](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild)

[![meridio-e2e-kind-nsm](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild/badge/icon?config=meridio-e2e-kind-nsm)](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild)

[![meridio-e2e-kind-ip-family](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild/badge/icon?config=meridio-e2e-kind-ip-family)](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild)

[![meridio-e2e-kind-kubernetes](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild/badge/icon?config=meridio-e2e-kind-kubernetes)](https://jenkins.nordix.org/job/meridio-e2e-test-kind/lastCompletedBuild)

## Issue link

## Checklist

- Purpose
    - [ ] Bug fix
    - [ ] New functionality
    - [x] Documentation
    - [ ] Refactoring
    - [x] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [ ] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
