### PR TITLE
proxy; TAPA connection IPs stored in IPAM using TAPA side ID as key

### DIFF
--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -149,7 +149,14 @@ func Test_SetIPContext_NSE(t *testing.T) {
 		IpamClient: ipamClient,
 	}
 
-	conn := &networkservice.Connection{}
+	conn := &networkservice.Connection{
+		Path: &networkservice.Path{
+			Index: 3,
+			PathSegments: []*networkservice.PathSegment{
+				{},
+			},
+		},
+	}
 
 	err := proxy.SetIPContext(context.TODO(), conn, networking.NSE)
 	assert.Nil(t, err)
@@ -240,6 +247,14 @@ func Test_SetIPContext_NSE_Update(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+		},
+		Path: &networkservice.Path{
+			Index: 3,
+			PathSegments: []*networkservice.PathSegment{
+				{
+					Id: "xyz",
 				},
 			},
 		},
@@ -334,6 +349,14 @@ func Test_SetIPContext_NSE_Update_New_IPs(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+		},
+		Path: &networkservice.Path{
+			Index: 3,
+			PathSegments: []*networkservice.PathSegment{
+				{
+					Id: "xyz",
 				},
 			},
 		},


### PR DESCRIPTION
## Description
TAPA connection IPs are stored in IPAM using TAPA side ID as key (i.e. the first segment path ID of NSM connection).

The goal is to make the IPs associated with a TAPA NSM connection retrievable even if the collocated Proxy POD is replaced (e.g. due to upgrade).

As a consequence the IPs for such NSM connection do not need to be replaced after the Proxy POD changes. Thus for example the old Proxy POD IP of the connection is not leaked either.

## Issue link
https://github.com/Nordix/Meridio/issues/386

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [ x Tested manually
- Introduce a breaking change
    - [x] Yes (description required)
      TAPA connections that has been up before upgrading the Proxy will get a new IP. It has been agreed that this NBC is acceptable. The effects of the NBC are the same described in https://github.com/Nordix/Meridio/issues/383, and old IPs will be leaked.
      If still considered a problem some TAPA versioning information could be introduced that would be also conveyed in the NSM request, so that the proxy could distinguish which ID/key to use. That wouldn't solve the case if application POD would be upgraded before nVIP though.
    - [ ] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
