### PR TITLE
TAPA; connection monitor backward compatibility

### DIFF
--- a/pkg/ambassador/tap/conduit/conduit.go
+++ b/pkg/ambassador/tap/conduit/conduit.go
@@ -170,8 +170,8 @@ func (c *Conduit) Connect(ctx context.Context) error {
 
 		event, err := stream.Recv()
 		if err != nil {
-			c.logger.Info("Connect monitorConnectionClient recv failed", "err", err)
-			return err
+			// probably running older NSM version, fallback to legacy behavior to request connection
+			c.logger.Error(err, "error from monitorConnection stream")
 		} else {
 			monitoredConnections = event.Connections
 		}


### PR DESCRIPTION
## Description
Follow-up item for https://github.com/Nordix/Meridio/pull/444

If connection monitor recv returns with error, fallback to legacy behavior keeping backward compatibility in case of older NSM versions (e.g., NSM 1.6.1).

## Issue link

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
