### PR TITLE
Monitor NSM connection in TAPA to get latest local IPs 

### DIFF
--- a/pkg/ambassador/tap/conduit/conduit_test.go
+++ b/pkg/ambassador/tap/conduit/conduit_test.go
@@ -76,7 +76,7 @@ func Test_Connect_Disconnect(t *testing.T) {
 		return nil, nil
 	})
 
-	cndt, err := conduit.New(c, targetName, namespace, node, nil, nil, networkServiceClient, nil, nil, 30*time.Second)
+	cndt, err := conduit.New(c, targetName, namespace, node, nil, nil, networkServiceClient, nil, nil, nil, 30*time.Second)
 	assert.Nil(t, err)
 	assert.NotNil(t, cndt)
 	cndt.Configuration = configuration
@@ -112,7 +112,7 @@ func Test_AddStream(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	cndt, _ := conduit.New(c, targetName, namespace, node, nil, nil, nil, nil, nil, 30*time.Second)
+	cndt, _ := conduit.New(c, targetName, namespace, node, nil, nil, nil, nil, nil, nil, 30*time.Second)
 	streamRegistry := registry.New()
 	cndt.StreamManager = conduit.NewStreamManager(nil, nil, streamRegistry, fakeStreamFactory(ctrl), 0, 30*time.Second)
 
@@ -150,7 +150,7 @@ func Test_AddStream_Invalid(t *testing.T) {
 	namespace := "red"
 	node := "worker"
 
-	cndt, _ := conduit.New(c, targetName, namespace, node, nil, nil, nil, nil, nil, 30*time.Second)
+	cndt, _ := conduit.New(c, targetName, namespace, node, nil, nil, nil, nil, nil, nil, 30*time.Second)
 
 	err := cndt.AddStream(context.TODO(), s)
 	assert.NotNil(t, err)
@@ -180,7 +180,7 @@ func Test_RemoveStream(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	cndt, _ := conduit.New(c, targetName, namespace, node, nil, nil, nil, nil, nil, 30*time.Second)
+	cndt, _ := conduit.New(c, targetName, namespace, node, nil, nil, nil, nil, nil, nil, 30*time.Second)
 	streamRegistry := registry.New()
 	cndt.StreamManager = conduit.NewStreamManager(nil, nil, streamRegistry, fakeStreamFactory(ctrl), 0, 30*time.Second)
 
@@ -224,7 +224,7 @@ func Test_SetVIPs_Not_Connected(t *testing.T) {
 	targetName := "abc"
 	namespace := "red"
 	node := "worker"
-	cndt, err := conduit.New(c, targetName, namespace, node, nil, nil, nil, nil, nil, 30*time.Second)
+	cndt, err := conduit.New(c, targetName, namespace, node, nil, nil, nil, nil, nil, nil, 30*time.Second)
 	assert.Nil(t, err)
 	assert.NotNil(t, cndt)
 
@@ -319,7 +319,7 @@ func Test_SetVIPs(t *testing.T) {
 	})
 
 	// 1.
-	cndt, err := conduit.New(c, targetName, namespace, node, nil, nil, networkServiceClient, nil, nil, 30*time.Second)
+	cndt, err := conduit.New(c, targetName, namespace, node, nil, nil, networkServiceClient, nil, nil, nil, 30*time.Second)
 	assert.Nil(t, err)
 	assert.NotNil(t, cndt)
 	cndt.Configuration = configuration
@@ -418,7 +418,7 @@ func Test_LocalIPs_Switch(t *testing.T) {
 	})
 
 	// 1.
-	cndt, err := conduit.New(c, targetName, namespace, node, nil, nil, networkServiceClient, nil, nil, 30*time.Second)
+	cndt, err := conduit.New(c, targetName, namespace, node, nil, nil, networkServiceClient, nil, nil, nil, 30*time.Second)
 	assert.Nil(t, err)
 	assert.NotNil(t, cndt)
 	cndt.Configuration = configuration

--- a/pkg/ambassador/tap/tap.go
+++ b/pkg/ambassador/tap/tap.go
@@ -36,38 +36,41 @@ import (
 // Tap implements ambassadorAPI.TapServer
 type Tap struct {
 	ambassadorAPI.UnimplementedTapServer
-	TargetName           string
-	Namespace            string
-	NodeName             string
-	NetworkServiceClient networkservice.NetworkServiceClient
-	NSPServiceName       string
-	NSPServicePort       int
-	NSPEntryTimeout      time.Duration
-	NetUtils             networking.Utils
-	StreamRegistry       types.Registry
-	currentTrench        types.Trench
-	mu                   sync.Mutex
-	logger               logr.Logger
+	TargetName              string
+	Namespace               string
+	NodeName                string
+	NetworkServiceClient    networkservice.NetworkServiceClient
+	MonitorConnectionClient networkservice.MonitorConnectionClient
+	NSPServiceName          string
+	NSPServicePort          int
+	NSPEntryTimeout         time.Duration
+	NetUtils                networking.Utils
+	StreamRegistry          types.Registry
+	currentTrench           types.Trench
+	mu                      sync.Mutex
+	logger                  logr.Logger
 }
 
 func New(targetName string,
 	namespace string,
 	nodeName string,
 	networkServiceClient networkservice.NetworkServiceClient,
+	monitorConnectionClient networkservice.MonitorConnectionClient,
 	nspServiceName string,
 	nspServicePort int,
 	nspEntryTimeout time.Duration,
 	netUtils networking.Utils) (*Tap, error) {
 	tap := &Tap{
-		TargetName:           targetName,
-		NetworkServiceClient: networkServiceClient,
-		Namespace:            namespace,
-		NodeName:             nodeName,
-		NSPServiceName:       nspServiceName,
-		NSPServicePort:       nspServicePort,
-		NSPEntryTimeout:      nspEntryTimeout,
-		NetUtils:             netUtils,
-		logger:               log.Logger.WithValues("class", "Tap"),
+		TargetName:              targetName,
+		NetworkServiceClient:    networkServiceClient,
+		MonitorConnectionClient: monitorConnectionClient,
+		Namespace:               namespace,
+		NodeName:                nodeName,
+		NSPServiceName:          nspServiceName,
+		NSPServicePort:          nspServicePort,
+		NSPEntryTimeout:         nspEntryTimeout,
+		NetUtils:                netUtils,
+		logger:                  log.Logger.WithValues("class", "Tap"),
 	}
 	tap.StreamRegistry = registry.New()
 	return tap, nil
@@ -167,6 +170,7 @@ func (tap *Tap) setTrench(t *ambassadorAPI.Trench) (types.Trench, error) {
 		tap.Namespace,
 		tap.NodeName,
 		tap.NetworkServiceClient,
+		tap.MonitorConnectionClient,
 		tap.StreamRegistry,
 		tap.NSPServiceName,
 		tap.NSPServicePort,

--- a/pkg/ambassador/tap/trench/factory.go
+++ b/pkg/ambassador/tap/trench/factory.go
@@ -39,6 +39,7 @@ type conduitFactoryImpl struct {
 	Namespace                  string
 	NodeName                   string
 	ConfigurationManagerClient nspAPI.ConfigurationManagerClient
+	MonitorConnectionClient    networkservice.MonitorConnectionClient
 	TargetRegistryClient       nspAPI.TargetRegistryClient
 	NetworkServiceClient       networkservice.NetworkServiceClient
 	StreamRegistry             types.Registry
@@ -53,6 +54,7 @@ func newConduitFactoryImpl(
 	configurationManagerClient nspAPI.ConfigurationManagerClient,
 	targetRegistryClient nspAPI.TargetRegistryClient,
 	networkServiceClient networkservice.NetworkServiceClient,
+	monitorConnectionClient networkservice.MonitorConnectionClient,
 	streamRegistry types.Registry,
 	netUtils networking.Utils,
 	nspEntryTimeout time.Duration) *conduitFactoryImpl {
@@ -61,6 +63,7 @@ func newConduitFactoryImpl(
 		Namespace:                  namespace,
 		NodeName:                   nodeName,
 		ConfigurationManagerClient: configurationManagerClient,
+		MonitorConnectionClient:    monitorConnectionClient,
 		TargetRegistryClient:       targetRegistryClient,
 		NetworkServiceClient:       networkServiceClient,
 		StreamRegistry:             streamRegistry,
@@ -78,6 +81,7 @@ func (cfi *conduitFactoryImpl) New(cndt *ambassadorAPI.Conduit) (types.Conduit, 
 		cfi.ConfigurationManagerClient,
 		cfi.TargetRegistryClient,
 		cfi.NetworkServiceClient,
+		cfi.MonitorConnectionClient,
 		cfi.StreamRegistry,
 		cfi.NetUtils,
 		cfi.NSPEntryTimeout)

--- a/pkg/ambassador/tap/trench/trench.go
+++ b/pkg/ambassador/tap/trench/trench.go
@@ -35,7 +35,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 )
 
-const grpcKeepaliveTime = 10 * time.Second
+const grpcKeepaliveTime = 20 * time.Second
 
 // Trench implements types.Trench (/pkg/ambassador/tap/types)
 // Responsible for connection/disconnecting the conduits, and providing
@@ -68,6 +68,7 @@ func New(trench *ambassadorAPI.Trench,
 	namespace string,
 	nodeName string,
 	networkServiceClient networkservice.NetworkServiceClient,
+	monitorConnectionClient networkservice.MonitorConnectionClient,
 	streamRegistry types.Registry,
 	nspServiceName string,
 	nspServicePort int,
@@ -100,6 +101,7 @@ func New(trench *ambassadorAPI.Trench,
 		t.ConfigurationManagerClient,
 		t.TargetRegistryClient,
 		t.NetworkServiceClient,
+		monitorConnectionClient,
 		t.StreamRegistry,
 		t.NetUtils,
 		nspEntryTimeout)


### PR DESCRIPTION
## Description

The conduit handler in the TAPA is now monitoring the NSM connection to get the local IPs up to date. The local IPs can be updated by the proxy in case of a restart.
grpcKeepaliveTime has been increased to avoid grpc err: ENHANCE_YOUR_CALM:too_many_pings

## Issue link

https://github.com/Nordix/Meridio/issues/383
https://github.com/Nordix/Meridio/issues/159

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [x] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
