### PR TITLE
CI: New Makefile for kind-helm e2e environment

### DIFF
--- a/test/e2e/environment/kind-helm/Makefile
+++ b/test/e2e/environment/kind-helm/Makefile
@@ -1,0 +1,55 @@
+
+.PHONY: default
+default:
+	$(MAKE) -s -C $(shell pwd) $(STEPS)
+
+.PHONY: all
+all: default
+
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+############################################################################
+# Variables
+############################################################################
+
+STEPS ?= environment meridio wait wait-meridio
+
+MERIDIO_VERSION ?= "latest"
+TAPA_VERSION ?= "latest"
+NSM_VERSION ?= "v1.6.0"
+KUBERNETES_VERSION ?= "v1.25"
+IP_FAMILY ?= "dualstack"
+
+KUBERNETES_WORKERS ?= 2
+
+WAIT_TIME ?= 10
+
+BASE_PATH ?= $(shell pwd)/../../../..
+
+#############################################################################
+##@ Environment
+#############################################################################
+
+.PHONY: environment
+environment: ## Deploy the enviroment (Kind + Gateways + NSM + Spire)
+	$(MAKE) -s -C $(BASE_PATH)/docs/demo/scripts/kind/ KUBERNETES_VERSION=$(KUBERNETES_VERSION) NSM_VERSION=$(NSM_VERSION) KUBERNETES_IP_FAMILY=$(IP_FAMILY) KUBERNETES_WORKERS=$(KUBERNETES_WORKERS)
+
+.PHONY: meridio
+meridio: ## Deploy Meridio (trench-a + trench-b + target-a + target-b)
+	helm install trench-a $(BASE_PATH)/deployments/helm/ --create-namespace --namespace red --set trench.name=trench-a --set ipFamily=$(IP_FAMILY) ; \
+	helm install trench-b $(BASE_PATH)/deployments/helm/ --create-namespace --namespace red --set trench.name=trench-b --set vlan.id=200 --set ipFamily=$(IP_FAMILY) ; \
+	helm install target-a $(BASE_PATH)/examples/target/deployments/helm/ --create-namespace --namespace red --set applicationName=target-a --set default.trench.name=trench-a ; \
+	helm install target-b $(BASE_PATH)/examples/target/deployments/helm/ --create-namespace --namespace red --set applicationName=target-b --set default.trench.name=trench-b
+
+.PHONY: wait-meridio
+wait-meridio:
+	kubectl wait --for=condition=Ready pods --all -n red --timeout=5m
+
+#############################################################################
+# Tools
+#############################################################################
+
+.PHONY: wait
+wait:
+	sleep $(WAIT_TIME)

--- a/test/e2e/environment/kind-helm/test-scope.yaml
+++ b/test/e2e/environment/kind-helm/test-scope.yaml
@@ -3,6 +3,7 @@ Meridio:
 TAPA:
 - latest
 NSM:
+- v1.5.0
 - v1.6.0
 - v1.6.1
 Kubernetes:
@@ -13,5 +14,3 @@ Kubernetes:
 - v1.21
 IP-Family:
 - dualstack
-- ipv4
-- ipv6


### PR DESCRIPTION
## Description

This Makefile deploys the Meridio environment needed to run the e2e tests using kind and Helm. The CI will now have the environment (kind-helm) as parameter, so it will be possible to run any other environment (like the kind + operator).

Enables NSM 1.5.0 and disable ipv4/ipv6 e2e tests.

## Issue link

https://gerrit.nordix.org/c/infra/cicd/+/15875

## Checklist

- Purpose
    - [ ] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [x] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
