### PR TITLE
Set persistentVolumeClaimRetentionPolicy for NSP and IPAM statefulsets

### DIFF
--- a/config/templates/charts/meridio/deployment/ipam.yaml
+++ b/config/templates/charts/meridio/deployment/ipam.yaml
@@ -7,6 +7,8 @@ metadata:
     app: ipam
 spec:
   podManagementPolicy: OrderedReady
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
   replicas: 1
   revisionHistoryLimit: 10
   serviceName: ipam

--- a/config/templates/charts/meridio/deployment/nsp.yaml
+++ b/config/templates/charts/meridio/deployment/nsp.yaml
@@ -8,6 +8,8 @@ metadata:
     app: nsp
 spec:
   podManagementPolicy: OrderedReady
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
   replicas: 1
   revisionHistoryLimit: 10
   serviceName: nsp

--- a/deployments/helm/templates/ipam.yaml
+++ b/deployments/helm/templates/ipam.yaml
@@ -7,6 +7,8 @@ metadata:
     app: ipam-{{ .Values.trench.name }}
 spec:
   replicas: 1
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
   serviceName: ipam-{{ .Values.trench.name }}
   selector:
     matchLabels:

--- a/deployments/helm/templates/nsp.yaml
+++ b/deployments/helm/templates/nsp.yaml
@@ -7,6 +7,8 @@ metadata:
     app: nsp-{{ .Values.trench.name }}
 spec:
   replicas: 1
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
   serviceName: nsp-{{ .Values.trench.name }}
   selector:
     matchLabels:


### PR DESCRIPTION
## Description
Set persistentVolumeClaimRetentionPolicy for NSP and IPAM statefulsets.

The retention behaviour orders PVC deletion when the related statefulset is deleted. Thus old persistent databases won't be retained when a trench gets redeployed, and won't interfere with subsequent Trench deployments.

Note: requires k8s feature gate **StatefulSetAutoDeletePVC**

## Issue link
https://github.com/Nordix/Meridio/issues/361

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [x] Yes (description required)
    - [ ] No
