### PR TITLE
Add training page on website

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -92,6 +92,11 @@ const config = {
                         label: 'Documentation',
                     },
                     {
+                        to: '/training',
+                        position: 'left',
+                        label: 'Training',
+                    },
+                    {
                         href: 'https://github.com/nordix/meridio',
                         position: 'right',
                         className: 'header-github-link header-icon-link',

--- a/website/src/pages/markdown-page.md
+++ b/website/src/pages/markdown-page.md
@@ -1,7 +1,0 @@
----
-title: Markdown page example
----
-
-# Markdown page example
-
-You don't need React to write simple standalone pages.

--- a/website/src/pages/training.md
+++ b/website/src/pages/training.md
@@ -1,0 +1,37 @@
+# Training
+
+* [Youtube](https://www.youtube.com/@meridio6663)
+* [Killercoda](https://killercoda.com/meridio)
+* [asciinema](https://asciinema.org/~LionelJouin)
+
+## Playground
+
+Simple playground environment with Meridio
+
+* Access the Killercoda environment [here](https://killercoda.com/meridio/scenario/Playground)
+
+## Installation
+
+The deployment of the operator and the application of different resources Meridio offers (Trench, VIP, Conduit, Stream, Flow, Attactor, Gateway)
+
+* Access the Killercoda environment [here](https://killercoda.com/meridio/scenario/Installation)
+* Play the recording [here](https://asciinema.org/a/558008)
+
+## Traffic Path
+
+With NSM v1.7.1 and Meridio v1.0.0, Follow the ingress and egress traffic path from the gateway, worker network, VPP forwarder, stateless-lb-frontend, proxy and the target
+
+* Access the Killercoda environment [here](https://killercoda.com/meridio/scenario/Traffic-Path)
+
+## Troubleshooting CTFs
+
+Set of challenges/exercises to debug and troubleshoot common Meridio problems such as non-ready pods, traffic loss, errors...
+
+* Scenario 1 - [Killercoda](https://killercoda.com/meridio/course/Troubleshooting/Scenario-1) - Traffic does not reach the application pods (targets)...
+* Scenario 2 - [Killercoda](https://killercoda.com/meridio/course/Troubleshooting/Scenario-2) - stateless-lb-frontend pods are not ready...
+
+## Archived
+
+* v0.8.0 - Initial deployment - https://www.youtube.com/watch?v=KB3vNyJnpV8
+* v0.8.0 - Installation - https://www.youtube.com/watch?v=14icbmj9PH0
+* v0.7.1 - Demo with 2 Streams/Flows - https://www.youtube.com/watch?v=zRPK-qQ_mWg


### PR DESCRIPTION
## Description

Add new section of the website for the training materials.
https://website.meridio.pages.dev/training

## Issue link

https://github.com/Nordix/Meridio/issues/365

## Checklist

- Purpose
    - [ ] Bug fix
    - [ ] New functionality
    - [x] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [ ] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
