### PR TITLE
operator; fix max-targets validation for Streams

### DIFF
--- a/api/v1/stream_webhook.go
+++ b/api/v1/stream_webhook.go
@@ -110,7 +110,8 @@ func (r *Stream) validateUpdate(oldObj runtime.Object) error {
 		return apierrors.NewForbidden(r.GroupResource(),
 			r.Name, field.Forbidden(field.NewPath("metadata", "labels", "trench"), "update on trench label is forbidden"))
 	}
-	if r.Spec.MaxTargets != old.Spec.MaxTargets {
+	if r.Spec.MaxTargets != old.Spec.MaxTargets &&
+		(r.Spec.MaxTargets == nil || old.Spec.MaxTargets == nil || *r.Spec.MaxTargets != *old.Spec.MaxTargets) {
 		return apierrors.NewForbidden(r.GroupResource(),
 			r.Name, field.Forbidden(field.NewPath("metadata", "spec", "max-targets"), "update on max-targets is forbidden"))
 	}


### PR DESCRIPTION
## Description
Mistakenly the pointer values and not the contents of max-targets pointers were compared by the stream webhook.

The faulty check lead to strange problems such as a Stream could not be removed properly (got stuck in the config map unless the related Flows were removed previously).

## Issue link
NA

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [x] Yes (description required)
    Stream webhook fixed.
    - [ ] No
