### PR TITLE
Fix IP release on proxy and fix Node subnet allocation

### DIFF
--- a/pkg/ipam/conduit/conduit.go
+++ b/pkg/ipam/conduit/conduit.go
@@ -18,7 +18,6 @@ package conduit
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/nordix/meridio/pkg/ipam/node"
 	"github.com/nordix/meridio/pkg/ipam/prefix"
@@ -76,11 +75,7 @@ func (c *Conduit) RemoveNode(ctx context.Context, name string) error {
 func (c *Conduit) addNode(ctx context.Context, name string) (types.Node, error) {
 	newPrefix, err := prefix.Allocate(ctx, c, name, c.PrefixLengths.NodeLength, c.Store)
 	if err != nil {
-		errFinal := err
-		newPrefix, err = c.Store.Get(ctx, name, c)
-		if err != nil {
-			return nil, fmt.Errorf("%w; %v", errFinal, err) // todo
-		}
+		return nil, err
 	}
 	return node.New(newPrefix, c.Store, c.PrefixLengths), nil
 }

--- a/pkg/ipam/conduit/conduit_test.go
+++ b/pkg/ipam/conduit/conduit_test.go
@@ -72,3 +72,25 @@ func Test_RemoveNode(t *testing.T) {
 	assert.Equal(t, node.GetName(), "node-b")
 	assert.Equal(t, node.GetCidr(), "172.0.0.0/24")
 }
+
+func Test_GetNode_Full(t *testing.T) {
+	prefixConduit := prefix.New("conduit-a", "172.0.0.0/31", nil)
+	store := memory.New()
+	conduit := conduit.New(prefixConduit, store, types.NewPrefixLengths(31, 32, 32))
+	assert.NotNil(t, conduit)
+	node, err := conduit.GetNode(context.Background(), "node-a")
+	assert.Nil(t, err)
+	assert.NotNil(t, node)
+	assert.True(t, node.GetParent().Equals(prefixConduit))
+	assert.Equal(t, node.GetName(), "node-a")
+	assert.Equal(t, node.GetCidr(), "172.0.0.0/32")
+	node, err = conduit.GetNode(context.Background(), "node-b")
+	assert.Nil(t, err)
+	assert.NotNil(t, node)
+	assert.True(t, node.GetParent().Equals(prefixConduit))
+	assert.Equal(t, node.GetName(), "node-b")
+	assert.Equal(t, node.GetCidr(), "172.0.0.1/32")
+	node, err = conduit.GetNode(context.Background(), "node-c")
+	assert.NotNil(t, err)
+	assert.Nil(t, node)
+}

--- a/pkg/ipam/trench/trench_test.go
+++ b/pkg/ipam/trench/trench_test.go
@@ -58,3 +58,32 @@ func Test_Add_Get_Delete_Conduit(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, conduit)
 }
+
+func Test_Add_Conduit_Full(t *testing.T) {
+	prefixTrench := prefix.New("trench-a", "172.0.0.0/31", nil)
+	store := memory.New()
+	trench := &trench.Trench{
+		Prefix:        prefixTrench,
+		Store:         store,
+		PrefixLengths: types.NewPrefixLengths(32, 32, 32),
+	}
+	assert.NotNil(t, trench)
+	conduit, err := trench.GetConduit(context.Background(), "conduit-a")
+	assert.Nil(t, err)
+	assert.Nil(t, conduit)
+	conduit, err = trench.AddConduit(context.Background(), "conduit-a")
+	assert.Nil(t, err)
+	assert.NotNil(t, conduit)
+	assert.True(t, conduit.GetParent().Equals(prefixTrench))
+	assert.Equal(t, conduit.GetName(), "conduit-a")
+	assert.Equal(t, conduit.GetCidr(), "172.0.0.0/32")
+	conduit, err = trench.AddConduit(context.Background(), "conduit-b")
+	assert.Nil(t, err)
+	assert.NotNil(t, conduit)
+	assert.True(t, conduit.GetParent().Equals(prefixTrench))
+	assert.Equal(t, conduit.GetName(), "conduit-b")
+	assert.Equal(t, conduit.GetCidr(), "172.0.0.1/32")
+	conduit, err = trench.AddConduit(context.Background(), "conduit-c")
+	assert.NotNil(t, err)
+	assert.Nil(t, conduit)
+}


### PR DESCRIPTION
## Description

* The proxy was not releasing the dst IPs
* Fix node subnet allocation which was not returning error on Full conduit subnet

## Issue link

https://github.com/Nordix/Meridio/issues/366

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [x] Unit test
    - [x] E2E Test
    - [ ] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
