### PR TITLE
FE; BGP also accepts advertised non-default routes

### DIFF
--- a/cmd/frontend/internal/bird/bgp_test.go
+++ b/cmd/frontend/internal/bird/bgp_test.go
@@ -172,8 +172,8 @@ NBR-gateway1 BGP        ---        up     16:03:22.388  Established
     State:          UP
     Table:          master4
     Preference:     100
-    Input filter:   default_rt
-    Output filter:  cluster_e_static
+    Input filter:   cluster_breakout
+    Output filter:  cluster_access
     Routes:         1 imported, 2 exported, 1 preferred
     Route change stats:     received   rejected   filtered    ignored   accepted
       Import updates:              1          0          0          0          1
@@ -234,8 +234,8 @@ NBR-gateway2 BGP        ---        up     16:03:25.264  Established
     State:          UP
     Table:          master6
     Preference:     100
-    Input filter:   default_rt
-    Output filter:  cluster_e_static
+    Input filter:   cluster_breakout
+    Output filter:  cluster_access
     Routes:         1 imported, 1 exported, 1 preferred
     Route change stats:     received   rejected   filtered    ignored   accepted
       Import updates:              1          0          0          0          1
@@ -255,8 +255,8 @@ NBR-gateway3 BGP        ---        start  17:17:33.913  Idle          Received: 
     State:          DOWN
     Table:          master4
     Preference:     100
-    Input filter:   default_rt
-    Output filter:  cluster_e_static
+    Input filter:   cluster_breakout
+    Output filter:  cluster_access
   Channel ipv6
     State:          DOWN
     Table:          master6
@@ -303,8 +303,8 @@ NBR-gateway4 BGP        ---        up     16:03:25.204  Established
     State:          UP
     Table:          master6
     Preference:     100
-    Input filter:   default_rt
-    Output filter:  cluster_e_static
+    Input filter:   cluster_breakout
+    Output filter:  cluster_access
     Routes:         1 imported, 1 exported, 0 preferred
     Route change stats:     received   rejected   filtered    ignored   accepted
       Import updates:              1          0          0          0          1
@@ -346,8 +346,8 @@ NBR-gateway1 BGP        ---        up     16:03:22.388  Established
     State:          UP
     Table:          master4
     Preference:     100
-    Input filter:   default_rt
-    Output filter:  cluster_e_static
+    Input filter:   cluster_breakout
+    Output filter:  cluster_access
     Routes:         1 imported, 2 exported, 1 preferred
     Route change stats:     received   rejected   filtered    ignored   accepted
       Import updates:              1          0          0          0          1
@@ -408,8 +408,8 @@ NBR-gateway2 BGP        ---        up     17:53:39.604  Established
     State:          UP
     Table:          master6
     Preference:     100
-    Input filter:   default_rt
-    Output filter:  cluster_e_static
+    Input filter:   cluster_breakout
+    Output filter:  cluster_access
     Routes:         1 imported, 1 exported, 1 preferred
     Route change stats:     received   rejected   filtered    ignored   accepted
       Import updates:              1          0          0          0          1
@@ -444,8 +444,8 @@ NBR-gateway3 BGP        ---        up     17:18:30.468  Established
     State:          UP
     Table:          master4
     Preference:     100
-    Input filter:   default_rt
-    Output filter:  cluster_e_static
+    Input filter:   cluster_breakout
+    Output filter:  cluster_access
     Routes:         1 imported, 2 exported, 0 preferred
     Route change stats:     received   rejected   filtered    ignored   accepted
       Import updates:              1          0          0          0          1
@@ -506,8 +506,8 @@ NBR-gateway4 BGP        ---        up     17:53:40.211  Established
     State:          UP
     Table:          master6
     Preference:     100
-    Input filter:   default_rt
-    Output filter:  cluster_e_static
+    Input filter:   cluster_breakout
+    Output filter:  cluster_access
     Routes:         1 imported, 1 exported, 0 preferred
     Route change stats:     received   rejected   filtered    ignored   accepted
       Import updates:              1          0          0          0          1

--- a/cmd/frontend/internal/env/config.go
+++ b/cmd/frontend/internal/env/config.go
@@ -29,9 +29,9 @@ type Config struct {
 	BGPLocalPort          string        `default:"10179" desc:"Local BGP server port" envconfig:"BGP_LOCAL_PORT"`
 	BGPRemotePort         string        `default:"10179" desc:"Remote BGP server port" envconfig:"BGP_REMOTE_PORT"`
 	BGPHoldTime           string        `default:"3" desc:"Seconds to wait for a Keepalive message from peer before considering the connection stale" envconfig:"BGP_HOLD_TIME"`
-	TableID               int           `default:"4096" desc:"OS Kernel routing table ID BIRD syncs the routes with" envconfig:"TABLE_ID"`
+	TableID               int           `default:"4096" desc:"Start ID of the two consecutive OS Kernel routing tables BIRD syncs the routes with" envconfig:"TABLE_ID"`
 	ECMP                  bool          `default:"false" desc:"Enable ECMP towards next-hops of avaialble gateways" envconfig:"ECMP"`
-	DropIfNoPeer          bool          `default:"false" desc:"Install default blackhole route with high metric into routing table TableID" split_words:"true"`
+	DropIfNoPeer          bool          `default:"true" desc:"Install default blackhole route with high metric into routing table TableID" split_words:"true"`
 	LogBird               bool          `default:"false" desc:"Add important bird log snippets to our log" split_words:"true"`
 	Namespace             string        `default:"default" desc:"Namespace the pod is running on" split_words:"true"`
 	NSPService            string        `default:"nsp-service-trench-a:7778" desc:"IP (or domain) and port of the NSP Service" split_words:"true"`

--- a/docs/components/frontend.md
+++ b/docs/components/frontend.md
@@ -15,7 +15,7 @@ Alternatively, the external interface can be provided using Multus in which case
 When started, the frontend installs src routing rules for each configured VIP address, then configures and spins off a [BIRD](https://bird.network.cz/) routing program instance providing for external connectivity. The bird routing suite is restricted to the external interface. The frontend uses [birdc](https://bird.network.cz/?get_doc&v=20&f=bird-4.html) for both monitoring and changing BIRD configuration.
 
 BGP protocol with optional BFD supervision and Static+BFD setup are supported at the moment. Since they lack inherent neighbor discovery mechanism, the external gateway IP addresses must be configured.
-In case of BGP a next-hop route for each VIP address gets announced by the protocol to its external peer advertising the frontend IP as next-hop, thus attracting external traffic to the frontend. While from the external BGP peer a default next-hop route is expected that will be utilized by the VIP src routing to steer egress traffic.
+In case of BGP a next-hop route for each VIP address gets announced by the protocol to its external peer advertising the frontend IP as next-hop, thus attracting external traffic to the frontend. While from the external BGP peer at least one next-hop route is expected to be utilized by the VIP src routing to steer egress traffic. The external BGP peer can decide to announce a default route or a set of network routes.
 
 Both ingress and egress traffic traverse a frontend POD (not necessarily the same).
 
@@ -44,9 +44,9 @@ NFE_REMOTE_AS | string | Local BGP AS number | 4248829953
 NFE_BGP_LOCAL_PORT | string | Local BGP server port | 10179
 NFE_BGP_REMOTE_PORT | string | Remote BGP server port | 10179
 NFE_BGP_HOLD_TIME | string | Seconds to wait for a Keepalive message from peer before considering the connection stale | 3
-NFE_TABLE_ID | int | OS Kernel routing table ID BIRD syncs the routes with | 4096
+NFE_TABLE_ID | int | Start ID of the two consecutive OS Kernel routing tables BIRD syncs the routes with | 4096
 NFE_ECMP | bool | Enable ECMP towards next-hops of avaialble gateways | false
-NFE_DROP_IF_NO_PEER | bool | Install default blackhole route with high metric into routing table TableID | false
+NFE_DROP_IF_NO_PEER | bool | Install default blackhole route with high metric into routing table TableID | true
 NFE_LOG_BIRD | bool | Add important bird log snippets to our log | false
 NFE_NAMESPACE | string | Namespace the pod is running on | default
 NFE_NSP_SERVICE | string | IP (or domain) and port of the NSP Service | nsp-service-trench-a:7778

--- a/docs/demo/scripts/kind/Dockerfile
+++ b/docs/demo/scripts/kind/Dockerfile
@@ -22,5 +22,6 @@ ARG BIRD_CONFIG_PATH=docs/demo/scripts/kind/bird
 
 COPY $BIRD_CONFIG_PATH/bird-common.conf /etc/bird/
 COPY $BIRD_CONFIG_PATH/bird-gw.conf /etc/bird/
+COPY $BIRD_CONFIG_PATH/bird-gw-no-default.conf /etc/bird/
 
 CMD sleep 5 ; /usr/sbin/bird -d -c /etc/bird/bird-gw.conf

--- a/docs/demo/scripts/kind/bird/bird-common.conf
+++ b/docs/demo/scripts/kind/bird/bird-common.conf
@@ -15,61 +15,6 @@ protocol bfd {
 	};
 }
 
-# filter telling what BGP nFE can send to BGP GW peer
-# note: should be the VIP addresses
-filter cluster_e_v4 {
-	if net ~ [ 2.2.2.2/32, 3.3.3.3/32, 4.4.4.4/32 ] then accept;
-	else reject;
-}
-# filter telling what BGP nFE can accept from BGP GW peer
-filter cluster_i_v4 {
-	if ( net ~ [ 0.0.0.0/0 ] ) then accept;
-	reject;
-}
-# filter telling what BGP GW can send to BGP nFE peer
-filter gw_e_v4 {
-	if ( net ~ [ 0.0.0.0/0 ] ) then accept;
-	else reject;
-}
-
-# filter telling what BGP nFE can send to BGP GW peer
-# note: should be the VIP addresses
-filter cluster_e_v6 {
-	if net ~ [ 2000::2/128, 3000::3/128, 4000::4/128 ] then accept;
-	else reject;
-}
-# filter telling what BGP nFE can accept from BGP GW peer
-filter cluster_i_v6 {
-	if ( net ~ [ 0::/0 ] ) then accept;
-	reject;
-}
-# filter telling what BGP GW can send to BGP nFE peer
-filter gw_e_v6 {
-	if ( net ~ [ 0::/0 ] ) then accept;
-	else reject;
-}
-
-# filter matching default IPv4 routes
-filter default_v4 {
-	if ( net ~ [ 0.0.0.0/0 ] ) then accept;
-	else reject;
-}
-# filter matching default IPv4 routes
-filter default_v6 {
-	if ( net ~ [ 0::/0 ] ) then accept;
-	else reject;
-}
-
-# filter telling what BGP nFE can send to BGP GW peer
-# note: should be the VIP addresses
-# Since VIPs are configured as static blackhole routes in BIRD, there's
-# no point maintaining complex v4/v6 filters. Such filters would require
-# updates upon changes related to VIP addresses anyways...
-filter cluster_e_static {
-	if source = RTS_STATIC && dest = RTD_BLACKHOLE then accept;
-	else reject;
-}
-
 template bgp LINK {
  	debug {events};
  	# will imply that the peer is directly connected through the interface

--- a/docs/demo/scripts/kind/bird/bird-gw-no-default.conf
+++ b/docs/demo/scripts/kind/bird/bird-gw-no-default.conf
@@ -1,9 +1,10 @@
 include "bird-common.conf";
 
 
-# Register default routes into BIRD through static blackhole routes,
-# they will get announced to BGP neighbors with a local next-hop IP
-# (refer to "next hop self").
+# Register below routes into BIRD through static blackhole routes.
+# They will get announced to BGP neighbors with a local next-hop IP
+# (refer to "next hop self"). They will serve as cluster breakout routes
+# on the cluster side.
 # note: in kernel protocol forbid syncing these into OS routing table
 #
 # Needed because on routed networks (e.g. calico CNI) the POD default
@@ -11,22 +12,29 @@ include "bird-common.conf";
 # the POD has no interface addresses configured. Such routes are
 # by default rejected by BIRD!
 # e.g.: <ERR> KRT: Received route 0.0.0.0/0 with strange next-hop 169.254.1.1
-#
-# This approach lacks possibility to withdraw such routes announced to BGP
-# neighbors, should anything happen to the "default routing capabality"
-# of the GW (not really relevant in k8s)... 
-protocol static DEFAULT4 {
-	ipv4 { preference 110; };
-	route 0.0.0.0/0 blackhole;
+protocol static NET4_1 {
+	ipv4 { preference 100; };
+	route 169.254.0.0/16 blackhole;
 }
 
-protocol static DEFAULT6 {
-	ipv6 { preference 110; };
-	route 0::/0 blackhole;	
+protocol static NET4_2 {
+        ipv4 { preference 100; };
+        route 200.100.0.0/16 blackhole;
 }
 
-# Do not sync above default backhole routes into OS kernel.
-# But export everything (VIP routes) learned through BGP neighbors.
+protocol static NET6_1 {
+	ipv6 { preference 100; };
+	route 100::/16 blackhole;
+}
+
+protocol static NET6_2 {
+        ipv6 { preference 100; };
+        route 200:100::/32 blackhole;
+}
+
+# Do not sync above backhole routes into OS kernel.
+# But export everything (VIP routes) learned through BGP neighbors
+# into OS kernel.
 filter gw_kernel_export {
 	if source = RTS_STATIC && dest = RTD_BLACKHOLE then reject;
 	else accept;
@@ -88,7 +96,7 @@ protocol bgp GW6 from LINK {
 	neighbor range 0::/0 port 10179 as 8103;
 	dynamic name "GW6_";
 	ipv6 {
-		import all;		            # expecting VIP addresses from the nFE peer
+		import all;			        # expecting VIP addresses from the nFE peer
 		export filter bgp_announce;	# push route(s) intended to get announced to BGP peer
 	};
 }

--- a/docs/demo/scripts/kind/external-host.sh
+++ b/docs/demo/scripts/kind/external-host.sh
@@ -1,5 +1,20 @@
 #! /bin/bash
 
+while echo "$1" | grep -q '^--'; do
+        if echo $1 | grep -q =; then
+                o=$(echo "$1" | cut -d= -f1 | sed -e 's,-,_,g')
+                v=$(echo "$1" | cut -d= -f2-)
+                eval "$o=\"$v\""
+        else
+                o=$(echo "$1" | sed -e 's,-,_,g')
+                eval "$o=yes"
+        fi
+        shift
+done
+unset o v
+long_opts=`set | grep '^__' | cut -d= -f1`
+
+test -n "$__default_route" || __default_route=yes  # BGP to annouce default routes by default
 parent_if_name="eth0"
 vlan_id="100"
 
@@ -10,11 +25,17 @@ for (( index_trench=0; index_trench<=$((${#trenches[@]}-1)); index_trench++ ))
 do
     vi=$((vlan_id + index_trench * 100))
     container_name=${trenches[$index_trench]}
+    cmd=""
 
     docker kill $container_name || true
     docker rm $container_name || true
 
-    docker run -t -d --network="kind" --name="$container_name" --privileged registry.nordix.org/cloud-native/meridio/kind-host:latest
+    if [ "$__default_route" == "yes" ]; then
+        docker run -t -d --network="kind" --name="$container_name" --privileged localhost:80/cloud-native/meridio/kind-host:bgp-test
+    else
+        docker run -t -d --network="kind" --name="$container_name" --privileged localhost:80/cloud-native/meridio/kind-host:bgp-test \
+            /bin/sh -c "sleep 5 ; /usr/sbin/bird -d -c /etc/bird/bird-gw-no-default.conf"
+    fi
     
     docker exec $container_name sh -c "echo \"PS1='[GW/TG] $container_name | VLAN:${vi}..$(($vi + ${#vlans[@]}-1))> '\" >> ~/.bashrc"
 
@@ -31,11 +52,20 @@ do
         v_id=$((vi + index_vlan))
         ip="169.254.$((vlan_id + index_vlan)).150/24"
         ip6="100:$((vlan_id + index_vlan))::150/64"
+
+        # Create IP addresses for traffic tests that are not part of the network shared with
+        # external interfaces on the connected cluster. Thus, cluster side device routes wouldn't
+        # interfere.
+        # Note: local BGP must announce these networks
+        tip="200.100.0.$((vlan_id + index_vlan))/32"
+        tip6="200:100::$((vlan_id + index_vlan))/128"
         
         docker exec $container_name ip link add link $parent_if_name name $if_name type vlan id $v_id
         docker exec $container_name ip link set $if_name up
         docker exec $container_name ip addr add $ip dev $if_name
         docker exec $container_name ip addr add $ip6 dev $if_name
+        docker exec $container_name ip addr add $tip dev $if_name
+        docker exec $container_name ip addr add $tip6 dev $if_name
 
         docker exec $container_name ethtool -K $parent_if_name tx off
     done

--- a/docs/demo/scripts/kind/external-host.sh
+++ b/docs/demo/scripts/kind/external-host.sh
@@ -31,9 +31,9 @@ do
     docker rm $container_name || true
 
     if [ "$__default_route" == "yes" ]; then
-        docker run -t -d --network="kind" --name="$container_name" --privileged localhost:80/cloud-native/meridio/kind-host:bgp-test
+        docker run -t -d --network="kind" --name="$container_name" --privileged registry.nordix.org/cloud-native/meridio/kind-host:latest
     else
-        docker run -t -d --network="kind" --name="$container_name" --privileged localhost:80/cloud-native/meridio/kind-host:bgp-test \
+        docker run -t -d --network="kind" --name="$container_name" --privileged registry.nordix.org/cloud-native/meridio/kind-host:latest \
             /bin/sh -c "sleep 5 ; /usr/sbin/bird -d -c /etc/bird/bird-gw-no-default.conf"
     fi
     


### PR DESCRIPTION
## Description
- BIRD filters used by the generated BIRD configuration have been updated to accept non-default routes announced by connected BGP peers.

- Introduced new low prio PBR rule to ensure outbound VIP traffic is not misrouted, i.e. will not be leaked to primary network.
Blackhole logic is installed by default, but can be configured through frontend env variable DROP_IF_NO_PEER.
(The related blackhole routes are inserted by BIRD as well.)

- Updated external-host test tool to either announce default routes (default behavior), or advertise certain pre-defined network routes.

Start external-host to announce non-default routes:
./docs/demo/scripts/kind/external-host.sh --default-route=no

## Issue link
#453 

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
