### PR TITLE
fe; timeout for external connectivity announcements

### DIFF
--- a/cmd/frontend/internal/frontend/notify.go
+++ b/cmd/frontend/internal/frontend/notify.go
@@ -36,16 +36,14 @@ import (
 // Note: Currently IPv4/IPv6 connectivity is not separated, as IPv4/IPv6 handling is not properly
 // separated in Meridio when managing the NSM backplane either.
 
-// TODO: add context to nspClient calls so that they could be cancelled
-// TODO: must denounce FE upon its shutdown (make sure it won't block forever e.g. in case NSP is no longer available)
 // TODO: maybe introduce update target through new context keyword, indicating nsp to replace found item with new one
-func announceFrontend(targetRegistryClient nspAPI.TargetRegistryClient) error {
+func announceFrontend(ctx context.Context, targetRegistryClient nspAPI.TargetRegistryClient) error {
 	hn, _ := os.Hostname()
 	targetContext := map[string]string{
 		types.IdentifierKey: hn,
 	}
 	log.Logger.V(2).Info("Announce frontend", "hostname", hn, "targetType", nspAPI.Target_FRONTEND)
-	_, err := targetRegistryClient.Register(context.Background(), &nspAPI.Target{
+	_, err := targetRegistryClient.Register(ctx, &nspAPI.Target{
 		Ips:     []string{hn},
 		Type:    nspAPI.Target_FRONTEND,
 		Context: targetContext,
@@ -56,13 +54,13 @@ func announceFrontend(targetRegistryClient nspAPI.TargetRegistryClient) error {
 	return nil
 }
 
-func denounceFrontend(targetRegistryClient nspAPI.TargetRegistryClient) error {
+func denounceFrontend(ctx context.Context, targetRegistryClient nspAPI.TargetRegistryClient) error {
 	hn, _ := os.Hostname()
 	targetContext := map[string]string{
 		types.IdentifierKey: hn,
 	}
 	log.Logger.Info("Denounce frontend", "hostname", hn, "targetType", nspAPI.Target_FRONTEND)
-	_, err := targetRegistryClient.Unregister(context.Background(), &nspAPI.Target{
+	_, err := targetRegistryClient.Unregister(ctx, &nspAPI.Target{
 		Ips:     []string{hn},
 		Type:    nspAPI.Target_FRONTEND,
 		Context: targetContext,

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3
 	github.com/golang/mock v1.6.0
+	github.com/golang/protobuf v1.5.3
 	github.com/google/nftables v0.1.0
 	github.com/google/uuid v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
@@ -66,7 +67,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/pkg/retry/config.go
+++ b/pkg/retry/config.go
@@ -19,6 +19,8 @@ package retry
 import (
 	"context"
 	"time"
+
+	"github.com/go-logr/logr"
 )
 
 // RetryTrigger is the function definition specifying when the Do
@@ -33,6 +35,7 @@ type Config struct {
 	context            context.Context
 	retryTriggerFunc   RetryTrigger
 	retryConditionFunc RetryCondition
+	logger             *logr.Logger
 }
 
 func newConfig() *Config {

--- a/pkg/retry/option.go
+++ b/pkg/retry/option.go
@@ -19,6 +19,8 @@ package retry
 import (
 	"context"
 	"time"
+
+	"github.com/go-logr/logr"
 )
 
 type Option func(*Config)
@@ -73,4 +75,11 @@ func WithErrorIngnored() Option {
 	return WithRetryCondition(func(err error) bool {
 		return true
 	})
+}
+
+// WithLogger sets a logger to log error return of the retryableFunc.
+func WithLogger(logger *logr.Logger) Option {
+	return func(c *Config) {
+		c.logger = logger
+	}
 }

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -47,6 +47,9 @@ retry:
 		err := retryableFunc()
 
 		if err != nil {
+			if config.logger != nil {
+				(*config.logger).Info("retryable function failed", "error", err)
+			}
 			errFinal = fmt.Errorf("%w; %v", errFinal, err) // todo
 		}
 


### PR DESCRIPTION
## Description
In FE RPCs block due to WaitForReady() option.
Use context with timeout when calling announcements.

Allow retry pkg to log errors when calling the retryable function (when used with retry.WithErrorIngnored()).

## Issue link
NA

## Checklist

- Purpose
    - [ ] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [x] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
