### PR TITLE
Fix VIPs used as local IPs in TAPA

### DIFF
--- a/cmd/proxy/internal/client/fullmesh.go
+++ b/cmd/proxy/internal/client/fullmesh.go
@@ -126,7 +126,7 @@ func (fmnsc *FullMeshNetworkServiceClient) addNetworkServiceClient(networkServic
 	request.Connection.NetworkServiceEndpointName = networkServiceEndpointName
 	// UUID part at the start of the conn id will be used by NSM to generate the interface name (we want it to be unique)
 	request.Connection.Id = fmt.Sprintf("%s-%s-%s-%s", uuid.New().String(), fmnsc.config.Name, request.Connection.NetworkService, request.Connection.NetworkServiceEndpointName)
-	fmnsc.logger.Info("Add endpoint", "service", networkServiceEndpointName, "id", request.Connection.NetworkService, request.Connection.Id)
+	fmnsc.logger.Info("Add endpoint", "service", networkServiceEndpointName, "NetworkService", request.Connection.NetworkService, "id", request.Connection.Id)
 
 	// Request would try forever, but what if the NetworkServiceEndpoint is removed in the meantime?
 	// The recv() method must not be blocked by a pending Request that might not ever succeed.

--- a/pkg/ambassador/tap/conduit/conduit_test.go
+++ b/pkg/ambassador/tap/conduit/conduit_test.go
@@ -253,7 +253,7 @@ func Test_SetVIPs(t *testing.T) {
 	targetName := "abc"
 	namespace := "red"
 	node := "worker"
-	vips := []string{"20.0.0.1/32", "[2000::1]/128"}
+	vips := []string{"20.0.0.1/32", "2000::1/128"}
 	srcIpAddrs := []string{"172.16.0.1/24", "fd00::1/64"}
 	dstIpAddrs := []string{"172.16.0.2/24", "fd00::2/64"}
 	extraPrefixes := []string{"172.16.0.100/24", "fd00::100/64"}
@@ -286,10 +286,10 @@ func Test_SetVIPs(t *testing.T) {
 		assert.NotNil(t, in.GetConnection().GetContext())
 		ipContext := in.GetConnection().GetContext().GetIpContext()
 		assert.NotNil(t, ipContext)
-		assert.Equal(t, dstIpAddrs, ipContext.DstIpAddrs)
-		assert.Equal(t, append(srcIpAddrs, vips...), ipContext.SrcIpAddrs)
+		assert.ElementsMatch(t, dstIpAddrs, ipContext.DstIpAddrs)
+		assert.ElementsMatch(t, append(srcIpAddrs, vips...), ipContext.SrcIpAddrs)
 		assert.Len(t, ipContext.Policies, 2)
-		assert.Equal(t, []*networkservice.PolicyRoute{
+		assert.ElementsMatch(t, []*networkservice.PolicyRoute{
 			{
 				From: "20.0.0.1/32",
 				Routes: []*networkservice.Route{
@@ -300,7 +300,7 @@ func Test_SetVIPs(t *testing.T) {
 				},
 			},
 			{
-				From: "[2000::1]/128",
+				From: "2000::1/128",
 				Routes: []*networkservice.Route{
 					{
 						Prefix:  "::/0",
@@ -365,7 +365,7 @@ func Test_LocalIPs_Switch(t *testing.T) {
 	targetName := "abc"
 	namespace := "red"
 	node := "worker"
-	vips := []string{"20.0.0.1/32", "[2000::1]/128"}
+	vips := []string{"20.0.0.1/32", "2000::1/128"}
 	srcIpAddrs := []string{"172.16.0.1/24", "fd00::1/64"}
 	dstIpAddrs := []string{"172.16.0.2/24", "fd00::2/64"}
 	extraPrefixes := []string{"172.16.0.100/24", "fd00::100/64"}
@@ -402,8 +402,8 @@ func Test_LocalIPs_Switch(t *testing.T) {
 		assert.NotNil(t, in.GetConnection().GetContext())
 		ipContext := in.GetConnection().GetContext().GetIpContext()
 		assert.NotNil(t, ipContext)
-		assert.Equal(t, dstIpAddrs, ipContext.DstIpAddrs)
-		assert.Equal(t, append(srcIpAddrs, vips...), ipContext.SrcIpAddrs)
+		assert.ElementsMatch(t, dstIpAddrs, ipContext.DstIpAddrs)
+		assert.ElementsMatch(t, append(srcIpAddrs, vips...), ipContext.SrcIpAddrs)
 		assert.Len(t, ipContext.Policies, 2)
 		ipContext.DstIpAddrs = dstIpAddrs2
 		ipContext.SrcIpAddrs = srcIpAddrs2


### PR DESCRIPTION
## Description

Due to the implementation of the NSM monitor connections in the TAPA, the split between local IPs and VIP addresses was not good enough, so the TAPA was registering itself with some VIP + local IPs.

## Issue link

https://github.com/Nordix/Meridio/pull/387

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [x] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
- Introduce changes in the Operator 
    - [ ] Yes (description required)
    - [x] No
