### PR TITLE
Clean target IP from Neighbor table on add

### DIFF
--- a/test/e2e/utils/trafficgenerator.go
+++ b/test/e2e/utils/trafficgenerator.go
@@ -92,7 +92,7 @@ type MConnect struct {
 }
 
 func (mc *MConnect) GetCommand(ipPort string, protocol string) string {
-	return fmt.Sprintf("mconnect %s -address %s -nconn %d -timeout 5m -output json", getProtocolParameter(protocol), ipPort, mc.NConn)
+	return fmt.Sprintf("mconnect %s -address %s -nconn %d -timeout 2m -output json", getProtocolParameter(protocol), ipPort, mc.NConn)
 }
 
 func (mc *MConnect) AnalyzeTraffic(output []byte) (map[string]int, int, error) {


### PR DESCRIPTION
## Description

If a target is disconnecting and connecting again to a conduit on a short period, the IP(s) allocated to the target might be the same, but the MAC address will be different. The LBs will still have the old IP(s)-MAC address association in the neighbor table, it then has to be cleaned, traffic towards that target will be lost until the time for the cache to be automatically removed.

This fix solves most of the failing e2e caused by: https://github.com/Nordix/Meridio/issues/234
Based on the latest 130 runs, we have now 13% of failing runs (30% without the fix).

1. Currently the neighbor entry for a target is cleaned no matter if the target is already configured for another stream or not. This means some traffic can go through stream-a (target-1 has opened it), and a target-1 opens stream-b, then target-1 will still get its neighbor entry in the LBs. Will it impact traffic on stream-a? Do we have to fix it?

## Issue link

https://github.com/Nordix/Meridio/issues/316
https://github.com/Nordix/Meridio/issues/234

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [x] E2E Test
    - [ ] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
