### PR TITLE
TAPA queries NSM to re-use connection if possible

### DIFF
--- a/pkg/nsm/interfacename/cache.go
+++ b/pkg/nsm/interfacename/cache.go
@@ -25,7 +25,7 @@ import (
 	"github.com/nordix/meridio/pkg/log"
 )
 
-const defaultReleaseTimeout = 60 * time.Second
+const defaultReleaseTimeout = 600 * time.Second
 
 type ReleaseTrigger func() <-chan struct{}
 


### PR DESCRIPTION
## Description
TAPA uses a `deterministic` NSM Connection/Segment ID that does not change if connecting to [Conduit, Trench] tuple with the same names from the same application POD.

```
var nsName string = conduit.GetNetworkServiceNameWithProxy(c.Conduit.GetName(), c.Conduit.GetTrench().GetName(), c.Namespace)
var id string = fmt.Sprintf("%s-%s-%d", c.TargetName, nsName, 0)
```

In case NSM connection Close() fails for example on the TAPA side for some reason (or the TAPA container crashes), then requesting a new connection with the same Connection ID will create a second connection in NSM.
Unfortunately, once the "old" connection's token lifetime expires, and NSM orders clean-up, it will trigger a `heal event` in TAPA because of the shared Connection ID.
This will lead to unwanted NSM connection `reconnect`. Also, in general having multiple NSM connections that share the same TAPA connection/segment ID is problematic, since IPAM uses that ID as key to track who owns the assigned IPs.

fix:
TAPA has been improved to query NSMgr checking if it is aware of a Connection with a particular ID. If it is, the TAPA will re-use that Connection to request a NSM connection towards a particular Conduit. This shall update the connection maintained in NSM, meaning no unexpected reconnect due to duplicated connections.

## Issue link

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
