### PR TITLE
FE; make BIRD use IANA approved ports for BFD (49152-65535)

### DIFF
--- a/deployments/helm/templates/_helpers.tpl
+++ b/deployments/helm/templates/_helpers.tpl
@@ -6,11 +6,11 @@ Set IP Family
 
 {{- define "meridio.loadBalancer.sysctls" -}}
 {{- if eq .Values.ipFamily "dualstack" -}}
-{{- printf "sysctl -w net.ipv6.conf.all.forwarding=1 ; sysctl -w net.ipv4.conf.all.forwarding=1 ; sysctl -w net.ipv4.fib_multipath_hash_policy=1 ; sysctl -w net.ipv6.fib_multipath_hash_policy=1 ; sysctl -w net.ipv4.conf.all.rp_filter=0 ; sysctl -w net.ipv4.conf.default.rp_filter=0" -}}
+{{- printf "sysctl -w net.ipv6.conf.all.forwarding=1 ; sysctl -w net.ipv4.conf.all.forwarding=1 ; sysctl -w net.ipv4.fib_multipath_hash_policy=1 ; sysctl -w net.ipv6.fib_multipath_hash_policy=1 ; sysctl -w net.ipv4.conf.all.rp_filter=0 ; sysctl -w net.ipv4.conf.default.rp_filter=0 ; sysctl -w net.ipv4.ip_local_port_range='49152 65535'" -}}
 {{- else if eq .Values.ipFamily "ipv6" -}}
-{{- printf "sysctl -w net.ipv6.conf.all.forwarding=1 ; sysctl -w net.ipv6.fib_multipath_hash_policy=1" -}}
+{{- printf "sysctl -w net.ipv6.conf.all.forwarding=1 ; sysctl -w net.ipv6.fib_multipath_hash_policy=1 ; sysctl -w net.ipv4.ip_local_port_range='49152 65535'" -}}
 {{- else -}}
-{{- printf "sysctl -w net.ipv4.conf.all.forwarding=1 ; sysctl -w net.ipv4.fib_multipath_hash_policy=1" -}}
+{{- printf "sysctl -w net.ipv4.conf.all.forwarding=1 ; sysctl -w net.ipv4.fib_multipath_hash_policy=1 ; sysctl -w net.ipv4.ip_local_port_range='49152 65535'" -}}
 {{- end -}}
 {{- end -}}
 

--- a/docs/components/frontend.md
+++ b/docs/components/frontend.md
@@ -96,6 +96,7 @@ Sysctl: net.ipv4.fib_multipath_hash_policy=1 | To use Layer 4 hash policy for EC
 Sysctl: net.ipv6.fib_multipath_hash_policy=1 | To use Layer 4 hash policy for ECMP on IPv6
 Sysctl: net.ipv4.conf.all.rp_filter=0 | Allow packets to have a source IPv4 address which does not correspond to any routing destination address.
 Sysctl: net.ipv4.conf.default.rp_filter=0 | Allow packets to have a source IPv6 address which does not correspond to any routing destination address.
+Sysctl: net.ipv4.ip_local_port_range='49152 65535' | The source port of BFD Control packets must be in the IANA approved range 49152-65535
 NET_ADMIN | The frontend creates IP rules to handle outbound traffic from VIP sources. BIRD interacts with kernel routing tables.
 NET_BIND_SERVICE | Allows BIRD to bind to privileged ports depending on the config (for example to BGP port 173).
 NET_RAW | Allows BIRD to use the SO_BINDTODEVICE socket option.

--- a/pkg/controllers/common/models.go
+++ b/pkg/controllers/common/models.go
@@ -36,14 +36,15 @@ func GetIPFamily(cr *meridiov1.Trench) string {
 
 const ipv4SysCtl = "sysctl -w net.ipv4.conf.all.forwarding=1 ; sysctl -w net.ipv4.fib_multipath_hash_policy=1 ; sysctl -w net.ipv4.conf.all.rp_filter=0 ; sysctl -w net.ipv4.conf.default.rp_filter=0"
 const ipv6SysCtl = "sysctl -w net.ipv6.conf.all.forwarding=1 ; sysctl -w net.ipv6.fib_multipath_hash_policy=1"
+const localPortRangeSysCtl = "sysctl -w net.ipv4.ip_local_port_range='49152 65535'" // ephemeral port range to make BIRD use IANA approved src ports for BFD
 
 func GetLoadBalancerSysCtl(cr *meridiov1.Trench) string {
 	if cr.Spec.IPFamily == string(meridiov1.Dualstack) {
-		return fmt.Sprintf("%s ; %s", ipv4SysCtl, ipv6SysCtl)
+		return fmt.Sprintf("%s ; %s ; %s", ipv4SysCtl, ipv6SysCtl, localPortRangeSysCtl)
 	} else if cr.Spec.IPFamily == string(meridiov1.IPv4) {
-		return ipv4SysCtl
+		return fmt.Sprintf("%s ; %s", ipv4SysCtl, localPortRangeSysCtl)
 	} else if cr.Spec.IPFamily == string(meridiov1.IPv6) {
-		return ipv6SysCtl
+		return fmt.Sprintf("%s ; %s", ipv6SysCtl, localPortRangeSysCtl)
 	}
 	return ""
 }


### PR DESCRIPTION
## Description
As per BIRD documentation, use ip_local_port_range to force BIRD using IANA approved src ports for BFD.

```BFD packets are sent with a dynamic source port number. Linux systems use by default a bit different dynamic port range than the IANA approved one (49152-65535). If you experience problems with compatibility, please adjust /proc/sys/net/ipv4/ip_local_port_range.```

## Issue link
NA

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
