### PR TITLE
frontend; lack of bfd session logged for gateways with static+bfd

### DIFF
--- a/cmd/frontend/internal/bird/bird.go
+++ b/cmd/frontend/internal/bird/bird.go
@@ -31,7 +31,7 @@ import (
 	"github.com/nordix/meridio/pkg/log"
 )
 
-var regexError *regexp.Regexp = regexp.MustCompile(`Error|<ERROR>|<BUG>|<FATAL>`)
+var regexError *regexp.Regexp = regexp.MustCompile(`Error|<ERROR>|<BUG>|<FATAL>|syntax error`)
 var regexInfo *regexp.Regexp = regexp.MustCompile(`<INFO>|<WARNING>|BGP session|Connected|Received:|Started|Neighbor|Startup delayed`)
 
 func NewRoutingService(ctx context.Context, commSocket string, configFile string) *RoutingService {

--- a/cmd/frontend/internal/bird/proto.go
+++ b/cmd/frontend/internal/bird/proto.go
@@ -18,6 +18,7 @@ package bird
 
 import (
 	"bufio"
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -95,11 +96,12 @@ func bfdDown(p *Protocol) bool {
 	scanner := bufio.NewScanner(strings.NewReader(p.BfdSessions()))
 	for scanner.Scan() {
 		if bfdMatch := regexBFD.FindStringSubmatch(scanner.Text()); bfdMatch != nil {
-			p.Log(" bfd: " + bfdMatch[0])
+			p.Log(fmt.Sprintf(" bfd: %s", bfdMatch[0]))
 			return bfdMatch[1] != "Up"
 		}
 	}
 	// did not find the BFD session
+	p.Log(" bfd: no session")
 	return true
 }
 

--- a/cmd/frontend/internal/bird/static_test.go
+++ b/cmd/frontend/internal/bird/static_test.go
@@ -242,9 +242,9 @@ func TestParseProtocolsStaticWithMissingBfd(t *testing.T) {
 	expectedLog := `BIRD 2.0.7 ready.` + "\n" +
 		`Name       Proto      Table      State  Since         Info` + "\n" +
 		`NBR-gateway1 Static     master4    up     21:10:21.868 bfd: 169.254.100.254           ext-vlan   Up         22:13:19.019    0.100    0.500` + "\n" +
-		`NBR-gateway2 Static     master6    up     21:10:21.868` + "\n" +
+		`NBR-gateway2 Static     master6    up     21:10:21.868 bfd: no session` + "\n" +
 		`NBR-gateway3 Static     master4    up     21:10:21.886 bfd: 169.254.100.253           ext-vlan   Up         22:13:19.439    0.100    0.500` + "\n" +
-		`NBR-gateway4 Static     master6    up     21:10:21.886` + "\n"
+		`NBR-gateway4 Static     master6    up     21:10:21.886 bfd: no session` + "\n"
 
 	assert.NotNil(t, cs)
 	assert.Empty(t, cs.Log())

--- a/cmd/frontend/internal/frontend/service.go
+++ b/cmd/frontend/internal/frontend/service.go
@@ -963,7 +963,7 @@ func (fes *FrontEndService) reconfigurationAgent(ctx context.Context, reconfCh <
 func (fes *FrontEndService) reconfigure(ctx context.Context, path string) error {
 	stringOut, err := fes.routingService.Configure(ctx, path)
 	if err != nil {
-		return err
+		return fmt.Errorf("%v; %v", err, stringOut)
 	} else {
 		fes.logger.V(1).Info("routing service reconfigured", "out", strings.Split(stringOut, "\n"))
 		fes.logger.Info("routing service configuration applied")


### PR DESCRIPTION
## Description
BIRD removes a BFD session if the net devive hosting it becomes unavailable.
This might be misleading, as the status printouts won't indicate any of that, while the related gateway will be considered down.

To ease troubleshooting that information is included from now on.

example (including the changes):
```
{
  "severity": "error",
  "timestamp": "2023-01-27T15:12:42.81+00:00",
  "service_id": "Meridio-frontend",
  "message": "connectivity",
  "version": "1.0.0",
  "extra_data": {
    "class": "FrontEndService",
    "func": "Monitor",
    "status": 18,
    "out": [
      "BIRD 2.0.8 ready.",
      "Name       Proto      Table      State  Since         Info",
      "NBR-gateway1 Static     master4    up     15:09:08.239   bfd: no session",
      "NBR-gateway2 Static     master6    up     15:09:08.239   bfd: no session",
      ""
    ],
    "error": "gateway down"
  }
}


~ $ birdc -s /var/run/bird/bird.ctl
BIRD 2.0.8 ready.
bird> show bfd session
NBR-BFD:
IP address                Interface  State      Since         Interval  Timeout
bird> 
```

## Issue link
NA

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [x] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
