### PR TITLE
Log: disable the Sample function

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -127,6 +127,7 @@ func newLogger(level string) logr.Logger {
 	zc.EncoderConfig.EncodeTime = timeEncoder
 	zc.EncoderConfig.EncodeLevel = levelEncoder
 	zc.Encoding = "json"
+	zc.Sampling = nil
 	zc.OutputPaths = []string{"stdout"}
 	z, err := zc.Build()
 	if err != nil {


### PR DESCRIPTION
## Description

The "Sample" function in the zap logger is enabled by default. We are not using it, and it consumes a lot of memory, ~>50%~ 20-30% of heap mem in TAPA for instance.

## Issue link

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [ ] No
