### PR TITLE
Fix NSP Target Registry on stream conduit switch

### DIFF
--- a/pkg/nsp/registry/sqlite/sqlite_test.go
+++ b/pkg/nsp/registry/sqlite/sqlite_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright (c) 2021 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqlite_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	nspAPI "github.com/nordix/meridio/api/nsp/v1"
+	"github.com/nordix/meridio/pkg/nsp/registry/sqlite"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
+)
+
+func TestTargetRegistrySQLite_Set(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	dbFile := "test.db"
+	os.Remove(dbFile)
+	db, err := sqlite.New(dbFile)
+	assert.Nil(t, err)
+	defer func() {
+		db.Close()
+		os.Remove(dbFile)
+	}()
+
+	ctx := context.Background()
+
+	nspTargets := []*nspAPI.Target{
+		{
+			Ips: []string{"172.16.0.1/32"},
+			Context: map[string]string{
+				"identifier": "32",
+			},
+			Status: nspAPI.Target_DISABLED,
+			Type:   nspAPI.Target_DEFAULT,
+			Stream: &nspAPI.Stream{
+				Name: "stream-a",
+				Conduit: &nspAPI.Conduit{
+					Name: "conduit-a",
+					Trench: &nspAPI.Trench{
+						Name: "trench-a",
+					},
+				},
+			},
+		},
+		{
+			Ips: []string{"172.16.0.2/32"},
+			Context: map[string]string{
+				"identifier": "65",
+			},
+			Status: nspAPI.Target_DISABLED,
+			Type:   nspAPI.Target_DEFAULT,
+			Stream: &nspAPI.Stream{
+				Name: "stream-a",
+				Conduit: &nspAPI.Conduit{
+					Name: "conduit-a",
+					Trench: &nspAPI.Trench{
+						Name: "trench-a",
+					},
+				},
+			},
+		},
+		{
+			Ips: []string{"172.16.0.3/32"},
+			Context: map[string]string{
+				"identifier": "1",
+			},
+			Status: nspAPI.Target_DISABLED,
+			Type:   nspAPI.Target_DEFAULT,
+			Stream: &nspAPI.Stream{
+				Conduit: &nspAPI.Conduit{
+					Trench: &nspAPI.Trench{},
+				},
+			},
+		},
+	}
+
+	// Add nspTargets[0]
+	err = db.Set(ctx, nspTargets[0])
+	assert.Nil(t, err)
+
+	targets, err := db.Get(ctx, &nspAPI.Target{Status: nspAPI.Target_ANY, Type: nspAPI.Target_DEFAULT})
+	assert.Nil(t, err)
+	assert.Len(t, targets, 1)
+	assert.Equal(t, nspTargets[0], targets[0])
+
+	// Update nspTargets[0]
+	nspTargets[0].Status = nspAPI.Target_ENABLED
+	err = db.Set(ctx, nspTargets[0])
+	assert.Nil(t, err)
+
+	targets, err = db.Get(ctx, &nspAPI.Target{Status: nspAPI.Target_ANY, Type: nspAPI.Target_DEFAULT})
+	assert.Nil(t, err)
+	assert.Len(t, targets, 1)
+	assert.Equal(t, nspTargets[0], targets[0])
+
+	// Add nspTargets[1]
+	err = db.Set(ctx, nspTargets[1])
+	assert.Nil(t, err)
+
+	targets, err = db.Get(ctx, &nspAPI.Target{Status: nspAPI.Target_ANY, Type: nspAPI.Target_DEFAULT})
+	assert.Nil(t, err)
+	assert.Len(t, targets, 2)
+	assert.Contains(t, targets, nspTargets[0])
+	assert.Contains(t, targets, nspTargets[1])
+
+	// Add nspTargets[2]
+	err = db.Set(ctx, nspTargets[2])
+	assert.Nil(t, err)
+
+	targets, err = db.Get(ctx, &nspAPI.Target{Status: nspAPI.Target_ANY, Type: nspAPI.Target_DEFAULT})
+	assert.Nil(t, err)
+	assert.Len(t, targets, 3)
+	assert.Contains(t, targets, nspTargets[0])
+	assert.Contains(t, targets, nspTargets[1])
+	assert.Contains(t, targets, nspTargets[2])
+
+	// Update nspTargets[0] with different conduit
+	// Due the way the data are stored, 2 objects (Stream, Conduit, Trench) with the same name causes problems.
+	// A new nspTargets[0] entry will be created and old nspTargets[0] and nspTargets[1] will be deleted due to stream name conflict.
+	nspTargets[0].Stream.Conduit.Name = "conduit-b"
+	nspTargets[0].Context["identifier"] = "100"
+	err = db.Set(ctx, nspTargets[0])
+	assert.Nil(t, err)
+
+	targets, err = db.Get(ctx, &nspAPI.Target{Status: nspAPI.Target_ANY, Type: nspAPI.Target_DEFAULT})
+	assert.Nil(t, err)
+	assert.Len(t, targets, 2)
+	assert.Contains(t, targets, nspTargets[0])
+	assert.Contains(t, targets, nspTargets[2])
+
+	// Remove nspTargets[0]
+	err = db.Remove(ctx, nspTargets[0])
+	assert.Nil(t, err)
+	targets, err = db.Get(ctx, &nspAPI.Target{Status: nspAPI.Target_ANY, Type: nspAPI.Target_DEFAULT})
+	assert.Nil(t, err)
+	assert.Len(t, targets, 1)
+	assert.Contains(t, targets, nspTargets[2])
+
+	// Remove nspTargets[2]
+	err = db.Remove(ctx, nspTargets[2])
+	assert.Nil(t, err)
+	targets, err = db.Get(ctx, &nspAPI.Target{Status: nspAPI.Target_ANY, Type: nspAPI.Target_DEFAULT})
+	assert.Nil(t, err)
+	assert.Len(t, targets, 0)
+}


### PR DESCRIPTION
## Description

When a stream was switched between 2 different conduits (switched or deleted/created in a new conduit), the NSP sqlite registry was taking the old conduit association instead of updating the conduit name of the association.

This case is covered by the e2e test: `new-stream` followed with `new-attractor-nsm-vlan` 

### To Reproduce

To reproduce the bug:
1. Create a stream (S-1) in a conduit (C-1)
2. Open the stream (S-1) in a target
3. Move the stream (S-1) in conduit (C-2) 
4. Open the stream (S-1) in a target

### Reason

Due to the missing `FullSaveAssociations` in gorm setting, and the previous registration of a Target in S-1.C-1, when the stream will be moved, the NSP will register new targets with S-1.C-2 without updating the nested conduit property C-1 to C-2.
This will cause the NSP to return an empty list of targets when watching S-1.C-2. The LBs will then not configure any target for that stream and the TAPA will then keep trying to register itself with a new identifier.

### Limitations

Due the way the data are stored, 2 objects (Stream, Conduit, Trench) with the same name would cause problems.

A better solution would be to fix it via a new way to represent the data in the database. So we would need a v2 of the sqlite registry. Then we would need a way to recover and convert the v1 to v2 (to handle the upgrade), but downgrade would not be supported since a v2 to v1 could not be added.

### Alternative to the limitations

Since Meridio v0.5.0 and the introduction of the keepalive mechanism in the NSP target registry (https://github.com/Nordix/Meridio/pull/205), we could not really care about the backward compatibility of the database, and just switch to v2 without any recover/convert mechanism. The TAPA updates itself every 30 seconds, so it will re-register itself if it sees it has been deleted. During an upgrade, this means there would be a traffic interruption.

## Issue link

https://github.com/Nordix/Meridio/pull/343

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [x] Unit test
    - [x] E2E Test
    - [ ] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
