### PR TITLE
Allow internal target IP change without close/reopen

### DIFF
--- a/docs/test.md
+++ b/docs/test.md
@@ -71,6 +71,8 @@ A bash script file must be passed as parameter of the e2e tests. The script is r
 | on_failure () error | Executed on failure |
 | configuration_new_vip () error | Executed just before running the `new-vip` test |
 | configuration_new_vip_revert () error | Executed just after running the `new-vip` test |
+| delete_create_trench | Executed just before running the `delete-create-trench` test |
+| delete_create_trench_revert | Executed just before running the `delete-create-trench` test and after the `delete_create_trench` script |
 
 ### List of tests
 
@@ -86,6 +88,7 @@ A bash script file must be passed as parameter of the e2e tests. The script is r
 | Scale-Up | Scaling | Scale up `target-a-deployment-name` |
 | close-open | TAPA | Close `stream-a-I` in one of the target from `target-a-deployment-name` and re-open it |
 | new-vip | Configuration | Configure `vip-2-v4` and `vip-2-v6` in `flow-a-z-tcp` and `attractor-a-1` |
+| delete-create-trench | Trench | Delete `trench-a` and recreate and reconfigure it |
 <!-- TODO: | open | TAPA | Open `stream-a-II` in one of the target from `target-a-deployment-name` and close it | -->
 
 ### Steps (Kind + Helm)

--- a/pkg/nsm/ipcontext/client.go
+++ b/pkg/nsm/ipcontext/client.go
@@ -40,7 +40,7 @@ func NewClient(ipContextSetter ipContextSetter) networkservice.NetworkServiceCli
 
 // Request
 func (icc *ipcontextClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
-	err := icc.ics.SetIPContext(request.Connection, networking.NSC)
+	err := icc.ics.SetIPContext(ctx, request.Connection, networking.NSC)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func (icc *ipcontextClient) Request(ctx context.Context, request *networkservice
 
 // Close
 func (icc *ipcontextClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
-	err := icc.ics.UnsetIPContext(conn, networking.NSC)
+	err := icc.ics.UnsetIPContext(ctx, conn, networking.NSC)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/nsm/ipcontext/common.go
+++ b/pkg/nsm/ipcontext/common.go
@@ -17,11 +17,13 @@ limitations under the License.
 package ipcontext
 
 import (
+	"context"
+
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/nordix/meridio/pkg/networking"
 )
 
 type ipContextSetter interface {
-	SetIPContext(conn *networkservice.Connection, interfaceType networking.InterfaceType) error
-	UnsetIPContext(conn *networkservice.Connection, interfaceType networking.InterfaceType) error
+	SetIPContext(ctx context.Context, conn *networkservice.Connection, interfaceType networking.InterfaceType) error
+	UnsetIPContext(ctx context.Context, conn *networkservice.Connection, interfaceType networking.InterfaceType) error
 }

--- a/pkg/nsm/ipcontext/server.go
+++ b/pkg/nsm/ipcontext/server.go
@@ -38,7 +38,7 @@ func NewServer(ipContextSetter ipContextSetter) networkservice.NetworkServiceSer
 
 // Request
 func (ics *ipcontextServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
-	err := ics.ics.SetIPContext(request.Connection, networking.NSE)
+	err := ics.ics.SetIPContext(ctx, request.Connection, networking.NSE)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func (ics *ipcontextServer) Request(ctx context.Context, request *networkservice
 
 // Close
 func (ics *ipcontextServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
-	err := ics.ics.UnsetIPContext(conn, networking.NSE)
+	err := ics.ics.UnsetIPContext(ctx, conn, networking.NSE)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -230,19 +230,23 @@ func removeOldIPs(ips []string, gateways []string) []string {
 		}
 		gws = append(gws, n)
 	}
-	ipsMap := listToMap(ips)
-	for ip := range ipsMap {
+	res := []string{}
+	for _, ip := range ips {
 		i, _, err := net.ParseCIDR(ip)
 		if err != nil {
 			continue
 		}
+		ipInGatewaySubnet := false
 		for _, net := range gws {
 			if net.Contains(i) {
-				delete(ipsMap, ip)
+				ipInGatewaySubnet = true
 			}
 		}
+		if !ipInGatewaySubnet {
+			res = append(res, ip)
+		}
 	}
-	return mapToList(ipsMap)
+	return res
 }
 
 // Tells if a contains all b items
@@ -262,15 +266,6 @@ func listToMap(l []string) map[string]struct{} {
 	res := map[string]struct{}{}
 	for _, s := range l {
 		res[s] = struct{}{}
-	}
-	return res
-}
-
-// convert the keys of a map to a list
-func mapToList(m map[string]struct{}) []string {
-	res := []string{}
-	for k := range m {
-		res = append(res, k)
 	}
 	return res
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -1,0 +1,399 @@
+/*
+Copyright (c) 2023 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	ipamAPI "github.com/nordix/meridio/api/ipam/v1"
+	v1 "github.com/nordix/meridio/api/nsp/v1"
+	"github.com/nordix/meridio/pkg/kernel"
+	"github.com/nordix/meridio/pkg/networking"
+	"github.com/nordix/meridio/pkg/proxy"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func Test_SetIPContext_NSC(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	conduit := &v1.Conduit{
+		Name: "",
+		Trench: &v1.Trench{
+			Name: "",
+		},
+	}
+	ipamClient := &mockIPAM{
+		ips: map[ipamAPI.IPFamily][]*ipamAPI.Prefix{
+			ipamAPI.IPFamily_IPV4: {
+				{
+					Address:      "172.16.0.1",
+					PrefixLength: 24,
+				},
+				{
+					Address:      "172.16.0.2",
+					PrefixLength: 24,
+				},
+			},
+			ipamAPI.IPFamily_IPV6: {
+				{
+					Address:      "fd00::1",
+					PrefixLength: 64,
+				},
+				{
+					Address:      "fd00::2",
+					PrefixLength: 64,
+				},
+			},
+		},
+		currentIPv4: 0,
+		currentIPv6: 0,
+	}
+
+	proxy := proxy.Proxy{
+		Bridge: nil,
+		Subnets: map[ipamAPI.IPFamily]*ipamAPI.Subnet{
+			ipamAPI.IPFamily_IPV4: {
+				Conduit:  conduit,
+				Node:     "Worker",
+				IpFamily: ipamAPI.IPFamily_IPV4,
+			},
+			ipamAPI.IPFamily_IPV6: {
+				Conduit:  conduit,
+				Node:     "Worker",
+				IpFamily: ipamAPI.IPFamily_IPV6,
+			},
+		},
+		IpamClient: ipamClient,
+	}
+
+	conn := &networkservice.Connection{}
+
+	err := proxy.SetIPContext(context.TODO(), conn, networking.NSC)
+	assert.Nil(t, err)
+	assert.NotNil(t, conn.GetContext())
+	assert.NotNil(t, conn.GetContext().GetIpContext())
+	assert.ElementsMatch(t, conn.GetContext().GetIpContext().DstIpAddrs, []string{"172.16.0.1/24", "fd00::1/64"})
+	assert.ElementsMatch(t, conn.GetContext().GetIpContext().SrcIpAddrs, []string{"172.16.0.2/24", "fd00::2/64"})
+}
+
+func Test_SetIPContext_NSE(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	conduit := &v1.Conduit{
+		Name: "",
+		Trench: &v1.Trench{
+			Name: "",
+		},
+	}
+	ipamClient := &mockIPAM{
+		ips: map[ipamAPI.IPFamily][]*ipamAPI.Prefix{
+			ipamAPI.IPFamily_IPV4: {
+				{
+					Address:      "172.16.0.1",
+					PrefixLength: 24,
+				},
+				{
+					Address:      "172.16.0.2",
+					PrefixLength: 24,
+				},
+			},
+			ipamAPI.IPFamily_IPV6: {
+				{
+					Address:      "fd00::1",
+					PrefixLength: 64,
+				},
+				{
+					Address:      "fd00::2",
+					PrefixLength: 64,
+				},
+			},
+		},
+		currentIPv4: 0,
+		currentIPv6: 0,
+	}
+	bridge := &mockBridge{}
+
+	proxy := proxy.Proxy{
+		Bridge: bridge,
+		Subnets: map[ipamAPI.IPFamily]*ipamAPI.Subnet{
+			ipamAPI.IPFamily_IPV4: {
+				Conduit:  conduit,
+				Node:     "Worker",
+				IpFamily: ipamAPI.IPFamily_IPV4,
+			},
+			ipamAPI.IPFamily_IPV6: {
+				Conduit:  conduit,
+				Node:     "Worker",
+				IpFamily: ipamAPI.IPFamily_IPV6,
+			},
+		},
+		IpamClient: ipamClient,
+	}
+
+	conn := &networkservice.Connection{}
+
+	err := proxy.SetIPContext(context.TODO(), conn, networking.NSE)
+	assert.Nil(t, err)
+	assert.NotNil(t, conn.GetContext())
+	assert.NotNil(t, conn.GetContext().GetIpContext())
+	assert.ElementsMatch(t, conn.GetContext().GetIpContext().SrcIpAddrs, []string{"172.16.0.1/24", "fd00::1/64"})
+	assert.ElementsMatch(t, conn.GetContext().GetIpContext().DstIpAddrs, []string{"172.16.0.2/24", "fd00::2/64"})
+	assert.ElementsMatch(t, conn.GetContext().GetIpContext().ExtraPrefixes, []string{"172.16.0.100/24", "fd00::100/64"})
+}
+
+func Test_SetIPContext_NSE_Update(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	conduit := &v1.Conduit{
+		Name: "",
+		Trench: &v1.Trench{
+			Name: "",
+		},
+	}
+	ipamClient := &mockIPAM{
+		ips: map[ipamAPI.IPFamily][]*ipamAPI.Prefix{
+			ipamAPI.IPFamily_IPV4: {
+				{
+					Address:      "172.16.0.1",
+					PrefixLength: 24,
+				},
+				{
+					Address:      "172.16.0.2",
+					PrefixLength: 24,
+				},
+			},
+			ipamAPI.IPFamily_IPV6: {
+				{
+					Address:      "fd00::1",
+					PrefixLength: 64,
+				},
+				{
+					Address:      "fd00::2",
+					PrefixLength: 64,
+				},
+			},
+		},
+		currentIPv4: 0,
+		currentIPv6: 0,
+	}
+	bridge := &mockBridge{}
+
+	proxy := proxy.Proxy{
+		Bridge: bridge,
+		Subnets: map[ipamAPI.IPFamily]*ipamAPI.Subnet{
+			ipamAPI.IPFamily_IPV4: {
+				Conduit:  conduit,
+				Node:     "Worker",
+				IpFamily: ipamAPI.IPFamily_IPV4,
+			},
+			ipamAPI.IPFamily_IPV6: {
+				Conduit:  conduit,
+				Node:     "Worker",
+				IpFamily: ipamAPI.IPFamily_IPV6,
+			},
+		},
+		IpamClient: ipamClient,
+	}
+
+	conn := &networkservice.Connection{
+		Id: "abc",
+		Context: &networkservice.ConnectionContext{
+			IpContext: &networkservice.IPContext{
+				SrcIpAddrs:    []string{"172.16.0.1/24", "fd00::1/64", "20.0.0.1/32", "2000::1/128"},
+				DstIpAddrs:    []string{"172.16.0.2/24", "fd00::2/64"},
+				ExtraPrefixes: []string{"172.16.0.100/24", "fd00::100/64"},
+				Policies: []*networkservice.PolicyRoute{
+					{
+						From: "20.0.0.1/32",
+						Routes: []*networkservice.Route{
+							{
+								Prefix:  "0.0.0.0/0",
+								NextHop: "172.16.0.100",
+							},
+						},
+					},
+					{
+						From: "2000::1/128",
+						Routes: []*networkservice.Route{
+							{
+								Prefix:  "::/0",
+								NextHop: "fd00::100",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := proxy.SetIPContext(context.TODO(), conn, networking.NSE)
+	assert.Nil(t, err)
+	assert.NotNil(t, conn.GetContext())
+	assert.NotNil(t, conn.GetContext().GetIpContext())
+	assert.ElementsMatch(t, conn.GetContext().GetIpContext().SrcIpAddrs, []string{"172.16.0.1/24", "fd00::1/64", "20.0.0.1/32", "2000::1/128"})
+	assert.ElementsMatch(t, conn.GetContext().GetIpContext().DstIpAddrs, []string{"172.16.0.2/24", "fd00::2/64"})
+	assert.ElementsMatch(t, conn.GetContext().GetIpContext().ExtraPrefixes, []string{"172.16.0.100/24", "fd00::100/64"})
+}
+
+func Test_SetIPContext_NSE_Update_New_IPs(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	conduit := &v1.Conduit{
+		Name: "",
+		Trench: &v1.Trench{
+			Name: "",
+		},
+	}
+	ipamClient := &mockIPAM{
+		ips: map[ipamAPI.IPFamily][]*ipamAPI.Prefix{
+			ipamAPI.IPFamily_IPV4: {
+				{
+					Address:      "172.16.0.10",
+					PrefixLength: 24,
+				},
+				{
+					Address:      "172.16.0.20",
+					PrefixLength: 24,
+				},
+			},
+			ipamAPI.IPFamily_IPV6: {
+				{
+					Address:      "fd00::10",
+					PrefixLength: 64,
+				},
+				{
+					Address:      "fd00::20",
+					PrefixLength: 64,
+				},
+			},
+		},
+		currentIPv4: 0,
+		currentIPv6: 0,
+	}
+	bridge := &mockBridge{}
+
+	proxy := proxy.Proxy{
+		Bridge: bridge,
+		Subnets: map[ipamAPI.IPFamily]*ipamAPI.Subnet{
+			ipamAPI.IPFamily_IPV4: {
+				Conduit:  conduit,
+				Node:     "Worker",
+				IpFamily: ipamAPI.IPFamily_IPV4,
+			},
+			ipamAPI.IPFamily_IPV6: {
+				Conduit:  conduit,
+				Node:     "Worker",
+				IpFamily: ipamAPI.IPFamily_IPV6,
+			},
+		},
+		IpamClient: ipamClient,
+	}
+
+	conn := &networkservice.Connection{
+		Id: "abc",
+		Context: &networkservice.ConnectionContext{
+			IpContext: &networkservice.IPContext{
+				SrcIpAddrs:    []string{"172.16.0.1/24", "fd00::1/64", "20.0.0.1/32", "2000::1/128"},
+				DstIpAddrs:    []string{"172.16.0.2/24", "fd00::2/64"},
+				ExtraPrefixes: []string{"172.16.0.10/24", "fd00::10/64"},
+				Policies: []*networkservice.PolicyRoute{
+					{
+						From: "20.0.0.1/32",
+						Routes: []*networkservice.Route{
+							{
+								Prefix:  "0.0.0.0/0",
+								NextHop: "172.16.0.10",
+							},
+						},
+					},
+					{
+						From: "2000::1/128",
+						Routes: []*networkservice.Route{
+							{
+								Prefix:  "::/0",
+								NextHop: "fd00::10",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := proxy.SetIPContext(context.TODO(), conn, networking.NSE)
+	assert.Nil(t, err)
+	assert.NotNil(t, conn.GetContext())
+	assert.NotNil(t, conn.GetContext().GetIpContext())
+	assert.ElementsMatch(t, conn.GetContext().GetIpContext().SrcIpAddrs, []string{"172.16.0.10/24", "fd00::10/64", "20.0.0.1/32", "2000::1/128"})
+	assert.ElementsMatch(t, conn.GetContext().GetIpContext().DstIpAddrs, []string{"172.16.0.20/24", "fd00::20/64"})
+	assert.ElementsMatch(t, conn.GetContext().GetIpContext().ExtraPrefixes, []string{"172.16.0.100/24", "fd00::100/64"})
+	policies := conn.GetContext().GetIpContext().Policies
+	assert.Len(t, policies, 2)
+	if policies[0].From == "20.0.0.1/32" {
+		assert.Equal(t, "20.0.0.1/32", policies[0].From)
+		assert.Len(t, policies[0].Routes, 1)
+		assert.Equal(t, "0.0.0.0/0", policies[0].Routes[0].Prefix)
+		assert.Equal(t, "172.16.0.100", policies[0].Routes[0].NextHop)
+		assert.Equal(t, "2000::1/128", policies[1].From)
+		assert.Len(t, policies[1].Routes, 1)
+		assert.Equal(t, "::/0", policies[1].Routes[0].Prefix)
+		assert.Equal(t, "fd00::100", policies[1].Routes[0].NextHop)
+	} else {
+		assert.Equal(t, "20.0.0.1/32", policies[1].From)
+		assert.Len(t, policies[1].Routes, 1)
+		assert.Equal(t, "0.0.0.0/0", policies[1].Routes[0].Prefix)
+		assert.Equal(t, "172.16.0.100", policies[1].Routes[0].NextHop)
+		assert.Equal(t, "2000::1/128", policies[0].From)
+		assert.Len(t, policies[0].Routes, 1)
+		assert.Equal(t, "::/0", policies[0].Routes[0].Prefix)
+		assert.Equal(t, "fd00::100", policies[0].Routes[0].NextHop)
+	}
+}
+
+type mockBridge struct {
+	kernel.Bridge
+}
+
+func (mb *mockBridge) GetLocalPrefixes() []string {
+	return []string{"172.16.0.100/24", "fd00::100/64"}
+}
+
+type mockIPAM struct {
+	ips         map[ipamAPI.IPFamily][]*ipamAPI.Prefix
+	currentIPv4 int
+	currentIPv6 int
+}
+
+func (mi *mockIPAM) Allocate(ctx context.Context, in *ipamAPI.Child, opts ...grpc.CallOption) (*ipamAPI.Prefix, error) {
+	if in.Subnet.IpFamily == ipamAPI.IPFamily_IPV4 {
+		res := mi.ips[in.Subnet.IpFamily][mi.currentIPv4]
+		mi.currentIPv4++
+		return res, nil
+	}
+	res := mi.ips[in.Subnet.IpFamily][mi.currentIPv6]
+	mi.currentIPv6++
+	return res, nil
+}
+
+func (mi *mockIPAM) Release(ctx context.Context, in *ipamAPI.Child, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return nil, nil
+}

--- a/test/e2e/environment/kind-operator/dualstack/test.sh
+++ b/test/e2e/environment/kind-operator/dualstack/test.sh
@@ -22,5 +22,19 @@ function configuration_new_vip_revert () {
     kubectl delete vip -n red vip-a-2-v6
 }
 
+function delete_create_trench () {
+    kubectl delete trench trench-a -n red
+    sleep 5
+    kubectl wait --for=condition=Ready pods --all -n red --timeout=4m
+    # Wait for all pods to be in running state (no Terminating pods)
+    while kubectl get pods -n red --no-headers | awk '$3' | grep -v "Running" > /dev/null; do sleep 1; done
+}
+
+function delete_create_trench_revert () {
+    kubectl apply -f $(dirname -- $(readlink -fn -- "$0"))/configuration/init-trench-a.yaml
+    sleep 5
+    kubectl wait --for=condition=Ready pods --all -n red --timeout=4m
+}
+
 # Required to call the corresponding function
 $1 $@

--- a/test/e2e/trench_test.go
+++ b/test/e2e/trench_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright (c) 2023 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nordix/meridio/test/e2e/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Trench", func() {
+
+	Describe("delete-create-trench", func() {
+		When("Delete trench-a and recreate and reconfigure it", func() {
+			BeforeEach(func() {
+				By(fmt.Sprintf("Deleting the trench %s", config.trenchA))
+				err := utils.Exec(config.script, "delete_create_trench")
+				Expect(err).ToNot(HaveOccurred())
+				By(fmt.Sprintf("Recreate the trench %s", config.trenchA))
+				err = utils.Exec(config.script, "delete_create_trench_revert")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("(Traffic) is received by the targets", func(ctx context.Context) {
+				protocol := "tcp"
+				if !utils.IsIPv6(config.ipFamily) { // Don't send traffic with IPv4 if the tests are only IPv6
+					ipPort := utils.VIPPort(config.vip1V4, config.flowAZTcpDestinationPort0)
+					By(fmt.Sprintf("Sending %s traffic from the TG %s (%s) to %s", protocol, config.trenchA, config.k8sNamespace, ipPort))
+					lastingConnections, lostConnections := trafficGeneratorHost.SendTraffic(trafficGenerator, config.trenchA, config.k8sNamespace, ipPort, protocol)
+					Expect(lostConnections).To(Equal(0), "There should be no lost connection: %v", lastingConnections)
+					Expect(len(lastingConnections)).To(Equal(numberOfTargetA), "All targets with the stream opened should have received traffic: %v", lastingConnections)
+				}
+				if !utils.IsIPv4(config.ipFamily) { // Don't send traffic with IPv6 if the tests are only IPv4
+					ipPort := utils.VIPPort(config.vip1V6, config.flowAZTcpDestinationPort0)
+					By(fmt.Sprintf("Sending %s traffic from the TG %s (%s) to %s", protocol, config.trenchA, config.k8sNamespace, ipPort))
+					lastingConnections, lostConnections := trafficGeneratorHost.SendTraffic(trafficGenerator, config.trenchA, config.k8sNamespace, ipPort, protocol)
+					Expect(lostConnections).To(Equal(0), "There should be no lost connection: %v", lastingConnections)
+					Expect(len(lastingConnections)).To(Equal(numberOfTargetA), "All targets with the stream opened should have received traffic: %v", lastingConnections)
+				}
+			}, SpecTimeout(timeoutTest))
+		})
+	})
+
+})


### PR DESCRIPTION
## Description

- Allow internal target IP change without close/reopen
   - When a trench/conduit/stream is deleted and recreated, the target that was connected will again request the connections with the old parameters (IPs, GWs, routes...). The proxy might get different subnets allocated and will forget the target IPs in use. So this will cause the targets to have wrong/colliding IP addresses.
   - The proxy is now detecting if a target is requesting the connection with invalid IP addresses and will fix them together with the other parameters (GWs, routes...).
   - In addition, the tapa can now handle the internal IP changes and will register itself with the new IP assigned.
- Fix NSP reconnect in the TAPA in case of NSP service delete/create  
   - If the NSP service is re-created, the TAPA will take around 15 minutes to re-connect to the NSP service. Having the time field set in the keepalive parameters for GRPC forces the DNS to be refreshed.
- Add delete/recreate trench e2e test
   - New e2e test deleting the complete trench-a and recreating it.

### Other alternative

The TAPA stops to update the connections to request new VIPs and instead, the proxy does it. The proxy would watch the VIP addresses in the conduit it serves, and would update the connection with the latest VIP list. This feature has been added to NSM, but I never tried it, and I am not sure how, from the NSC side, we can be aware of the connection changes.

### e2e test

#### delete-create-trench
```
STEP: Deleting the trench trench-a @ 01/24/23 11:14:14.408
STEP: Recreate the trench trench-a @ 01/24/23 11:14:48.716
STEP: Sending tcp traffic from the TG trench-a (red) to 20.0.0.1:4000 @ 01/24/23 11:15:31.173
STEP: Sending tcp traffic from the TG trench-a (red) to [2000::1]:4000 @ 01/24/23 11:16:05.862
```

## Issue link

/

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [x] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
