### PR TITLE
Allow multi NAD in attractor

### DIFF
--- a/api/v1/attractor_webhook.go
+++ b/api/v1/attractor_webhook.go
@@ -117,10 +117,6 @@ func (r *Attractor) validateAttractor() error {
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec").Child("ipv6-prefix"), "not supported for type"))
 		}
 
-		if len(r.Spec.Interface.NetworkAttachments) != 1 {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("interface").Child("multus-interface"),
-				r.Spec.Interface.NetworkAttachments, "single Network Attachment item required"))
-		}
 		for _, na := range r.Spec.Interface.NetworkAttachments {
 			if na.Name == "" {
 				allErrs = append(allErrs, field.Required(field.NewPath("spec").Child("interface").Child("network-attachments").Child("name"),

--- a/pkg/controllers/attractor/stateless-lb-frontend.go
+++ b/pkg/controllers/attractor/stateless-lb-frontend.go
@@ -90,22 +90,13 @@ func (l *LoadBalancer) getNscEnvVars(allEnv []corev1.EnvVar) []corev1.EnvVar {
 
 func (l *LoadBalancer) getFeEnvVars(allEnv []corev1.EnvVar) []corev1.EnvVar {
 	operatorEnv := map[string]string{
-		"NFE_CONFIG_MAP_NAME": common.ConfigMapName(l.trench),
-		"NFE_NSP_SERVICE":     common.NSPServiceWithPort(l.trench),
-		"NFE_TRENCH_NAME":     l.trench.ObjectMeta.Name,
-		"NFE_ATTRACTOR_NAME":  l.attractor.ObjectMeta.Name,
-		"NFE_NAMESPACE":       l.attractor.ObjectMeta.Namespace,
-		"NFE_EXTERNAL_INTERFACE": func() string {
-			externalInterface := l.attractor.Spec.Interface.Name
-			// if set use the interface provided by the Network Attachment
-			if l.attractor.Spec.Interface.Type == meridiov1.NAD &&
-				len(l.attractor.Spec.Interface.NetworkAttachments) == 1 &&
-				l.attractor.Spec.Interface.NetworkAttachments[0].InterfaceRequest != "" {
-				externalInterface = l.attractor.Spec.Interface.NetworkAttachments[0].InterfaceRequest
-			}
-			return externalInterface
-		}(),
-		"NFE_LOG_LEVEL": common.GetLogLevel(),
+		"NFE_CONFIG_MAP_NAME":    common.ConfigMapName(l.trench),
+		"NFE_NSP_SERVICE":        common.NSPServiceWithPort(l.trench),
+		"NFE_TRENCH_NAME":        l.trench.ObjectMeta.Name,
+		"NFE_ATTRACTOR_NAME":     l.attractor.ObjectMeta.Name,
+		"NFE_NAMESPACE":          l.attractor.ObjectMeta.Namespace,
+		"NFE_EXTERNAL_INTERFACE": l.attractor.Spec.Interface.Name,
+		"NFE_LOG_LEVEL":          common.GetLogLevel(),
 	}
 	return common.CompileEnvironmentVariables(allEnv, operatorEnv)
 }
@@ -114,10 +105,6 @@ func (l *LoadBalancer) getFeEnvVars(allEnv []corev1.EnvVar) []corev1.EnvVar {
 // Currently a single Network Attachment is supported, but the code can be easily extended
 // to support multiple.
 func (l *LoadBalancer) insertNetworkAnnotation(dep *appsv1.Deployment) error {
-	if len(l.attractor.Spec.Interface.NetworkAttachments) != 1 {
-		return fmt.Errorf("required one network attachment")
-	}
-
 	if dep.Spec.Template.ObjectMeta.Annotations == nil {
 		dep.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 	}


### PR DESCRIPTION
## Description

Multi NAD allows multiple network interfaces to be added to the attractor pods. The feature is already developed, only some conditions prevented its usage.
The interface name that will be injected in the frontend via the environment variable will be the one specified in the attractor specs

## Issue link

/

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
