### PR TITLE
Fix CVE-2023-24535

### DIFF
--- a/build/base-image/Dockerfile
+++ b/build/base-image/Dockerfile
@@ -4,5 +4,5 @@ RUN apk update && apk add iproute2 tcpdump iputils net-tools libcap \
   && setcap 'cap_sys_ptrace,cap_dac_override+ep' /bin/netstat \
   && setcap 'cap_net_raw+ep' /bin/ping \
   && setcap 'cap_net_raw+ep' /usr/bin/tcpdump
-ADD https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.16/grpc_health_probe-linux-amd64 /bin/grpc_health_probe
+ADD https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.17/grpc_health_probe-linux-amd64 /bin/grpc_health_probe
 RUN chmod a+x /bin/grpc_health_probe


### PR DESCRIPTION
## Description

Update google.golang.org/protobuf to v1.30.0.

https://github.com/grpc-ecosystem/grpc-health-probe has to be fixed: https://github.com/grpc-ecosystem/grpc-health-probe/pull/138 (Waiting for a release).

## Issue link

https://jenkins.nordix.org/job/meridio-periodic-security-scan/180/artifact/_output/report.txt
https://github.com/advisories/GHSA-hw7c-3rfg-p46j

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [ ] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
