### PR TITLE
Keepalive on grpc connections

### DIFF
--- a/cmd/frontend/internal/env/config.go
+++ b/cmd/frontend/internal/env/config.go
@@ -39,4 +39,5 @@ type Config struct {
 	AttractorName         string        `default:"default" desc:"Name of the Attractor the frontend is associated with" split_words:"true"`
 	LogLevel              string        `default:"DEBUG" desc:"Log level" split_words:"true"`
 	NSPEntryTimeout       time.Duration `default:"30s" desc:"Timeout of the entries" envconfig:"nsp_entry_timeout"`
+	GRPCKeepaliveTime     time.Duration `default:"30s" desc:"gRPC keepalive timeout"`
 }

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kelseyhightower/envconfig"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 
 	nspAPI "github.com/nordix/meridio/api/nsp/v1"
 	feConfig "github.com/nordix/meridio/cmd/frontend/internal/config"
@@ -98,7 +99,11 @@ func main() {
 		),
 		grpc.WithDefaultCallOptions(
 			grpc.WaitForReady(true),
-		))
+		),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time: config.GRPCKeepaliveTime,
+		}),
+	)
 	if err != nil {
 		log.Fatal(logger, "Dial NSP", "error", err)
 	}

--- a/cmd/ipam/config.go
+++ b/cmd/ipam/config.go
@@ -16,18 +16,21 @@ limitations under the License.
 
 package main
 
+import "time"
+
 // Config for the ipam
 type Config struct {
-	Port                    int    `default:"7777" desc:"Trench the pod is running on" split_words:"true"`
-	Datasource              string `default:"/run/ipam/data/registry.db" desc:"Path and file name of the sqlite database" split_words:"true"`
-	TrenchName              string `default:"default" desc:"Trench the pod is running on" split_words:"true"`
-	NSPService              string `default:"nsp-service:7778" desc:"IP (or domain) and port of the NSP Service" split_words:"true"`
-	PrefixIPv4              string `default:"169.255.0.0/16" desc:"ipv4 prefix from which the proxy prefixes will be allocated" envconfig:"prefix_ipv4"`
-	ConduitPrefixLengthIPv4 int    `default:"20" desc:"conduit prefix length which will be allocated" envconfig:"conduit_prefix_length_ipv4"`
-	NodePrefixLengthIPv4    int    `default:"24" desc:"node prefix length which will be allocated" envconfig:"node_prefix_length_ipv4"`
-	PrefixIPv6              string `default:"fd00::/48" desc:"ipv4 prefix from which the proxy prefixes will be allocated" envconfig:"prefix_ipv6"`
-	ConduitPrefixLengthIPv6 int    `default:"56" desc:"conduit prefix length which will be allocated" envconfig:"conduit_prefix_length_ipv6"`
-	NodePrefixLengthIPv6    int    `default:"64" desc:"node prefix length which will be allocated" envconfig:"node_prefix_length_ipv6"`
-	IPFamily                string `default:"dualstack" desc:"ip family" envconfig:"ip_family"`
-	LogLevel                string `default:"DEBUG" desc:"Log level" split_words:"true"`
+	Port                    int           `default:"7777" desc:"Trench the pod is running on" split_words:"true"`
+	Datasource              string        `default:"/run/ipam/data/registry.db" desc:"Path and file name of the sqlite database" split_words:"true"`
+	TrenchName              string        `default:"default" desc:"Trench the pod is running on" split_words:"true"`
+	NSPService              string        `default:"nsp-service:7778" desc:"IP (or domain) and port of the NSP Service" split_words:"true"`
+	PrefixIPv4              string        `default:"169.255.0.0/16" desc:"ipv4 prefix from which the proxy prefixes will be allocated" envconfig:"prefix_ipv4"`
+	ConduitPrefixLengthIPv4 int           `default:"20" desc:"conduit prefix length which will be allocated" envconfig:"conduit_prefix_length_ipv4"`
+	NodePrefixLengthIPv4    int           `default:"24" desc:"node prefix length which will be allocated" envconfig:"node_prefix_length_ipv4"`
+	PrefixIPv6              string        `default:"fd00::/48" desc:"ipv4 prefix from which the proxy prefixes will be allocated" envconfig:"prefix_ipv6"`
+	ConduitPrefixLengthIPv6 int           `default:"56" desc:"conduit prefix length which will be allocated" envconfig:"conduit_prefix_length_ipv6"`
+	NodePrefixLengthIPv6    int           `default:"64" desc:"node prefix length which will be allocated" envconfig:"node_prefix_length_ipv6"`
+	IPFamily                string        `default:"dualstack" desc:"ip family" envconfig:"ip_family"`
+	LogLevel                string        `default:"DEBUG" desc:"Log level" split_words:"true"`
+	GRPCKeepaliveTime       time.Duration `default:"30s" desc:"gRPC keepalive timeout"`
 }

--- a/cmd/ipam/main.go
+++ b/cmd/ipam/main.go
@@ -41,6 +41,7 @@ import (
 	"google.golang.org/grpc"
 	grpcHealth "google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
 )
 
 func printHelp() {
@@ -106,7 +107,11 @@ func main() {
 		),
 		grpc.WithDefaultCallOptions(
 			grpc.WaitForReady(true),
-		))
+		),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time: config.GRPCKeepaliveTime,
+		}),
+	)
 	if err != nil {
 		log.Fatal(logger, "Dial NSP err", "error", err)
 	}

--- a/cmd/proxy/internal/config/config.go
+++ b/cmd/proxy/internal/config/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	IPFamily           string        `default:"dualstack" desc:"ip family" envconfig:"ip_family"`
 	LogLevel           string        `default:"DEBUG" desc:"Log level" split_words:"true"`
 	MTU                int           `default:"1500" desc:"Conduit MTU considered by local NSCs and NSE composing the network mesh" split_words:"true"`
+	GRPCKeepaliveTime  time.Duration `default:"30s" desc:"gRPC keepalive timeout"`
 }
 
 // IsValid checks if the configuration is valid

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -48,6 +48,7 @@ import (
 	"github.com/nordix/meridio/pkg/security/credentials"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 )
 
 func printHelp() {
@@ -131,7 +132,11 @@ func main() {
 		),
 		grpc.WithDefaultCallOptions(
 			grpc.WaitForReady(true),
-		))
+		),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time: config.GRPCKeepaliveTime,
+		}),
+	)
 	if err != nil {
 		log.Fatal(logger, "Dialing IPAM", "error", err)
 	}
@@ -205,7 +210,11 @@ func main() {
 		),
 		grpc.WithDefaultCallOptions(
 			grpc.WaitForReady(true),
-		))
+		),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time: config.GRPCKeepaliveTime,
+		}),
+	)
 	if err != nil {
 		log.Fatal(logger, "Dialing NSP", "error", err)
 	}

--- a/cmd/stateless-lb/config.go
+++ b/cmd/stateless-lb/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	Nfqueue               string        `default:"0:3" desc:"netfilter queue(s) to be used by nfqlb" split_words:"true"`
 	NfqueueFanout         bool          `default:"false" desc:"enable fanout nfqueue option" split_words:"true"`
 	IdentifierOffsetStart int           `default:"5000" desc:"Each Stream will get a unique identifier range starting from that value" split_words:"true"`
+	GRPCKeepaliveTime     time.Duration `default:"30s" desc:"gRPC keepalive timeout"`
 }
 
 // IsValid checks if the configuration is valid

--- a/cmd/stateless-lb/main.go
+++ b/cmd/stateless-lb/main.go
@@ -59,6 +59,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 )
 
 func printHelp() {
@@ -131,7 +132,11 @@ func main() {
 		),
 		grpc.WithDefaultCallOptions(
 			grpc.WaitForReady(true),
-		))
+		),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time: config.GRPCKeepaliveTime,
+		}),
+	)
 	if err != nil {
 		log.Fatal(logger, "Dial NSP", "error", err)
 	}


### PR DESCRIPTION
## Description

Add keepalive setting for grpc connections towards NSP and IPAM improving the time for connection to be re-established after a failure.

https://www.evanjones.ca/tcp-connection-timeouts.html

## Issue link

https://github.com/Nordix/Meridio/issues/355

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
