### PR TITLE
tapa; graceful shutdown

### DIFF
--- a/pkg/ambassador/tap/trench/trench.go
+++ b/pkg/ambassador/tap/trench/trench.go
@@ -119,6 +119,7 @@ func (t *Trench) Delete(ctx context.Context) error {
 	if err != nil {
 		errFinal = fmt.Errorf("%w; %v", errFinal, err) // todo
 	}
+	t.logger.V(1).Info("Streams closed", "err", err)
 	streamsCancel()
 
 	// disconnect conduits
@@ -128,6 +129,7 @@ func (t *Trench) Delete(ctx context.Context) error {
 		errFinal = fmt.Errorf("%w; %v", errFinal, err) // todo
 	}
 	t.conduits = []*conduitConnect{}
+	t.logger.V(1).Info("Conduits disconnected", "err", err)
 	conduitsCancel()
 
 	// disconnect trench related services (connection to NSP)
@@ -135,6 +137,7 @@ func (t *Trench) Delete(ctx context.Context) error {
 	if err != nil {
 		errFinal = fmt.Errorf("%w; %v", errFinal, err) // todo
 	}
+	t.logger.V(1).Info("NSP connection closed", "err", err)
 	t.ConfigurationManagerClient = nil
 	t.TargetRegistryClient = nil
 	t.nspConn = nil
@@ -256,6 +259,7 @@ func (t *Trench) disconnectConduits(ctx context.Context) error {
 	var mu sync.Mutex
 	for _, c := range t.conduits {
 		go func(conduit *conduitConnect) {
+			defer wg.Done()
 			err := conduit.disconnect(ctx) // todo: retry
 			if err != nil {
 				mu.Lock()


### PR DESCRIPTION
## Description
Fixed TAPA termination so that open streams could be properly closed to avoid lingering interfaces on the proxy side.
A call to wg.Done() was also missing  in disconnectConduits() ambassador/tap/trench/trench.go causing tear-down to get stuck.

Test:
1., Deploy a trench and example targets connected to a stream in previous trench.
2., Check the interfaces with prefix in the proxies (proxies serve target PODs running on the same worker).
     The interfaces connecting proxy with target PODs have prefix `proxy.load-` assuming NSM_SERVICE_NAME is `proxy.load-balancer.[TRENCH_NAME]`.
3., Remove the example target deployment (or scale-in the number of PODs or simply kill a target POD). The related interfaces in proxies must disappear with the changes. Basically, the number of such interfaces in the proxies must match the number of target PODs running on the same worker.

## Issue link
https://github.com/Nordix/Meridio/issues/351

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
