### PR TITLE
Stateless-lb: Disable old interfaces with same subnet as new

### DIFF
--- a/pkg/kernel/interface.go
+++ b/pkg/kernel/interface.go
@@ -27,7 +27,7 @@ import (
 
 type Interface struct {
 	index         int
-	name          string
+	Name          string
 	LocalIPs      []string
 	NeighborIPs   []string
 	Gateways      []string
@@ -43,14 +43,13 @@ func (intf *Interface) GetIndex() int {
 }
 
 func (intf *Interface) GetName() string {
-	if intf.name != "" {
-		return intf.name
+	if intf.Name == "" {
+		i, err := intf.getLink()
+		if err == nil {
+			intf.Name = i.Attrs().Name
+		}
 	}
-	i, err := intf.getLink()
-	if err != nil {
-		return ""
-	}
-	return i.Attrs().Name
+	return intf.Name
 }
 
 func (intf *Interface) GetLocalPrefixes() []string {
@@ -129,7 +128,7 @@ func NewInterface(index int, options ...InterfaceOption) *Interface {
 	}
 	intf := &Interface{
 		index:         index,
-		name:          opts.name,
+		Name:          opts.name,
 		LocalIPs:      []string{},
 		NeighborIPs:   []string{},
 		Gateways:      []string{},


### PR DESCRIPTION
## Description

When a new interface is detected any existing interface with the same subnet is disabled

## Issue link

https://github.com/Nordix/Meridio/issues/392

# Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [ ] No
