### PR TITLE
NSP/IPAM reconnect improvements

### DIFF
--- a/cmd/frontend/internal/env/config.go
+++ b/cmd/frontend/internal/env/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	LogLevel              string        `default:"DEBUG" desc:"Log level" split_words:"true"`
 	NSPEntryTimeout       time.Duration `default:"30s" desc:"Timeout of the entries" envconfig:"nsp_entry_timeout"`
 	GRPCKeepaliveTime     time.Duration `default:"30s" desc:"gRPC keepalive timeout"`
+	GRPCMaxBackoff        time.Duration `default:"5s" desc:"Upper bound on gRPC connection backoff delay" envconfig:"grpc_max_backoff"`
 	DelayConnectivity     time.Duration `default:"1s" desc:"Delay between checks with connectivity"`
 	DelayNoConnectivity   time.Duration `default:"3s" desc:"Delay between checks without connectivity"`
 	MaxSessionErrors      int           `default:"5" desc:"Max session errors when checking Bird until denounce"`

--- a/cmd/ipam/config.go
+++ b/cmd/ipam/config.go
@@ -34,4 +34,5 @@ type Config struct {
 	LogLevel                string        `default:"DEBUG" desc:"Log level" split_words:"true"`
 	GRPCKeepaliveTime       time.Duration `default:"30s" desc:"gRPC keepalive timeout"`
 	GRPCProbeRPCTimeout     time.Duration `default:"1s" desc:"RPC timeout of internal gRPC health probe" envconfig:"grpc_probe_rpc_timeout"`
+	GRPCMaxBackoff          time.Duration `default:"5s" desc:"Upper bound on gRPC connection backoff delay" envconfig:"grpc_max_backoff"`
 }

--- a/cmd/ipam/main.go
+++ b/cmd/ipam/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/nordix/meridio/pkg/security/credentials"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
 	grpcHealth "google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
@@ -99,6 +100,10 @@ func main() {
 	}
 
 	// connect NSP
+	grpcBackoffCfg := backoff.DefaultConfig
+	if grpcBackoffCfg.MaxDelay != config.GRPCMaxBackoff {
+		grpcBackoffCfg.MaxDelay = config.GRPCMaxBackoff
+	}
 	conn, err := grpc.DialContext(
 		ctx,
 		config.NSPService,
@@ -108,6 +113,9 @@ func main() {
 		grpc.WithDefaultCallOptions(
 			grpc.WaitForReady(true),
 		),
+		grpc.WithConnectParams(grpc.ConnectParams{
+			Backoff: grpcBackoffCfg,
+		}),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time: config.GRPCKeepaliveTime,
 		}),

--- a/cmd/proxy/internal/config/config.go
+++ b/cmd/proxy/internal/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	MTU                 int           `default:"1500" desc:"Conduit MTU considered by local NSCs and NSE composing the network mesh" split_words:"true"`
 	GRPCKeepaliveTime   time.Duration `default:"30s" desc:"gRPC keepalive timeout"`
 	GRPCProbeRPCTimeout time.Duration `default:"1s" desc:"RPC timeout of internal gRPC health probe" envconfig:"grpc_probe_rpc_timeout"`
+	GRPCMaxBackoff      time.Duration `default:"5s" desc:"Upper bound on gRPC connection backoff delay" envconfig:"grpc_max_backoff"`
 }
 
 // IsValid checks if the configuration is valid

--- a/cmd/stateless-lb/config.go
+++ b/cmd/stateless-lb/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	IdentifierOffsetStart int           `default:"5000" desc:"Each Stream will get a unique identifier range starting from that value" split_words:"true"`
 	GRPCKeepaliveTime     time.Duration `default:"30s" desc:"gRPC keepalive timeout"`
 	GRPCProbeRPCTimeout   time.Duration `default:"1s" desc:"RPC timeout of internal gRPC health probe" envconfig:"grpc_probe_rpc_timeout"`
+	GRPCMaxBackoff        time.Duration `default:"5s" desc:"Upper bound on gRPC connection backoff delay" envconfig:"grpc_max_backoff"`
 }
 
 // IsValid checks if the configuration is valid

--- a/cmd/tapa/config.go
+++ b/cmd/tapa/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	MaxTokenLifetime time.Duration `default:"24h" desc:"maximum lifetime of tokens" split_words:"true"`
 	LogLevel         string        `default:"DEBUG" desc:"Log level" split_words:"true"`
 	NSPEntryTimeout  time.Duration `default:"30s" desc:"Timeout of the entries" envconfig:"nsp_entry_timeout"`
+	GRPCMaxBackoff   time.Duration `default:"5s" desc:"Upper bound on gRPC connection backoff delay" envconfig:"grpc_max_backoff"`
 }
 
 // IsValid checks if the configuration is valid

--- a/cmd/tapa/main.go
+++ b/cmd/tapa/main.go
@@ -167,7 +167,18 @@ func main() {
 	s := grpc.NewServer()
 	defer s.Stop()
 
-	ambassador, err := tap.New(config.Name, config.Namespace, config.Node, networkServiceClient, monitorClient, config.NSPServiceName, config.NSPServicePort, config.NSPEntryTimeout, netUtils)
+	ambassador, err := tap.New(
+		config.Name,
+		config.Namespace,
+		config.Node,
+		networkServiceClient,
+		monitorClient,
+		config.NSPServiceName,
+		config.NSPServicePort,
+		config.NSPEntryTimeout,
+		config.GRPCMaxBackoff,
+		netUtils,
+	)
 	if err != nil {
 		log.Fatal(logger, "creating new tap ambassador", "error", err)
 	}

--- a/pkg/ambassador/tap/conduit/manager.go
+++ b/pkg/ambassador/tap/conduit/manager.go
@@ -249,11 +249,10 @@ func (sr *streamRetry) Open(nspStream *nspAPI.Stream) {
 	go func() {
 		// retry to refresh
 		_ = retry.Do(func() error {
-			openCtx, cancel := context.WithTimeout(ctx, sr.Timeout)
-			defer cancel()
-
 			// retry to open
 			_ = retry.Do(func() error {
+				openCtx, cancel := context.WithTimeout(ctx, sr.Timeout)
+				defer cancel()
 				err := sr.Stream.Open(openCtx, nspStream)
 				if err != nil {
 					log.Logger.Error(err, "opening stream", "stream", sr.Stream.GetStream())
@@ -263,7 +262,7 @@ func (sr *streamRetry) Open(nspStream *nspAPI.Stream) {
 				}
 				sr.setStatus(ambassadorAPI.StreamStatus_OPEN)
 				return nil
-			}, retry.WithContext(openCtx),
+			}, retry.WithContext(ctx),
 				retry.WithDelay(sr.RetryDelay))
 
 			return nil

--- a/pkg/ambassador/tap/tap.go
+++ b/pkg/ambassador/tap/tap.go
@@ -44,6 +44,7 @@ type Tap struct {
 	NSPServiceName          string
 	NSPServicePort          int
 	NSPEntryTimeout         time.Duration
+	GRPCMaxBackoff          time.Duration
 	NetUtils                networking.Utils
 	StreamRegistry          types.Registry
 	currentTrench           types.Trench
@@ -59,6 +60,7 @@ func New(targetName string,
 	nspServiceName string,
 	nspServicePort int,
 	nspEntryTimeout time.Duration,
+	grpcMaxBackoff time.Duration,
 	netUtils networking.Utils) (*Tap, error) {
 	tap := &Tap{
 		TargetName:              targetName,
@@ -69,6 +71,7 @@ func New(targetName string,
 		NSPServiceName:          nspServiceName,
 		NSPServicePort:          nspServicePort,
 		NSPEntryTimeout:         nspEntryTimeout,
+		GRPCMaxBackoff:          grpcMaxBackoff,
 		NetUtils:                netUtils,
 		logger:                  log.Logger.WithValues("class", "Tap"),
 	}
@@ -175,6 +178,7 @@ func (tap *Tap) setTrench(t *ambassadorAPI.Trench) (types.Trench, error) {
 		tap.NSPServiceName,
 		tap.NSPServicePort,
 		tap.NSPEntryTimeout,
+		tap.GRPCMaxBackoff,
 		tap.NetUtils)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description
Adjust Max Backoff Delay to limit gRPC reconnect interval. Allows faster client reconnect to NSP and IPAM service backends.
With default settings gRPC might wait up to 2 minutes to attempt reconnect. New default value is 5 seconds.
Now, clients can reconnect within ~5 seconds even if the server was unavailable for minutes.
(refer to: https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md)

Max Backoff Delay is not exposed through Operator by a common env variable at the moment, instead can be set one-by-one in the templates.

Possible way to verify improvement:
-Deploy Meridio (trench, conduit etc.)
-Deploy example-target with 1 replica
-Start tcpdump filtering for port 7778 (NSP) in Target POD
-Provoke NSP unavailability for >2minutes:
When all the PODs have reached readiness and Target has opened the stream, edit the NSP POD's config (e.g. `kubectl edit pod nsp-trench-a-0`) and change the label `app` so that it won't match the related k8s service. Verify no endpoints are linked to the service (`kubectl get endpoints nsp-service-trench-a`). Then, kill the nsp process in the NSP continer (`kubectl exec nsp-trench-a-0 -- kill -2 1`). Wait 2 minutes, then fix the NSP POD label `app` b re-editing the NSP POD. Verify the service endpoints.
-TAPA: tcpdump should show reconnect attempts i.e. TCP SYNs (with max 5-6 seconds max interval). Once the NSP endpoint re-appears, TAPA should establish NSP connection within 5-6 seconds.
-Other Meridio components reflecting NSP connectivity as part of their readiness probes should recover within 5-6 seconds as well.



## Issue link
NA

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
