### PR TITLE
Retain legacy calculation of NSE expiration time

### DIFF
--- a/pkg/nsm/client.go
+++ b/pkg/nsm/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package nsm
 
 import (
 	"context"
+	"time"
 
 	"github.com/edwarnicke/grpcfd"
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
@@ -32,6 +33,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 	"github.com/networkservicemesh/sdk/pkg/tools/tracing"
 	"github.com/nordix/meridio/pkg/log"
+	"github.com/nordix/meridio/pkg/nsm/endpoint/expirationtime"
 	creds "github.com/nordix/meridio/pkg/security/credentials"
 	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
@@ -82,6 +84,7 @@ func (apiClient *APIClient) setNetworkServiceEndpointRegistryClient() {
 		registryclient.WithClientURL(&apiClient.Config.ConnectTo),
 		registryclient.WithDialOptions(clientOptions...),
 		registryclient.WithNSEAdditionalFunctionality(
+			expirationtime.NewNetworkServiceEndpointRegistryClient(time.Minute), // keep legacy nse lifetime (changed by https://github.com/networkservicemesh/sdk/pull/1404)
 			clientinfo.NewNetworkServiceEndpointRegistryClient(),
 			sendfd.NewNetworkServiceEndpointRegistryClient(),
 		),

--- a/pkg/nsm/endpoint/expirationtime/nse_client.go
+++ b/pkg/nsm/endpoint/expirationtime/nse_client.go
@@ -1,0 +1,58 @@
+/*
+Copyright (c) 2023 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package expirationtime
+
+import (
+	"context"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/clock"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type defaultExpirationNSEClient struct {
+	defaultLifetime time.Duration
+}
+
+// NewNetworkServiceEndpointRegistryClient creates new NetworkServiceEndpointRegistryClient that will set
+// NSE expiration time based on defaultLifetime during registration if no expiration time has been set yet.
+func NewNetworkServiceEndpointRegistryClient(defaultLifetime time.Duration) registry.NetworkServiceEndpointRegistryClient {
+	return &defaultExpirationNSEClient{
+		defaultLifetime: defaultLifetime,
+	}
+}
+
+func (c *defaultExpirationNSEClient) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
+	if nse.GetExpirationTime() == nil {
+		timeClock := clock.FromContext(ctx)
+		expirationTime := timeClock.Now().Add(c.defaultLifetime).Local()
+		nse.ExpirationTime = timestamppb.New(expirationTime)
+	}
+	return next.NetworkServiceEndpointRegistryClient(ctx).Register(ctx, nse, opts...)
+}
+
+func (c *defaultExpirationNSEClient) Find(ctx context.Context, query *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
+	return next.NetworkServiceEndpointRegistryClient(ctx).Find(ctx, query, opts...)
+}
+
+func (c *defaultExpirationNSEClient) Unregister(ctx context.Context, nse *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
+	return next.NetworkServiceEndpointRegistryClient(ctx).Unregister(ctx, nse, opts...)
+}


### PR DESCRIPTION
## Description
With https://github.com/networkservicemesh/sdk/pull/1404 NSE expiration time is controlled by NSM's MaxTokenLifetime parameter. This token lifetime defaults to 10 minutes, resulting in 10 minutes NSE lifetimes.

Introduce a custom chain function to ensure LB/Proxy NSEs are registered using 1 minute lifetime like before.

## Issue link
https://github.com/Nordix/Meridio/issues/438

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
