### PR TITLE
Fix validation of BGP auth related CRD parameters

### DIFF
--- a/api/v1alpha1/gateway_types.go
+++ b/api/v1alpha1/gateway_types.go
@@ -117,7 +117,7 @@ type BfdSpec struct {
 // BgpAuth defines the parameters to configure BGP authentication
 type BgpAuth struct {
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9\.-_]+`
+	// +kubebuilder:validation:Pattern=`^[-._a-zA-Z0-9]+$`
 
 	// Name of the BGP authentication key, used internally as a reference.
 	// KeyName is a key in the data section of a Secret. The associated value in
@@ -126,11 +126,13 @@ type BgpAuth struct {
 	KeyName string `json:"key-name,omitempty"`
 
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9](?:[A-Za-z0-9-\.]{0,61}?[A-Za-z0-9])?$`
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	// +kubebuilder:validation:MaxLength=253
 
 	// Name of the kubernetes Secret containing the password (pre-shared key)
 	// that can be looked up based on KeyName.
-	// Must be a valid  DNS subdomain name.
+	// Must be a valid lowercase RFC 1123 subdomain. (Must consist of lower case alphanumeric
+	// characters, '-' or '.', and must start and end with an alphanumeric character.)
 	KeySource string `json:"key-source,omitempty"`
 }
 

--- a/config/crd/bases/meridio.nordix.org_gateways.yaml
+++ b/config/crd/bases/meridio.nordix.org_gateways.yaml
@@ -65,13 +65,16 @@ spec:
                           a Secret. The associated value in the Secret is the password
                           (pre-shared key) to be used for authentication. Must consist
                           of alphanumeric characters, ".", "-" or "_".
-                        pattern: ^[A-Za-z0-9\.-_]+
+                        pattern: ^[-._a-zA-Z0-9]+$
                         type: string
                       key-source:
                         description: Name of the kubernetes Secret containing the
                           password (pre-shared key) that can be looked up based on
-                          KeyName. Must be a valid  DNS subdomain name.
-                        pattern: ^[A-Za-z0-9](?:[A-Za-z0-9-\.]{0,61}?[A-Za-z0-9])?$
+                          KeyName. Must be a valid lowercase RFC 1123 subdomain. (Must
+                          consist of lower case alphanumeric characters, '-' or '.',
+                          and must start and end with an alphanumeric character.)
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
                     type: object
                   bfd:


### PR DESCRIPTION
## Description
Name of the kubernetes Secret containing the password must be a valid lowercase RFC 1123 subdomain.

`a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`

## Issue link
https://github.com/Nordix/Meridio/issues/329

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [x] Yes (description required)
    Gateway CRD validation.
    - [ ] No
