### PR TITLE
operator; fix mount path of resource templates

### DIFF
--- a/config/operator/patches/operator_resource_templates_patch.yaml
+++ b/config/operator/patches/operator_resource_templates_patch.yaml
@@ -10,7 +10,7 @@ spec:
       - name: operator
         volumeMounts:
         - name: resource-templates
-          mountPath: "/template/resource"
+          mountPath: "/home/meridio/template/resource"
           readOnly: true
       volumes:
       - name: resource-templates


### PR DESCRIPTION
## Description
Fix mount path of resource templates.
Since home dir has been changed in the image by some commit, the operator was unable to open the resource templates.

## Issue link
#458 

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
