### PR TITLE
FE; advertise single AFI/SAFI pair via BGP

### DIFF
--- a/cmd/frontend/internal/bird/constants.go
+++ b/cmd/frontend/internal/bird/constants.go
@@ -39,3 +39,14 @@ const (
 	bfdSessions
 	bfd
 )
+
+const (
+	BGPTemplateIPv4 string = "LINK4" // name of BGP template for IPv4 to generate
+	BGPTemplateIPv6 string = "LINK6" // name of BGP template for IPv6 to generate
+)
+
+const (
+	LogFilePath       string = "/var/log/bird.log"                                            // file to write BIRD logs to
+	BackupLogFilePath string = "/var/log/bird.log.backup"                                     // backup log file; when current log file reaches the limit, it's renamed to the backup filename
+	LogClasses        string = "debug, trace, info, remote, warning, error, auth, fatal, bug" // list of log classes for which BIRD messages are logged
+)

--- a/cmd/stateless-lb/egress.go
+++ b/cmd/stateless-lb/egress.go
@@ -112,6 +112,7 @@ func (fns *FrontendNetworkService) recv() error {
 				logger.Error(err, "Announce")
 				continue
 			}
+			logger.Info("LB endpoint announced")
 			health.SetServingStatus(fns.ctx, health.EgressSvc, true)
 		} else {
 			logger.Info("FE unavailable", "IdentifierKey", target.GetContext()[types.IdentifierKey])
@@ -131,6 +132,7 @@ func (fns *FrontendNetworkService) recv() error {
 				logger.Error(err, "Denounce")
 				continue
 			}
+			logger.Info("LB endpoint denounced")
 		}
 	}
 	return nil


### PR DESCRIPTION
## Description
Advertise multi-protocol extension capability matching the associated Gateway's IP version,
Achieved by using separate BIRD BGP templates for IPv4, IPv6.
(Refer to the related issue for details.)

## Issue link
https://github.com/Nordix/Meridio/issues/370

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
