### PR TITLE
Use structured logging on TRACE level

### DIFF
--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -65,9 +65,6 @@ func main() {
 	}
 
 	config := &env.Config{}
-	if err := envconfig.Usage("nfe", config); err != nil {
-		panic(err)
-	}
 	if err := envconfig.Process("nfe", config); err != nil {
 		panic(err)
 	}

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -96,7 +96,9 @@ func main() {
 		logrus.SetLevel(logrus.TraceLevel)
 	}
 	logger.Info("NSM trace", "enabled", nsmlog.IsTracingEnabled())
-	ctx = nsmlog.WithLog(ctx, log.NSMLogger(logger))
+	nsmlogger := log.NSMLogger(logger)
+	nsmlog.SetGlobalLogger(nsmlogger)
+	ctx = nsmlog.WithLog(ctx, nsmlogger)
 
 	// create and start health server
 	ctx = health.CreateChecker(ctx)

--- a/cmd/stateless-lb/main.go
+++ b/cmd/stateless-lb/main.go
@@ -109,8 +109,10 @@ func main() {
 		logrus.SetLevel(logrus.TraceLevel)
 	}
 	logger.Info("NSM trace", "enabled", nsmlog.IsTracingEnabled())
-	// Doesn't work, see https://github.com/networkservicemesh/sdk/issues/1272
-	ctx = nsmlog.WithLog(ctx, log.NSMLogger(logger)) // allow NSM logs
+	// See https://github.com/networkservicemesh/sdk/issues/1272
+	nsmlogger := log.NSMLogger(logger)
+	nsmlog.SetGlobalLogger(nsmlogger)
+	ctx = nsmlog.WithLog(ctx, nsmlogger)
 
 	netUtils := &linuxKernel.KernelUtils{}
 


### PR DESCRIPTION
## Description

In NSM v1.7.x the NSM logger can be configured to use structured logging. This PR ensures that structured logging is used even for NSM trace logging.

The NSM trace logging uses a format with indentations that is awkward when structured logging is used. A better way would be to post-process log entries whic is made simple by structured logging.

## Issue link

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
