### PR TITLE
Log contents of interface objects

### DIFF
--- a/pkg/loadbalancer/stream/loadbalancer.go
+++ b/pkg/loadbalancer/stream/loadbalancer.go
@@ -433,7 +433,7 @@ func (lb *LoadBalancer) verifyTargets() {
 		}
 		err := lb.RemoveTarget(target.GetIdentifier())
 		if err != nil {
-			lb.logger.Error(err, "deleting target", "target", target.GetIdentifier())
+			lb.logger.Error(err, "deleting target", "target", target)
 		}
 		lb.addPendingTarget(target)
 	}

--- a/pkg/loadbalancer/stream/target.go
+++ b/pkg/loadbalancer/stream/target.go
@@ -17,6 +17,7 @@ limitations under the License.
 package stream
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -102,3 +103,14 @@ func (t *target) Delete() error {
 	t.fwMarks = []networking.FWMarkRoute{}
 	return errFinal
 }
+func (t *target) MarshalJSON() ([]byte, error) {
+	ts := struct {
+		Identifier int      `json:"identifier"`
+		IPs        []string `json:"ips"`
+	}{
+		t.identifier,
+		t.nspTarget.GetIps(),
+	}
+	return json.Marshal(&ts)
+}
+


### PR DESCRIPTION
## Description

Log contents of interface objects instead of the object itself in structured logging.

After a bit of fumbling I realized the right way is to define a custom `MarshalJSON` function for the _real_ class. Example:
```go
func (t *Target) MarshalJSON() ([]byte, error) {
	ts := struct {
		Identifier int      `json:"identifier"`
		IPs        []string `json:"ips"`
	}{
		t.getIdentifier(),
		t.nspTarget.GetIps(),
	}
	return json.Marshal(&ts)
}
```

<img src="https://media.giphy.com/media/6UFgdU9hirj1pAOJyN/giphy.gif" />


## Issue link

#358

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [ ] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
