### PR TITLE
Adjust rpc-timeout of gRPC probes

### DIFF
--- a/cmd/ipam/config.go
+++ b/cmd/ipam/config.go
@@ -33,4 +33,5 @@ type Config struct {
 	IPFamily                string        `default:"dualstack" desc:"ip family" envconfig:"ip_family"`
 	LogLevel                string        `default:"DEBUG" desc:"Log level" split_words:"true"`
 	GRPCKeepaliveTime       time.Duration `default:"30s" desc:"gRPC keepalive timeout"`
+	GRPCProbeRPCTimeout     time.Duration `default:"1s" desc:"RPC timeout of internal gRPC health probe" envconfig:"grpc_probe_rpc_timeout"`
 }

--- a/cmd/ipam/main.go
+++ b/cmd/ipam/main.go
@@ -158,7 +158,13 @@ func main() {
 	}
 
 	// internal probe checking health of IPAM server
-	probe.CreateAndRunGRPCHealthProbe(ctx, health.IPAMSvc, probe.WithAddress(fmt.Sprintf(":%d", config.Port)), probe.WithSpiffe())
+	probe.CreateAndRunGRPCHealthProbe(
+		ctx,
+		health.IPAMSvc,
+		probe.WithAddress(fmt.Sprintf(":%d", config.Port)),
+		probe.WithSpiffe(),
+		probe.WithRPCTimeout(config.GRPCProbeRPCTimeout.String()),
+	)
 
 	if err := startServer(ctx, server, listener); err != nil {
 		logger.Error(err, "IPAM Service: failed to serve: %v")

--- a/cmd/proxy/internal/config/config.go
+++ b/cmd/proxy/internal/config/config.go
@@ -25,24 +25,25 @@ import (
 
 // Config for the proxy
 type Config struct {
-	Name               string        `default:"proxy" desc:"Pod Name"`
-	ServiceName        string        `default:"proxy" desc:"Name of the Network Service" split_words:"true"`
-	ConnectTo          url.URL       `default:"unix:///var/lib/networkservicemesh/nsm.io.sock" desc:"url to connect to NSM" split_words:"true"`
-	DialTimeout        time.Duration `default:"5s" desc:"timeout to dial NSMgr" split_words:"true"`
-	RequestTimeout     time.Duration `default:"15s" desc:"timeout to request NSE" split_words:"true"`
-	MaxTokenLifetime   time.Duration `default:"24h" desc:"maximum lifetime of tokens" split_words:"true"`
-	IPAMService        string        `default:"ipam-service:7777" desc:"IP (or domain) and port of the IPAM Service" split_words:"true"`
-	Host               string        `default:"" desc:"Host name the proxy is running on" split_words:"true"`
-	NetworkServiceName string        `default:"load-balancer" desc:"Name of the network service the proxy request the connection" split_words:"true"`
-	Namespace          string        `default:"default" desc:"Namespace the pod is running on" split_words:"true"`
-	Trench             string        `default:"default" desc:"Trench the pod is running on" split_words:"true"`
-	Conduit            string        `default:"load-balancer" desc:"Name of the conduit" split_words:"true"`
-	NSPServiceName     string        `default:"nsp-service" desc:"IP (or domain) of the NSP Service" split_words:"true"`
-	NSPServicePort     int           `default:"7778" desc:"port of the NSP Service" split_words:"true"`
-	IPFamily           string        `default:"dualstack" desc:"ip family" envconfig:"ip_family"`
-	LogLevel           string        `default:"DEBUG" desc:"Log level" split_words:"true"`
-	MTU                int           `default:"1500" desc:"Conduit MTU considered by local NSCs and NSE composing the network mesh" split_words:"true"`
-	GRPCKeepaliveTime  time.Duration `default:"30s" desc:"gRPC keepalive timeout"`
+	Name                string        `default:"proxy" desc:"Pod Name"`
+	ServiceName         string        `default:"proxy" desc:"Name of the Network Service" split_words:"true"`
+	ConnectTo           url.URL       `default:"unix:///var/lib/networkservicemesh/nsm.io.sock" desc:"url to connect to NSM" split_words:"true"`
+	DialTimeout         time.Duration `default:"5s" desc:"timeout to dial NSMgr" split_words:"true"`
+	RequestTimeout      time.Duration `default:"15s" desc:"timeout to request NSE" split_words:"true"`
+	MaxTokenLifetime    time.Duration `default:"24h" desc:"maximum lifetime of tokens" split_words:"true"`
+	IPAMService         string        `default:"ipam-service:7777" desc:"IP (or domain) and port of the IPAM Service" split_words:"true"`
+	Host                string        `default:"" desc:"Host name the proxy is running on" split_words:"true"`
+	NetworkServiceName  string        `default:"load-balancer" desc:"Name of the network service the proxy request the connection" split_words:"true"`
+	Namespace           string        `default:"default" desc:"Namespace the pod is running on" split_words:"true"`
+	Trench              string        `default:"default" desc:"Trench the pod is running on" split_words:"true"`
+	Conduit             string        `default:"load-balancer" desc:"Name of the conduit" split_words:"true"`
+	NSPServiceName      string        `default:"nsp-service" desc:"IP (or domain) of the NSP Service" split_words:"true"`
+	NSPServicePort      int           `default:"7778" desc:"port of the NSP Service" split_words:"true"`
+	IPFamily            string        `default:"dualstack" desc:"ip family" envconfig:"ip_family"`
+	LogLevel            string        `default:"DEBUG" desc:"Log level" split_words:"true"`
+	MTU                 int           `default:"1500" desc:"Conduit MTU considered by local NSCs and NSE composing the network mesh" split_words:"true"`
+	GRPCKeepaliveTime   time.Duration `default:"30s" desc:"gRPC keepalive timeout"`
+	GRPCProbeRPCTimeout time.Duration `default:"1s" desc:"RPC timeout of internal gRPC health probe" envconfig:"grpc_probe_rpc_timeout"`
 }
 
 // IsValid checks if the configuration is valid

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -197,7 +197,13 @@ func main() {
 		}
 	}()
 	// internal probe checking health of NSE
-	probe.CreateAndRunGRPCHealthProbe(signalCtx, health.NSMEndpointSvc, probe.WithAddress(ep.Server.GetUrl()), probe.WithSpiffe())
+	probe.CreateAndRunGRPCHealthProbe(
+		signalCtx,
+		health.NSMEndpointSvc,
+		probe.WithAddress(ep.Server.GetUrl()),
+		probe.WithSpiffe(),
+		probe.WithRPCTimeout(config.GRPCProbeRPCTimeout.String()),
+	)
 
 	// connect NSP and start watching config events of interest
 	configurationContext, configurationCancel := context.WithCancel(signalCtx)

--- a/cmd/stateless-lb/config.go
+++ b/cmd/stateless-lb/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	NfqueueFanout         bool          `default:"false" desc:"enable fanout nfqueue option" split_words:"true"`
 	IdentifierOffsetStart int           `default:"5000" desc:"Each Stream will get a unique identifier range starting from that value" split_words:"true"`
 	GRPCKeepaliveTime     time.Duration `default:"30s" desc:"gRPC keepalive timeout"`
+	GRPCProbeRPCTimeout   time.Duration `default:"1s" desc:"RPC timeout of internal gRPC health probe" envconfig:"grpc_probe_rpc_timeout"`
 }
 
 // IsValid checks if the configuration is valid

--- a/cmd/stateless-lb/main.go
+++ b/cmd/stateless-lb/main.go
@@ -223,7 +223,13 @@ func main() {
 		log.Fatal(logger, "Unable to start nse", "error", err)
 	}
 
-	probe.CreateAndRunGRPCHealthProbe(ctx, health.NSMEndpointSvc, probe.WithAddress(ep.GetUrl()), probe.WithSpiffe())
+	probe.CreateAndRunGRPCHealthProbe(
+		ctx,
+		health.NSMEndpointSvc,
+		probe.WithAddress(ep.GetUrl()),
+		probe.WithSpiffe(),
+		probe.WithRPCTimeout(config.GRPCProbeRPCTimeout.String()),
+	)
 
 	ctx = lbFactory.Start(ctx) // start nfqlb process in background
 	sns.Start()

--- a/config/operator/operator.yaml
+++ b/config/operator/operator.yaml
@@ -55,6 +55,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: GRPC_PROBE_RPC_TIMEOUT
+            value: "1s"
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/config/templates/charts/meridio/deployment/ipam.yaml
+++ b/config/templates/charts/meridio/deployment/ipam.yaml
@@ -32,8 +32,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
+                - -connect-timeout=400ms
+                - -rpc-timeout=400ms
             initialDelaySeconds: 0
             periodSeconds: 2
             timeoutSeconds: 2
@@ -45,8 +45,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=Readiness
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
+                - -connect-timeout=400ms
+                - -rpc-timeout=400ms
             failureThreshold: 5
             initialDelaySeconds: 0
             periodSeconds: 10
@@ -58,10 +58,10 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
+                - -connect-timeout=400ms
+                - -rpc-timeout=400ms
             failureThreshold: 5
-            initialDelaySeconds: 0
+            initialDelaySeconds: 2
             periodSeconds: 10
             timeoutSeconds: 3
             successThreshold: 1

--- a/config/templates/charts/meridio/deployment/nse-vlan.yaml
+++ b/config/templates/charts/meridio/deployment/nse-vlan.yaml
@@ -36,8 +36,8 @@ spec:
                 - -spiffe
                 - -addr=:5003
                 - -service=
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
+                - -connect-timeout=400ms
+                - -rpc-timeout=1s
             initialDelaySeconds: 0
             periodSeconds: 2
             timeoutSeconds: 2
@@ -50,8 +50,8 @@ spec:
                 - -spiffe
                 - -addr=:5003
                 - -service=
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
+                - -connect-timeout=400ms
+                - -rpc-timeout=1s
             initialDelaySeconds: 0
             periodSeconds: 10
             timeoutSeconds: 3
@@ -64,9 +64,9 @@ spec:
                 - -spiffe
                 - -addr=:5003
                 - -service=
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
-            initialDelaySeconds: 0
+                - -connect-timeout=400ms
+                - -rpc-timeout=1s
+            initialDelaySeconds: 2
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 5

--- a/config/templates/charts/meridio/deployment/nsp.yaml
+++ b/config/templates/charts/meridio/deployment/nsp.yaml
@@ -33,8 +33,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
+                - -connect-timeout=400ms
+                - -rpc-timeout=400ms
             initialDelaySeconds: 0
             periodSeconds: 2
             timeoutSeconds: 2
@@ -47,8 +47,8 @@ spec:
                 - -spiffe
                 - -addr=:7778
                 - -service=
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
+                - -connect-timeout=400ms
+                - -rpc-timeout=1s
             failureThreshold: 5
             initialDelaySeconds: 0
             periodSeconds: 10
@@ -60,10 +60,10 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
+                - -connect-timeout=400ms
+                - -rpc-timeout=400ms
             failureThreshold: 5
-            initialDelaySeconds: 0
+            initialDelaySeconds: 2
             periodSeconds: 10
             timeoutSeconds: 3
             successThreshold: 1

--- a/config/templates/charts/meridio/deployment/proxy.yaml
+++ b/config/templates/charts/meridio/deployment/proxy.yaml
@@ -35,8 +35,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
+                - -connect-timeout=400ms
+                - -rpc-timeout=400ms
             initialDelaySeconds: 0
             periodSeconds: 2
             timeoutSeconds: 2
@@ -48,8 +48,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=Readiness
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
+                - -connect-timeout=400ms
+                - -rpc-timeout=400ms
             failureThreshold: 5
             initialDelaySeconds: 0
             periodSeconds: 10
@@ -61,10 +61,10 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
+                - -connect-timeout=400ms
+                - -rpc-timeout=400ms
             failureThreshold: 5
-            initialDelaySeconds: 0
+            initialDelaySeconds: 2
             periodSeconds: 10
             timeoutSeconds: 3
             successThreshold: 1

--- a/config/templates/charts/meridio/deployment/stateless-lb-frontend.yaml
+++ b/config/templates/charts/meridio/deployment/stateless-lb-frontend.yaml
@@ -55,8 +55,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
+                - -connect-timeout=400ms
+                - -rpc-timeout=400ms
             initialDelaySeconds: 0
             periodSeconds: 2
             timeoutSeconds: 2
@@ -68,8 +68,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=Readiness
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
+                - -connect-timeout=400ms
+                - -rpc-timeout=400ms
             failureThreshold: 5
             initialDelaySeconds: 0
             periodSeconds: 10
@@ -81,10 +81,10 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
+                - -connect-timeout=400ms
+                - -rpc-timeout=400ms
             failureThreshold: 5
-            initialDelaySeconds: 0
+            initialDelaySeconds: 2
             periodSeconds: 10
             timeoutSeconds: 3
             successThreshold: 1
@@ -182,8 +182,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
+                - -connect-timeout=400ms
+                - -rpc-timeout=400ms
             initialDelaySeconds: 0
             periodSeconds: 2
             timeoutSeconds: 2
@@ -195,8 +195,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=Readiness
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
+                - -connect-timeout=400ms
+                - -rpc-timeout=400ms
             initialDelaySeconds: 0
             periodSeconds: 10
             timeoutSeconds: 3
@@ -208,9 +208,9 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=250ms
-                - -rpc-timeout=350ms
-            initialDelaySeconds: 0
+                - -connect-timeout=400ms
+                - -rpc-timeout=400ms
+            initialDelaySeconds: 2
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 5

--- a/deployments/helm/templates/_helpers.tpl
+++ b/deployments/helm/templates/_helpers.tpl
@@ -87,13 +87,15 @@ Set IP Family
 exec:
   command:
   - /bin/grpc_health_probe
-{{- if $spiffe }}
-  - -spiffe
-{{- end }}
   - -addr={{ $healthAddr }}
   - -service={{ $healthService }}
-  - -connect-timeout=100ms
-  - -rpc-timeout=150ms
+{{- if $spiffe }}
+  - -spiffe
+  - -rpc-timeout=1s
+{{- else }}
+  - -rpc-timeout=400ms
+{{- end }}
+  - -connect-timeout=400ms
 initialDelaySeconds: 0
 periodSeconds: 2
 timeoutSeconds: 2
@@ -119,14 +121,16 @@ failureThreshold: 30
 exec:
   command:
   - /bin/grpc_health_probe
-{{- if $spiffe }}
-  - -spiffe
-{{- end }}
   - -addr={{ $healthAddr }}
   - -service={{ $healthService }}
-  - -connect-timeout=100ms
-  - -rpc-timeout=150ms
-initialDelaySeconds: 0
+{{- if $spiffe }}
+  - -spiffe
+  - -rpc-timeout=1s
+{{- else }}
+  - -rpc-timeout=400ms
+{{- end }}
+  - -connect-timeout=400ms
+initialDelaySeconds: 2
 periodSeconds: 10
 timeoutSeconds: 3
 failureThreshold: 5
@@ -151,13 +155,15 @@ failureThreshold: 5
 exec:
   command:
   - /bin/grpc_health_probe
-{{- if $spiffe }}
-  - -spiffe
-{{- end }}
   - -addr={{ $healthAddr }}
   - -service={{ $healthService }}
-  - -connect-timeout=100ms
-  - -rpc-timeout=150ms
+{{- if $spiffe }}
+  - -spiffe
+  - -rpc-timeout=1s
+{{- else }}
+  - -rpc-timeout=400ms
+{{- end }}
+  - -connect-timeout=400ms
 initialDelaySeconds: 0
 periodSeconds: 10
 timeoutSeconds: 3

--- a/pkg/controllers/attractor/stateless-lb-frontend.go
+++ b/pkg/controllers/attractor/stateless-lb-frontend.go
@@ -76,6 +76,9 @@ func (l *LoadBalancer) getLbEnvVars(allEnv []corev1.EnvVar) []corev1.EnvVar {
 		"NSM_NSP_SERVICE":  common.NSPServiceWithPort(l.trench),
 		"NSM_LOG_LEVEL":    common.GetLogLevel(),
 	}
+	if rpcTimeout := common.GetGRPCProbeRPCTimeout(); rpcTimeout != "" {
+		operatorEnv["NSM_GRPC_PROBE_RPC_TIMEOUT"] = rpcTimeout
+	}
 	return common.CompileEnvironmentVariables(allEnv, operatorEnv)
 }
 

--- a/pkg/controllers/common/const.go
+++ b/pkg/controllers/common/const.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -28,12 +29,13 @@ import (
 )
 
 const (
-	ResourceNamePrefixEnv = "RESOURCE_NAME_PREFIX"
-	ImagePullSecretEnv    = "IMAGE_PULL_SECRET"
-	NSMRegistryServiceEnv = "NSM_REGISTRY_SERVICE"
-	LogLevelEnv           = "LOG_LEVEL"
-	NspServiceAccountEnv  = "NSP_SERVICE_ACCOUNT"
-	FeServiceAccountEnv   = "FE_SERVICE_ACCOUNT"
+	ResourceNamePrefixEnv   = "RESOURCE_NAME_PREFIX"
+	ImagePullSecretEnv      = "IMAGE_PULL_SECRET"
+	NSMRegistryServiceEnv   = "NSM_REGISTRY_SERVICE"
+	LogLevelEnv             = "LOG_LEVEL"
+	NspServiceAccountEnv    = "NSP_SERVICE_ACCOUNT"
+	FeServiceAccountEnv     = "FE_SERVICE_ACCOUNT"
+	GRPCHealthRPCTimeoutEnv = "GRPC_PROBE_RPC_TIMEOUT" // RPC timeout of grpc_health_probes run from code
 
 	Registry        = "registry.nordix.org"
 	Organization    = "cloud-native/meridio"
@@ -170,6 +172,14 @@ func GetImagePullSecrets() []corev1.LocalObjectReference {
 		})
 	}
 	return pullSecs
+}
+
+func GetGRPCProbeRPCTimeout() string {
+	timeout := os.Getenv(GRPCHealthRPCTimeoutEnv)
+	if _, err := time.ParseDuration(timeout); err != nil {
+		return ""
+	}
+	return timeout
 }
 
 func NsName(meta metav1.ObjectMeta) string {

--- a/pkg/controllers/conduit/proxy.go
+++ b/pkg/controllers/conduit/proxy.go
@@ -69,6 +69,9 @@ func (i *Proxy) getEnvVars(allEnv []corev1.EnvVar) []corev1.EnvVar {
 		"NSM_NAMESPACE":        i.conduit.ObjectMeta.Namespace,
 		"NSM_LOG_LEVEL":        common.GetLogLevel(),
 	}
+	if rpcTimeout := common.GetGRPCProbeRPCTimeout(); rpcTimeout != "" {
+		operatorEnv["NSM_GRPC_PROBE_RPC_TIMEOUT"] = rpcTimeout
+	}
 	return common.CompileEnvironmentVariables(allEnv, operatorEnv)
 }
 

--- a/pkg/controllers/trench/ipam.go
+++ b/pkg/controllers/trench/ipam.go
@@ -67,6 +67,9 @@ func (i *IpamStatefulSet) getEnvVars(allEnv []corev1.EnvVar) []corev1.EnvVar {
 		"IPAM_IP_FAMILY":                  common.GetIPFamily(i.trench),
 		"IPAM_LOG_LEVEL":                  common.GetLogLevel(),
 	}
+	if rpcTimeout := common.GetGRPCProbeRPCTimeout(); rpcTimeout != "" {
+		operatorEnv["IPAM_GRPC_PROBE_RPC_TIMEOUT"] = rpcTimeout
+	}
 	return common.CompileEnvironmentVariables(allEnv, operatorEnv)
 }
 

--- a/pkg/health/probe/probe.go
+++ b/pkg/health/probe/probe.go
@@ -44,8 +44,8 @@ func NewGRPCHealthProbe(options ...Option) (*GrpcHealthProbe, error) {
 		cmd:         "grpc_health_probe",
 		addr:        fmt.Sprintf("-addr=%v", health.DefaultURL),
 		service:     "-service=",
-		rpcTimeout:  "-rpc-timeout=350ms",
-		connTimeout: "-connect-timeout=250ms",
+		rpcTimeout:  "-rpc-timeout=400ms",
+		connTimeout: "-connect-timeout=400ms",
 	}
 	for _, opt := range options {
 		opt(opts)
@@ -67,7 +67,7 @@ func NewGRPCHealthProbe(options ...Option) (*GrpcHealthProbe, error) {
 
 // String -
 func (ghp *GrpcHealthProbe) String() string {
-	return fmt.Sprintf("%v %v %v %v %v %v", ghp.cmd, ghp.addr, ghp.service, ghp.rpcTimeout, ghp.rpcTimeout, ghp.spiffe)
+	return fmt.Sprintf("%v %v %v %v %v %v", ghp.cmd, ghp.addr, ghp.service, ghp.connTimeout, ghp.rpcTimeout, ghp.spiffe)
 }
 
 // Run -
@@ -84,8 +84,8 @@ func (ghp *GrpcHealthProbe) Run(ctx context.Context) error {
 }
 
 // CreateAndRunGRPCHealthProbe -
-// Creates gRPC Health Probe and starts running it background while registering
-// the probing results to Health Server.
+// Creates gRPC Health Probe and starts running it in background.
+// Registers probing results to Health Server retrieved from context.
 // TODO: configurable period, timeout
 func CreateAndRunGRPCHealthProbe(ctx context.Context, healthService string, options ...Option) {
 	// create the probe for the servie
@@ -97,7 +97,7 @@ func CreateAndRunGRPCHealthProbe(ctx context.Context, healthService string, opti
 	log.Logger.V(1).Info("Created background probe", "probe", ghp)
 
 	runf := func(ctx context.Context) error {
-		cancelCtx, cancel := context.WithTimeout(ctx, 3*time.Second) // probe timeout
+		cancelCtx, cancel := context.WithTimeout(ctx, 4*time.Second) // probe timeout
 		defer cancel()
 		servingStatus := grpc_health_v1.HealthCheckResponse_SERVING
 		if err := ghp.Run(cancelCtx); err != nil {


### PR DESCRIPTION
## Description
Using SPIFFE Workload API to retrieve TLS credentials can be CPU intensive. Thus, employing resource limits for Spire can lead to failed probes.

Set default rpc-timeout of grpc-health-probes in case of SPIFFE issued credentials to 1s.
Also, use 2 seconds initial delay for liveness probes not to overlap with readiness probes.

RPC timeout of code internal grpc-health-probes can be adjusted via `GRPC_PROBE_RPC_TIMEOUT` operator environment variable (expects time.Duration values).

## Issue link
https://github.com/Nordix/Meridio/issues/420

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [ ] No
