### PR TITLE
Fix TAPA concurrency issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,13 +150,8 @@ e2e: ginkgo output-dir ## Run the E2E tests.
 	./test/e2e/... -- $(E2E_PARAMETERS)
 
 .PHONY: test
-test: ## Run the Unit tests.
-	go test -race -cover -short -count=1 ./... 
-
-.PHONY: cover
-cover: 
-	go test -race -coverprofile cover.out -short ./... 
-	go tool cover -html=cover.out -o cover.html
+test: output-dir ## Run the Unit tests (read coverage report: go tool cover -html=_output/cover_unit_test.out -o _output/cover_unit_test.html).
+	go test -race -cover -short -count=1 -coverprofile $(OUTPUT_DIR)/cover_unit_test.out ./... 
 
 .PHONY: check
 check: lint test ## Run the linter and the Unit tests.

--- a/pkg/ambassador/tap/conduit/conduit_test.go
+++ b/pkg/ambassador/tap/conduit/conduit_test.go
@@ -228,7 +228,7 @@ func Test_SetVIPs_Not_Connected(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, cndt)
 
-	err = cndt.SetVIPs([]string{})
+	err = cndt.SetVIPs(context.Background(), []string{})
 	assert.Nil(t, err)
 }
 
@@ -332,7 +332,7 @@ func Test_SetVIPs(t *testing.T) {
 	assert.Equal(t, srcIpAddrs, cndt.GetIPs())
 
 	// 5.
-	err = cndt.SetVIPs(vips)
+	err = cndt.SetVIPs(context.Background(), vips)
 	assert.Nil(t, err)
 
 	// 7.
@@ -431,7 +431,7 @@ func Test_LocalIPs_Switch(t *testing.T) {
 	assert.Equal(t, srcIpAddrs, cndt.GetIPs())
 
 	// 5.
-	err = cndt.SetVIPs(vips)
+	err = cndt.SetVIPs(context.Background(), vips)
 	assert.Nil(t, err)
 
 	// 7.

--- a/pkg/ambassador/tap/trench/trench.go
+++ b/pkg/ambassador/tap/trench/trench.go
@@ -157,7 +157,7 @@ func (t *Trench) AddConduit(ctx context.Context, cndt *ambassadorAPI.Conduit) (t
 	if err != nil {
 		return nil, err
 	}
-	cc := newConduitConnect(c)
+	cc := newConduitConnect(c, t.ConfigurationManagerClient)
 	go cc.connect()
 	t.conduits = append(t.conduits, cc)
 	return c, nil

--- a/pkg/ambassador/tap/types/conduit.go
+++ b/pkg/ambassador/tap/types/conduit.go
@@ -46,4 +46,5 @@ type Conduit interface {
 	GetStreams() []*ambassadorAPI.Stream
 	Equals(*ambassadorAPI.Conduit) bool
 	GetConduit() *ambassadorAPI.Conduit
+	SetVIPs(context.Context, []string) error
 }

--- a/pkg/ambassador/tap/types/mocks/conduit.go
+++ b/pkg/ambassador/tap/types/mocks/conduit.go
@@ -132,3 +132,17 @@ func (mr *MockConduitMockRecorder) RemoveStream(arg0, arg1 interface{}) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveStream", reflect.TypeOf((*MockConduit)(nil).RemoveStream), arg0, arg1)
 }
+
+// SetVIPs mocks base method.
+func (m *MockConduit) SetVIPs(arg0 context.Context, arg1 []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetVIPs", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetVIPs indicates an expected call of SetVIPs.
+func (mr *MockConduitMockRecorder) SetVIPs(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVIPs", reflect.TypeOf((*MockConduit)(nil).SetVIPs), arg0, arg1)
+}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -1,3 +1,19 @@
+/*
+Copyright (c) 2021-2023 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package utils
 
 import (

--- a/test/utils/waitgroup.go
+++ b/test/utils/waitgroup.go
@@ -1,0 +1,40 @@
+/*
+Copyright (c) 2023 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+const TestTimeout = 1 * time.Second
+
+func WaitTimeout(wg *sync.WaitGroup, timeout time.Duration) error {
+	c := make(chan struct{}, 1)
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	select {
+	case <-c:
+		break
+	case <-time.After(timeout):
+		return errors.New("timed out waiting")
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

- TAPA: Stream retry delay configurable
   - The delay was 50ms before, even in the unit tests. It is now 1 second by default and 1ms in the unit tests.
- TAPA: fix concurrency issue in the stream retry
   - if multiple events occur (AddStream, SetStreams), a stack of Open would pile up waiting for the mutex to be unlocked. When the mutex would be unlocked (on close call), the close could then be executed, and after, piled open calls would execute again, which would cause the stream to be re-opened.
- TAPA: fix conduit SetVips
   - SetVips could be called even after the conduit has been disconnected. So the NSM connection would have been requested a new time and the interface would be remaining in the pod.

## Issue link

https://github.com/Nordix/Meridio/issues/316
https://github.com/Nordix/Meridio/pull/343 (stream-max-targets test)

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [x] Unit test
    - [x] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
