### PR TITLE
Add a Meridio adapted initContainer image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help: ## Display this help.
 # Variables
 ############################################################################
 
-IMAGES ?= base-image stateless-lb proxy tapa ipam nsp example-target frontend operator
+IMAGES ?= base-image stateless-lb proxy tapa ipam nsp example-target frontend operator init
 
 # Versions
 VERSION ?= latest
@@ -27,6 +27,7 @@ VERSION_FRONTEND ?= $(VERSION)
 VERSION_BASE_IMAGE ?= $(VERSION)
 VERSION_OPERATOR ?= $(VERSION)
 LOCAL_VERSION ?= $(VERSION)
+VERSION_INIT ?= $(VERSION)
 
 # E2E tests
 E2E_FOCUS ?= ""
@@ -124,6 +125,10 @@ frontend: ## Build the frontend.
 operator: ## Build the operator.
 	VERSION=$(VERSION_OPERATOR) IMAGE=operator $(MAKE) -s $(BUILD_STEPS)
 
+.PHONY: init
+init: ## Build the init image.
+	VERSION=$(VERSION_INIT) IMAGE=init $(MAKE) -s $(BUILD_STEPS)
+
 #############################################################################
 ##@ Testing & Code check
 #############################################################################
@@ -186,7 +191,7 @@ trivy-scan: output-dir
 .PHONY: nancy
 nancy: nancy-tool output-dir ## Run nancy scanner on dependencies.
 	go list -json -deps ./... | nancy sleuth -o json-pretty > $(OUTPUT_DIR)/nancy.json || true
-	
+
 #############################################################################
 ##@ Code generation
 #############################################################################
@@ -245,7 +250,7 @@ namespace: # Edit the namespace of operator to be deployed
 print-manifests: manifests kustomize namespace set-templates-values # Generate manifests to be deployed in the cluster
 	cd config/operator && $(KUSTOMIZE) edit set image operator=${REGISTRY}/operator:${VERSION_OPERATOR}
 	$(KUSTOMIZE) build config/default --enable-helm
-	
+
 #############################################################################
 # Tools
 #############################################################################

--- a/build/init/Dockerfile
+++ b/build/init/Dockerfile
@@ -1,0 +1,4 @@
+FROM registry.nordix.org/cloud-native/meridio/base:latest
+WORKDIR /root
+COPY hack/meridio-init.sh .
+CMD ["/root/meridio-init.sh"]

--- a/deployments/helm/templates/load-balancer.yaml
+++ b/deployments/helm/templates/load-balancer.yaml
@@ -28,7 +28,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       initContainers:
         - name: sysctl-init
-          image: {{ .Values.registry }}/{{ .Values.organization }}/busybox:1.29
+          image: {{ .Values.registry }}/{{ .Values.organization }}/{{.Values.init.image}}:{{.Values.init.version}}
           securityContext:
             privileged: true
           volumeMounts:

--- a/deployments/helm/templates/proxy.yaml
+++ b/deployments/helm/templates/proxy.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
         - name: sysctl-init
-          image: {{ .Values.registry }}/{{ .Values.organization }}/busybox:1.29
+          image: {{ .Values.registry }}/{{ .Values.organization }}/{{.Values.init.image}}:{{.Values.init.version}}
           securityContext:
             privileged: true
           command: ["/bin/sh"]

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -22,6 +22,10 @@ attractor:
 configuration:
   configmap: meridio-configuration
 
+init:
+  image: init
+  version: latest
+
 loadBalancer:
   image: stateless-lb
   version: latest

--- a/hack/meridio-init.sh
+++ b/hack/meridio-init.sh
@@ -1,0 +1,206 @@
+#! /bin/sh
+##
+## meridio-init.sh --
+##
+##   This script should run in an initContainer and prepare for
+##   various Meridio PODs.
+##
+##   Tunnel handling copied from;
+##   https://github.com/Nordix/k8s-service-tunnel
+##
+##   Config:
+##
+##   Parameter:   Environment var:  Description:
+##   --dev=       TUNNEL_DEV        Tunnel device name (vxlan0)
+##   --master=    TUNNEL_MASTER     Tunnel master device (eth0)
+##   --peer=      TUNNEL_PEER       Ip address of the remote side
+##   --id=        TUNNEL_ID         VNI for vxlan (333)
+##   --dport=     TUNNEL_DPORT      Port for the remote side (5533)
+##   --sport=     TUNNEL_SPORT      Port for the local side (5533)
+##   --ipv4=      TUNNEL_IPV4       IPv4 on the tunnel device, e.g. 10.30.30.1/24
+##   --ipv6=      TUNNEL_IPV6       IPv6 on the tunnel device, e.g. fd00:1::1/64
+##   --ipv4-only  __ipv4_only       Only set sysctls for ipv4
+##   --ipv6-only  __ipv6_only       Only set sysctls for ipv6
+##
+## Commands;
+##
+
+prg=$(basename $0)
+dir=$(dirname $0); dir=$(readlink -f $dir)
+tmp=/tmp/${prg}_$$
+
+die() {
+    echo "ERROR: $*" >&2
+    rm -rf $tmp
+    exit 1
+}
+cmd_help() {
+    grep '^##' $0 | cut -c3-
+    rm -rf $tmp
+    exit 0
+}
+
+log() {
+	echo "$prg: $*" >&2
+}
+
+# initvar <variable> [default]
+#   Initiate a variable. The __<variable> will be defined if not set,
+#   from $TUNNEL_<variable-upper-case> or from the passed default
+initvar() {
+	local n N v
+	n=$1
+	v=$(eval "echo \$__$n")
+	test -n "$v" && return 0	# Already set
+	N=$(echo $n | tr a-z A-Z)
+	v=$(eval "echo \$TUNNEL_$N")
+	if test -n "$v"; then
+		eval "__$n=$v"
+		return 0
+	fi
+	test -n "$2" && eval "__$n=$2"
+	return 0
+}
+
+##   env
+##     Print environment.
+cmd_env() {
+	test "$envset" = "yes" && return 0
+	params="type|dev|master|peer|id|dport|sport|ipv4|ipv6|ipv6_only|ipv4_only"
+	initvar dev vxlan0
+	initvar master eth0
+	initvar peer
+	initvar id 333
+	initvar dport 5533
+	initvar sport 5533
+	initvar ipv4
+	initvar ipv6
+	if test "$cmd" = "env"; then
+		set | grep -E "^__($params).*=" | sort
+		return 0
+	fi
+	envset=yes
+}
+##   hold
+##     Don't return
+cmd_hold() {
+	log "Block return"
+	tail -f /dev/null
+}
+##   wait_for_udp --peer=ip-address [--sport=]
+##     Wait for an UDP packet. This MUST be done *before* setting up
+##     the tunnel if the peer is connected through a K8s service. It
+##     indicates that an UDP "connection" has been setup. If the
+##     tunnel setup without a UDP connection messages will be sent to
+##     the peer with the node IP as source (the normal ipv4 egress
+##     setup in K8s). This will fail and worse, it will mess up the
+##     conntracker so later connect attempts via the service will
+##     fail!
+cmd_wait_for_udp() {
+	cmd_env
+	log "Waiting for UDP packet from $__peer, port $__sport"
+	test -n "$__peer" || die "No peer address"
+	tcpdump -ni eth0 --immediate-mode -c 1 udp and host $__peer and port $__sport
+}
+##   vxlan --peer=ip-address [--master] [--dev=] [--id=vni] \
+##       [--dport=] [--sport=]
+##     Setup a vxlan tunnel. In a POD this should be preceded by a
+##     "wait_for_udp".
+cmd_vxlan() {
+	cmd_env
+	log "Setup a VXLAN tunnel to [$__peer]"
+	test -n "$__peer" || die "No peer address"
+	local sport1=$((__sport + 1))
+	if test -n "$__master"; then
+		ip link add $__dev type vxlan id $__id dev $__master remote $__peer \
+			dstport $__dport srcport $__sport $sport1
+	else
+		ip link add $__dev type vxlan id $__id remote $__peer \
+			dstport $__dport srcport $__sport $sport1
+	fi
+}
+##   lb
+##     Setup for Meridio stateless-lb. If $TUNNEL_PEER is specified
+##     a tunnel is setup.
+cmd_lb() {
+	log "Setup for Meridio stateless-lb"
+	if test "$__ipv6_only" != "yes"; then
+		sysctl -w net.ipv4.conf.all.forwarding=1
+		sysctl -w net.ipv4.fib_multipath_hash_policy=1
+		sysctl -w net.ipv4.conf.all.rp_filter=0
+		sysctl -w net.ipv4.conf.default.rp_filter=0
+	fi
+	if test "$__ipv4_only" != "yes"; then
+		sysctl -w net.ipv6.fib_multipath_hash_policy=1
+		sysctl -w net.ipv6.conf.all.forwarding=1
+	fi
+	cmd_env
+	test -n "$__peer" || return 0
+
+	cmd_wait_for_udp || log "FAILED: wait_for_udp"
+	cmd_vxlan
+	ip link set up dev $__dev
+	test -n "$__ipv4" && ip addr add $__ipv4 dev $__dev
+	test -n "$__ipv6" && ip -6 addr add $__ipv6 dev $__dev	
+	return 0
+}
+##   proxy
+##     Setup for Meridio proxy
+cmd_proxy() {
+	log "Setup for Meridio proxy"
+	if test "$__ipv6_only" != "yes"; then
+		sysctl -w net.ipv4.conf.all.forwarding=1
+		sysctl -w net.ipv4.fib_multipath_hash_policy=1
+		sysctl -w net.ipv4.conf.all.rp_filter=0
+		sysctl -w net.ipv4.conf.default.rp_filter=0
+	fi
+	if test "$__ipv4_only" != "yes"; then
+		sysctl -w net.ipv6.conf.all.forwarding=1
+		sysctl -w net.ipv6.conf.all.accept_dad=0
+		sysctl -w net.ipv6.fib_multipath_hash_policy=1
+	fi
+}
+##   tapa
+##     Setup for Meridio TAPA
+cmd_tapa() {
+	log "Setup for Meridio tapa"
+	sysctl -w net.ipv4.conf.all.arp_announce=2
+}
+
+
+##
+if test -n "$1"; then
+	cmd=$1
+	shift
+else
+	cmd=$INIT_FUNCTION
+fi
+test -n "$cmd" || die 'No command. Try "help"'
+
+# Get the command
+grep -q "^cmd_$cmd()" $0 $hook || die "Invalid command [$cmd]"
+
+while echo "$1" | grep -q '^--'; do
+    if echo $1 | grep -q =; then
+	o=$(echo "$1" | cut -d= -f1 | sed -e 's,-,_,g')
+	v=$(echo "$1" | cut -d= -f2-)
+	eval "$o=\"$v\""
+    else
+	o=$(echo "$1" | sed -e 's,-,_,g')
+	eval "$o=yes"
+    fi
+    shift
+done
+unset o v
+long_opts=`set | grep '^__' | cut -d= -f1`
+
+# Execute command
+trap "die Interrupted" INT TERM
+cmd_$cmd "$@"
+status=$?
+rm -rf $tmp
+
+if test $status -eq 0; then
+   test "$INIT_EXIT" = "NO" && cmd_hold
+fi
+exit $status


### PR DESCRIPTION
## Description

An initContainer is used to set sysctl's in the load-balancer and proxy PODs. It is currently a BusyBox image, not related to any other Meridio image. This PR adds an init image based on the Meridio base image (same as all other Meridio images).

The initContainer will get more responsibilities in the future, e.g. to setup a tunnel device in test environments that have no secondary networks, like public-cloud and "standard" test clusters. Therefore a `meridio-init.sh` is included for now, but more advanced programs can be added if necessary.

The first commit in this PR only builds and uses the new init image. The start commands (a bunch of sysctl -w) is not altered. However the `meridio-init.sh` is prepared to handle start without parameters.

```yaml
      initContainers:
        - name: init
          image: registry.nordix.org/cloud-native/meridio/init:latest
          securityContext:
            privileged: true
```
In such case the script setup depending on `hostname`.
```sh
if test -n "$1"; then
	cmd=$1
	shift
else
	cmd=$INIT_FUNCTION
fi
if ! test -n "$cmd"; then
	# Make a guess from the hostname
	if hostname | grep -qE 'load-balance|stateless-lb'; then
		cmd=lb
	elif hostname | grep -q 'proxy'; then
		cmd=proxy
	fi
fi
```
It is however better to explicitly specify the function in an environment variable.
```yaml
      initContainers:
        - name: init
          image: registry.nordix.org/cloud-native/meridio/init:latest
          env:
            - name: INIT_FUNCTION
              value: "proxy"
          securityContext:
            privileged: true
```

### Tunnel setup

As mentioned above the first use of the init image is to setup a tunnel (vxlan) to the load-balancer (instead of a real external interface). The configuration may look something like:
```yaml
      initContainers:
        - name: init
          image: registry.nordix.org/cloud-native/meridio/init:latest
          env:
            - name: INIT_FUNCTION
              value: "lb"
             - name: TUNNEL_PARAMS
              value: "10.244.2.10,100"
         securityContext:
            privileged: true
```
The params are the the POD address of the local test-generator (TG) and the vxlan id. The id will be handled in the same way as the vlan-tag for test compatibility reasons. So in this example the tunnel device will be called `ext-vlan.100`, same as for vlan setup.


## Issue link

N/A

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [x] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [x] Yes (description required)
    - [ ] No
