### PR TITLE
LB; improve PMTUd support for external clients

### DIFF
--- a/config/operator/operator.yaml
+++ b/config/operator/operator.yaml
@@ -57,6 +57,8 @@ spec:
                 fieldPath: metadata.namespace
           - name: GRPC_PROBE_RPC_TIMEOUT
             value: "1s"
+          - name: CONDUIT_MTU
+            value: "1500"
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/deployments/helm/templates/_helpers.tpl
+++ b/deployments/helm/templates/_helpers.tpl
@@ -6,11 +6,11 @@ Set IP Family
 
 {{- define "meridio.loadBalancer.sysctls" -}}
 {{- if eq .Values.ipFamily "dualstack" -}}
-{{- printf "sysctl -w net.ipv6.conf.all.forwarding=1 ; sysctl -w net.ipv4.conf.all.forwarding=1 ; sysctl -w net.ipv4.fib_multipath_hash_policy=1 ; sysctl -w net.ipv6.fib_multipath_hash_policy=1 ; sysctl -w net.ipv4.conf.all.rp_filter=0 ; sysctl -w net.ipv4.conf.default.rp_filter=0 ; sysctl -w net.ipv4.ip_local_port_range='49152 65535'" -}}
+{{- printf "sysctl -w net.ipv6.conf.all.forwarding=1 ; sysctl -w net.ipv4.conf.all.forwarding=1 ; sysctl -w net.ipv4.fib_multipath_hash_policy=1 ; sysctl -w net.ipv6.fib_multipath_hash_policy=1 ; sysctl -w net.ipv4.conf.all.rp_filter=0 ; sysctl -w net.ipv4.conf.default.rp_filter=0 ; sysctl -w net.ipv4.ip_local_port_range='49152 65535' ; sysctl -w net.ipv4.fwmark_reflect=1 ; sysctl -w net.ipv6.fwmark_reflect=1 " -}}
 {{- else if eq .Values.ipFamily "ipv6" -}}
-{{- printf "sysctl -w net.ipv6.conf.all.forwarding=1 ; sysctl -w net.ipv6.fib_multipath_hash_policy=1 ; sysctl -w net.ipv4.ip_local_port_range='49152 65535'" -}}
+{{- printf "sysctl -w net.ipv6.conf.all.forwarding=1 ; sysctl -w net.ipv6.fib_multipath_hash_policy=1 ; sysctl -w net.ipv4.ip_local_port_range='49152 65535' ; sysctl -w net.ipv6.fwmark_reflect=1" -}}
 {{- else -}}
-{{- printf "sysctl -w net.ipv4.conf.all.forwarding=1 ; sysctl -w net.ipv4.fib_multipath_hash_policy=1 ; sysctl -w net.ipv4.ip_local_port_range='49152 65535'" -}}
+{{- printf "sysctl -w net.ipv4.conf.all.forwarding=1 ; sysctl -w net.ipv4.fib_multipath_hash_policy=1 ; sysctl -w net.ipv4.ip_local_port_range='49152 65535' ; sysctl -w net.ipv4.fwmark_reflect=1" -}}
 {{- end -}}
 {{- end -}}
 

--- a/docs/components/stateless-lb.md
+++ b/docs/components/stateless-lb.md
@@ -73,6 +73,8 @@ Sysctl: net.ipv4.fib_multipath_hash_policy=1 | To use Layer 4 hash policy for EC
 Sysctl: net.ipv6.fib_multipath_hash_policy=1 | To use Layer 4 hash policy for ECMP on IPv6
 Sysctl: net.ipv4.conf.all.rp_filter=0 | Allow packets to have a source IPv4 address which does not correspond to any routing destination address.
 Sysctl: net.ipv4.conf.default.rp_filter=0 | Allow packets to have a source IPv6 address which does not correspond to any routing destination address.
+Sysctl: net.ipv4.fwmark_reflect=1 | Allow LB generated outbound ICMP Frag Needed reply to use VIP as source address.
+Sysctl: net.ipv6.fwmark_reflect=1 | Allow LB generated outbound ICMPv6 Packet Too Big reply to use VIP as source address.
 NET_ADMIN | The load balancer configures IP rules and IP routes to steer packets (processed by [nfqueue-loadbalancer program](https://github.com/Nordix/nfqueue-loadbalancer)) to targets. The user space load balancer program relies on [libnetfilter_queue](https://netfilter.org/projects/libnetfilter_queue).
 IPC_LOCK | The user space load balancer program uses shared memory.
 IPC_OWNER | The user space load balancer program uses shared memory.

--- a/pkg/controllers/common/const.go
+++ b/pkg/controllers/common/const.go
@@ -19,6 +19,7 @@ package common
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -36,6 +37,7 @@ const (
 	NspServiceAccountEnv    = "NSP_SERVICE_ACCOUNT"
 	FeServiceAccountEnv     = "FE_SERVICE_ACCOUNT"
 	GRPCHealthRPCTimeoutEnv = "GRPC_PROBE_RPC_TIMEOUT" // RPC timeout of grpc_health_probes run from code
+	ConduitMTU              = "CONDUIT_MTU"            // Control default Conduit MTU
 
 	Registry        = "registry.nordix.org"
 	Organization    = "cloud-native/meridio"
@@ -157,6 +159,15 @@ func GetNSMRegistryService() string {
 
 func GetLogLevel() string {
 	return os.Getenv(LogLevelEnv)
+}
+
+func GetConduitMTU() string {
+	mtu := os.Getenv(ConduitMTU)
+	// not doing any other sanity checks
+	if _, err := strconv.ParseUint(mtu, 10, 32); err != nil {
+		return ""
+	}
+	return mtu
 }
 
 func GetImagePullSecrets() []corev1.LocalObjectReference {

--- a/pkg/controllers/common/models.go
+++ b/pkg/controllers/common/models.go
@@ -37,14 +37,16 @@ func GetIPFamily(cr *meridiov1.Trench) string {
 const ipv4SysCtl = "sysctl -w net.ipv4.conf.all.forwarding=1 ; sysctl -w net.ipv4.fib_multipath_hash_policy=1 ; sysctl -w net.ipv4.conf.all.rp_filter=0 ; sysctl -w net.ipv4.conf.default.rp_filter=0"
 const ipv6SysCtl = "sysctl -w net.ipv6.conf.all.forwarding=1 ; sysctl -w net.ipv6.fib_multipath_hash_policy=1"
 const localPortRangeSysCtl = "sysctl -w net.ipv4.ip_local_port_range='49152 65535'" // ephemeral port range to make BIRD use IANA approved src ports for BFD
+const ipv4FwmarkReflect = "sysctl -w net.ipv4.fwmark_reflect=1"
+const ipv6FwmarkReflect = "sysctl -w net.ipv6.fwmark_reflect=1"
 
 func GetLoadBalancerSysCtl(cr *meridiov1.Trench) string {
 	if cr.Spec.IPFamily == string(meridiov1.Dualstack) {
-		return fmt.Sprintf("%s ; %s ; %s", ipv4SysCtl, ipv6SysCtl, localPortRangeSysCtl)
+		return fmt.Sprintf("%s ; %s ; %s ; %s ; %s", ipv4SysCtl, ipv6SysCtl, localPortRangeSysCtl, ipv4FwmarkReflect, ipv6FwmarkReflect)
 	} else if cr.Spec.IPFamily == string(meridiov1.IPv4) {
-		return fmt.Sprintf("%s ; %s", ipv4SysCtl, localPortRangeSysCtl)
+		return fmt.Sprintf("%s ; %s; %s", ipv4SysCtl, localPortRangeSysCtl, ipv4FwmarkReflect)
 	} else if cr.Spec.IPFamily == string(meridiov1.IPv6) {
-		return fmt.Sprintf("%s ; %s", ipv6SysCtl, localPortRangeSysCtl)
+		return fmt.Sprintf("%s ; %s ; %s", ipv6SysCtl, localPortRangeSysCtl, ipv6FwmarkReflect)
 	}
 	return ""
 }

--- a/pkg/controllers/conduit/proxy.go
+++ b/pkg/controllers/conduit/proxy.go
@@ -72,6 +72,9 @@ func (i *Proxy) getEnvVars(allEnv []corev1.EnvVar) []corev1.EnvVar {
 	if rpcTimeout := common.GetGRPCProbeRPCTimeout(); rpcTimeout != "" {
 		operatorEnv["NSM_GRPC_PROBE_RPC_TIMEOUT"] = rpcTimeout
 	}
+	if mtu := common.GetConduitMTU(); mtu != "" {
+		operatorEnv["NSM_MTU"] = mtu
+	}
 	return common.CompileEnvironmentVariables(allEnv, operatorEnv)
 }
 


### PR DESCRIPTION
## Description
In LB-FE make sure to return ICMP reply to external party from the VIP src the offending packet was sent to.

This is achieved by using nftables rules doing stateless SNAT on ICMP replies generated by the LB-FE.
Only replies triggered by incoming packets with VIP dst are of interest. (In which case MTU related ICMP reply can be triggered during forwarding of the original packet.)

Solution requires sysctl fwmark_reflect enabled for both ipv4 and ipv6:
- Helps limit scope of the introduced rules by checking if fwmark is non-zero.
- Inheriting the fwmark value of the original packet allows for an early successful route lookup due to the Target specific routes in place, thus the ICMP reply can be generated by the stack (instead of being discarded due to unreachable error).
https://elixir.bootlin.com/linux/v5.10/source/net/ipv6/icmp.c#L598
https://elixir.bootlin.com/linux/v5.10.194/source/net/ipv4/icmp.c#L744

#### In case using fwmark_reflect sysctls is not desirable:
If it could be granted that "plain routes" even pointing to wrong network (e.g. default routes for both IPv4 and IPv6) would exist for all possible remote addresses for which an ICMP Frag Needed/Packet Too Big should be returned, then nft rules could be replaced to check the encapsulated original packets addresses instead of relying on fwmark value. (Orig dst must be a VIP, but not the src.)

(In case of IPv6 adding a src route to match packets from IPv6 address of the external interface and point them e.g. towards the BIRD maintained routing table also works.)

### Test:
- Lower Meridio internal MTU by setting the NSM_MTU env variable in Proxy (e.g. to 1280)
- Setup a Kind cluster with Meridio and external-host. Running 1 LB-FE is sufficient
- Run tcpdump in both LB-FE and external-host capturing ICMP Frag Needed and ICMPv6 Packet Too Big
- On external-host use ping to send out big packets (use "-M do" in case of IPv4 to force IP DF bit):
  ping 20.0.0.1 -s 1380 -M do
  ping 2000::1 -s 1380 -M do
  Additionally, it's advised to configure additional new IPv4 and IPv6 "TG" addresses on the external-host's vlan0 interface, and use those to send out pings from (to not rely on existing device routes in the LB-FE):
    ping -I 5.5.5.5 20.0.0.1 -s 1380 -M do
    ping -I 5000::1 2000::1 -s 1380 -M do
- The ICMP replies must be sent out by the LB-FE using the VIP address as source the offending packet was destined to.
  Try without the PR as well, in which case depending on the src address of the original packet the ICMP reply will be either sent out to the primary network, or the external network using an address configured on the external interface.

## Issue link
#452 

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
