### PR TITLE
LB; remove replaced interface from interfaces list

### DIFF
--- a/cmd/stateless-lb/main.go
+++ b/cmd/stateless-lb/main.go
@@ -422,6 +422,10 @@ func (sns *SimpleNetworkService) InterfaceCreated(intf networking.Iface) {
 		if sameSubnet(intf, oldif) {
 			sns.logger.Info("Interface replaced", "old", oldif, "new", intf)
 			sns.disableInterface(oldif)
+			// remove replaced interface from the list in order to avoid further
+			// unnecessary and confusing replace printouts and disable attempts
+			// in case the old interface lingers on
+			sns.interfaces.Delete(oldif.GetIndex())
 		}
 		return true
 	})


### PR DESCRIPTION
## Description
LB-FE keeps track of interfaces connecting it with proxies. When a proxy interface is replaced, the old interface might linger on, or might not even get removed from the interface list. That's because LB-FE only gets InterfaceDeleted() event upon an NSM connection Close() request. Which might happen with severe delay (MaxTokenLifetime expiration), or might not even happen if the Close fails (does not reach LB-FE's interfacemonitor server chain). Either way, it leads to unnecessary and confusing excess work and printouts where LB-FE tries to set the old interface's state to Down again and again.

So let's remove the old interface from the interface list when the interface replace event is first noticed.

## Issue link
NA

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
