### PR TITLE
Frontend: Cleanup Monitor() function

### DIFF
--- a/cmd/frontend/internal/env/config.go
+++ b/cmd/frontend/internal/env/config.go
@@ -40,4 +40,7 @@ type Config struct {
 	LogLevel              string        `default:"DEBUG" desc:"Log level" split_words:"true"`
 	NSPEntryTimeout       time.Duration `default:"30s" desc:"Timeout of the entries" envconfig:"nsp_entry_timeout"`
 	GRPCKeepaliveTime     time.Duration `default:"30s" desc:"gRPC keepalive timeout"`
+	DelayConnectivity     time.Duration `default:"1s" desc:"Delay between checks with connectivity"`
+	DelayNoConnectivity   time.Duration `default:"3s" desc:"Delay between checks without connectivity"`
+	MaxSessionErrors      int           `default:"5" desc:"Max session errors when checking Bird until denounce"`
 }

--- a/cmd/frontend/internal/frontend/notify.go
+++ b/cmd/frontend/internal/frontend/notify.go
@@ -36,39 +36,34 @@ import (
 // Note: Currently IPv4/IPv6 connectivity is not separated, as IPv4/IPv6 handling is not properly
 // separated in Meridio when managing the NSM backplane either.
 
-// TODO: add context to nspClient calls so that they could be cancelled
 // TODO: must denounce FE upon its shutdown (make sure it won't block forever e.g. in case NSP is no longer available)
 // TODO: maybe introduce update target through new context keyword, indicating nsp to replace found item with new one
-func announceFrontend(targetRegistryClient nspAPI.TargetRegistryClient) error {
+func announceFrontend(ctx context.Context, targetRegistryClient nspAPI.TargetRegistryClient) error {
 	hn, _ := os.Hostname()
 	targetContext := map[string]string{
 		types.IdentifierKey: hn,
 	}
-	log.Logger.V(2).Info("Announce frontend", "hostname", hn, "targetType", nspAPI.Target_FRONTEND)
-	_, err := targetRegistryClient.Register(context.Background(), &nspAPI.Target{
+	logger := log.FromContextOrGlobal(ctx)
+	logger.V(2).Info("Announce frontend", "hostname", hn, "targetType", nspAPI.Target_FRONTEND)
+	_, err := targetRegistryClient.Register(ctx, &nspAPI.Target{
 		Ips:     []string{hn},
 		Type:    nspAPI.Target_FRONTEND,
 		Context: targetContext,
 	})
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
-func denounceFrontend(targetRegistryClient nspAPI.TargetRegistryClient) error {
+func denounceFrontend(ctx context.Context, targetRegistryClient nspAPI.TargetRegistryClient) error {
 	hn, _ := os.Hostname()
 	targetContext := map[string]string{
 		types.IdentifierKey: hn,
 	}
-	log.Logger.Info("Denounce frontend", "hostname", hn, "targetType", nspAPI.Target_FRONTEND)
-	_, err := targetRegistryClient.Unregister(context.Background(), &nspAPI.Target{
+	logger := log.FromContextOrGlobal(ctx)
+	logger.Info("Denounce frontend", "hostname", hn, "targetType", nspAPI.Target_FRONTEND)
+	_, err := targetRegistryClient.Unregister(ctx, &nspAPI.Target{
 		Ips:     []string{hn},
 		Type:    nspAPI.Target_FRONTEND,
 		Context: targetContext,
 	})
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }


### PR DESCRIPTION
## Description

There seems to be a bug in here somewhere. But I couldn't follow all logic so I made a general cleanup.

One thing that might have been a bug is the "break" in
https://github.com/Nordix/Meridio/blob/60a45b5a8254ada9843466871abccc62eb9f1f30/cmd/frontend/internal/frontend/service.go#L314

The Monitor can exit more or less silently and announceFe will not be called in intervals ever after.

## Issue link

May fix the NSP-FE issue described in https://github.com/Nordix/Meridio/issues/355#issuecomment-1514477574

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [x] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
