### PR TITLE
TAPA; sync interface name cache for recovered connections

### DIFF
--- a/pkg/nsm/interfacename/generator.go
+++ b/pkg/nsm/interfacename/generator.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -28,6 +30,7 @@ import (
 type NameGenerator interface {
 	Generate(prefix string, maxLength int) string
 	Release(name string)
+	Reserve(name, prefix string, maxLength int) error
 }
 
 type RandomGenerator struct {
@@ -59,6 +62,34 @@ func (rg *RandomGenerator) Release(name string) {
 	rg.mu.Lock()
 	defer rg.mu.Unlock()
 	delete(rg.usedNames, name)
+}
+
+// Reserve -
+// Reverse tries to reserve a certain name if the format is right
+func (rg *RandomGenerator) Reserve(name, prefix string, maxLength int) error {
+	rg.mu.Lock()
+	defer rg.mu.Unlock()
+	if rg.usedNames == nil {
+		rg.usedNames = make(map[string]struct{})
+	}
+
+	if len(name) > maxLength || len(name) == len(prefix) || (prefix != "" && !strings.HasPrefix(name, prefix)) {
+		return fmt.Errorf("wrong name format")
+	}
+
+	// XXX: For this generator I see no point checking if suffix is a number
+	// s := strings.TrimPrefix(name, prefix)
+	// if _, err := strconv.Atoi(s); err != nil {
+	// 	return fmt.Errorf("suffix not integer")
+	// }
+
+	if _, ok := rg.usedNames[name]; ok {
+		// already taken
+		return os.ErrExist
+	}
+	rg.usedNames[name] = struct{}{}
+
+	return nil
 }
 
 type CounterGenerator struct {
@@ -93,4 +124,32 @@ func (cg *CounterGenerator) Release(name string) {
 	cg.mu.Lock()
 	defer cg.mu.Unlock()
 	delete(cg.usedNames, name)
+}
+
+// Reserve -
+// Reverse tries to reserve a certain name if the format is right
+func (cg *CounterGenerator) Reserve(name, prefix string, maxLength int) error {
+	cg.mu.Lock()
+	defer cg.mu.Unlock()
+	if cg.usedNames == nil {
+		cg.usedNames = make(map[string]struct{})
+	}
+
+	if len(name) > maxLength || len(name) == len(prefix) || (prefix != "" && !strings.HasPrefix(name, prefix)) {
+		return fmt.Errorf("wrong name format")
+	}
+
+	// XXX: For this generator I see no point checking if suffix is a number
+	// s := strings.TrimPrefix(name, prefix)
+	// if _, err := strconv.Atoi(s); err != nil {
+	// 	return fmt.Errorf("suffix not integer")
+	// }
+
+	if _, ok := cg.usedNames[name]; ok {
+		// already taken
+		return os.ErrExist
+	}
+	cg.usedNames[name] = struct{}{}
+
+	return nil
 }

--- a/pkg/nsm/interfacename/server_test.go
+++ b/pkg/nsm/interfacename/server_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -35,6 +35,10 @@ func (rg *mockGenerator) Generate(prefix string, maxLength int) string {
 }
 
 func (rg *mockGenerator) Release(name string) {
+}
+
+func (rg *mockGenerator) Reserve(name, prefix string, maxLength int) error {
+	return nil
 }
 
 func Test_Server_Request(t *testing.T) {


### PR DESCRIPTION
## Description
Related to https://github.com/Nordix/Meridio/pull/444

In case of a connection recovered through NSM's connection monitor, the so called interface name cache in interfaceNameClient could have become out of sync.
That's because the cache was not contacted in such cases, thus upon a faulty Close() or TAPA crash the cache failed to keep track of recovered names. (Which means, such names could be re-used by some other connection.)

Therefor, move the interface name of recovered connections from Mechanism to MechanismPreferences, so that intefaceNameClient could handle such connection requests properly.
If the inteface name is not yet taken by some other connection, then use it, and also update the inteface name cache if needed. (But generate a new name if already taken by another connection.)

## Issue link

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [x] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
