### PR TITLE
e2e kind env set the NSM version

### DIFF
--- a/docs/demo/scripts/kind/Makefile
+++ b/docs/demo/scripts/kind/Makefile
@@ -154,7 +154,7 @@ wait-spire: ## Wait for spire to be ready
 
 .PHONY: install-nsm
 install-nsm: ## Install nsm
-	helm install nsm ../../deployments/nsm --create-namespace --namespace nsm
+	helm install nsm ../../deployments/nsm --create-namespace --namespace nsm --set tag=$(NSM_VERSION)
 
 .PHONY: wait-nsm
 wait-nsm: ## Wait for NSM to be ready


### PR DESCRIPTION
## Description

The NSM version was not used in the kind environment makefile.

## Issue link

https://github.com/Nordix/Meridio/issues/318

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [x] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
