### PR TITLE
Retry: return only last error

### DIFF
--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -18,7 +18,6 @@ package retry
 
 import (
 	"context"
-	"fmt"
 )
 
 // Function definition to be executed and retried.
@@ -47,7 +46,7 @@ retry:
 		err := retryableFunc()
 
 		if err != nil {
-			errFinal = fmt.Errorf("%w; %v", errFinal, err) // todo
+			errFinal = err // todo: concat errors with limit
 		}
 
 		if !config.retryConditionFunc(err) {


### PR DESCRIPTION
## Description

Using the retry pkg, if the retry iterates many times (maybe infinitly), the errFinal will increase and will consume more and more memory. For now, only the latest error will then be returned.

## Issue link

/

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
