### PR TITLE
FE; monitor BIRD route statistics

### DIFF
--- a/cmd/frontend/internal/bird/bird.go
+++ b/cmd/frontend/internal/bird/bird.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -226,6 +226,28 @@ func (b *RoutingService) ShowBfdSessions(ctx context.Context, lp, name string) (
 	}
 	if name != "" {
 		args = append(args, `'`+name+`'`)
+	}
+	return b.CliCmd(ctx, lp, args...)
+}
+
+// ShowRouteCount -
+// Retrieves number of routes from default BIRD routing tables (master4, master6)
+// Note: using filters significantly increases CPU usage
+func (b *RoutingService) ShowRouteCount(ctx context.Context, lp string) (string, error) {
+	args := []string{
+		"show",
+		"route",
+		"count",
+	}
+	return b.CliCmd(ctx, lp, args...)
+}
+
+// ShowMemory -
+// Retrieves memory usage information
+func (b *RoutingService) ShowMemory(ctx context.Context, lp string) (string, error) {
+	args := []string{
+		"show",
+		"memory",
 	}
 	return b.CliCmd(ctx, lp, args...)
 }

--- a/cmd/frontend/internal/bird/route.go
+++ b/cmd/frontend/internal/bird/route.go
@@ -1,0 +1,39 @@
+/*
+Copyright (c) 2023 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bird
+
+import (
+	"bufio"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var regexRouteCount *regexp.Regexp = regexp.MustCompile(`Total:\s+([0-9]+)`)
+
+func ParseRouteCount(input string) (uint64, error) {
+	var err error
+	var rc uint64 = 0
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	for scanner.Scan() {
+		if match := regexRouteCount.FindStringSubmatch(scanner.Text()); match != nil {
+			rc, err = strconv.ParseUint(match[1], 10, 32)
+			break
+		}
+	}
+	return rc, err
+}

--- a/cmd/frontend/internal/connectivity/conn_test.go
+++ b/cmd/frontend/internal/connectivity/conn_test.go
@@ -34,7 +34,6 @@ func TestStatusNoConfig(t *testing.T) {
 	cs.SetNoConfig(syscall.AF_INET)
 	cs.SetNoConfig(syscall.AF_INET6)
 
-	t.Logf("cs: %v\n", cs.String())
 	assert.Equal(connectivity.NoConfig, cs.Status())
 	assert.False(cs.AnyGatewayDown())
 	assert.True(cs.NoConnectivity())

--- a/cmd/frontend/internal/connectivity/connectivity.go
+++ b/cmd/frontend/internal/connectivity/connectivity.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ limitations under the License.
 package connectivity
 
 import (
-	"fmt"
+	"strings"
 	"syscall"
 )
 
@@ -30,6 +30,15 @@ const (
 	Up           = IPv4Up | IPv6Up             // FE has IPv4 and IPv6 external connectivity
 	NoConfig     = NoIPv4Config | NoIPv6Config // No Gateways configured at all
 )
+
+// note: Up and NoConfig are ignored because they are composed of other flags
+var statusToString = map[uint64]string{
+	IPv4Up:       "IPv4 UP",
+	IPv6Up:       "IPv6 UP",
+	NoIPv4Config: "No IPv4 Gateway Configured",
+	NoIPv6Config: "No IPv6 Gateway Configured",
+	AnyGWDown:    "Gateway Down",
+}
 
 func NewConnectivityStatus() *ConnectivityStatus {
 	return &ConnectivityStatus{
@@ -105,10 +114,19 @@ func (cs *ConnectivityStatus) Status() uint64 {
 	return cs.status
 }
 
-func (cs *ConnectivityStatus) StatusMap() map[string]bool {
-	return cs.statusMap
+// StatusToString -
+// Returns a string representation of the connectivity status
+func (cs *ConnectivityStatus) ToString() string {
+	currentStatus := cs.status
+	list := make([]string, 0)
+	for k, v := range statusToString {
+		if k&currentStatus != 0 {
+			list = append(list, v)
+		}
+	}
+	return strings.Join(list, ", ")
 }
 
-func (cs *ConnectivityStatus) String() string {
-	return fmt.Sprintf("%v, %v, \n%v", cs.status, cs.statusMap, cs.log)
+func (cs *ConnectivityStatus) StatusMap() map[string]bool {
+	return cs.statusMap
 }

--- a/cmd/frontend/internal/frontend/stats.go
+++ b/cmd/frontend/internal/frontend/stats.go
@@ -1,0 +1,139 @@
+/*
+Copyright (c) 2023 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package frontend
+
+import (
+	"context"
+	"strings"
+
+	"github.com/nordix/meridio/cmd/frontend/internal/bird"
+	"github.com/nordix/meridio/pkg/log"
+)
+
+const routePrintRateLimit int = 60 // max iterations (calls to limit) to wait before printing minor changes
+const routeThreshold uint64 = 1000 // diff threshold below which rate limiter is active
+
+type RateLimiter struct {
+	limit     int    // number of iterations to wait before lifting the rate limiter imposed block assuming diff is below threshold
+	threshold uint64 // diff threshold below which RateLimiter activates/is active
+}
+
+func NewRateLimiter(limit int, threshold uint64) *RateLimiter {
+	return &RateLimiter{
+		limit:     limit,
+		threshold: threshold,
+	}
+}
+
+// Active -
+// Returns true if rate limiter is active
+func (rl *RateLimiter) Active() bool {
+	return rl.limit > 0
+}
+
+// Permit -
+// Returns false if rate limiter says NOT to permit actions, true otherwise.
+func (rl *RateLimiter) Permit(diff uint64) bool {
+	if diff < rl.threshold {
+		// no diff, disable rate limiter, but still no permit (new value equals the last printed value)
+		if diff == 0 {
+			rl.limit = 0
+			return false
+		}
+		// minor change, enable rate limiter if not active and no permit
+		if !rl.Active() {
+			rl.limit = routePrintRateLimit
+			return false
+		}
+		// rate limiter already enabled, no permit until limit drops to zero
+		rl.limit = rl.limit - 1
+		if rl.limit > 0 {
+			return false
+		}
+	}
+	// permit, disable rate limiter if active
+	rl.limit = 0
+	return true
+}
+
+type RouteStats struct {
+	lastCount   uint64       // last recorded and printed route count
+	rateLimiter *RateLimiter // to avoid spamming logs on frequent changes
+}
+
+func NewRouteStats() *RouteStats {
+	return &RouteStats{
+		rateLimiter: NewRateLimiter(routePrintRateLimit, routeThreshold),
+	}
+}
+
+// LimiterActive -
+// Returns true if a route limiter is set and is actived (i.e. blocks actions)
+func (rs *RouteStats) LimiterActive() bool {
+	return rs.rateLimiter != nil && rs.rateLimiter.Active()
+}
+
+// Skip -
+// Returns true if a rate limiter is set and its Permit() func returns false
+func (rs *RouteStats) Skip(diff uint64) bool {
+	if rs.rateLimiter == nil {
+		return false
+	}
+	return !rs.rateLimiter.Permit(diff)
+}
+
+// checkRoutes -
+// Checks and logs number of routes in routing suite.
+// Employes some basic rate limiter to reduce spamming in case of minor changes.
+//
+// Note: IMHO it's not the best concept; BIRD routing suite seems to block the
+// CLI operation while the routing entries are being processed or a reconfiguration
+// is ongoing.. In my tests transfering 100k routes takes 2-3 seconds. The checker
+// is not able to print any information before that.
+// Consider there are even more routes and OMM just kills the container due to its
+// memory usage, but there's nothing in the logs...
+func (fes *FrontEndService) checkRoutes(ctx context.Context, stats *RouteStats, lp string) {
+	logger := log.FromContextOrGlobal(ctx)
+	routeOut, err := fes.routingService.ShowRouteCount(ctx, lp)
+	if err != nil {
+		logger.Info("Route check failed", "err", err, "out", strings.Split(routeOut, "\n"))
+		return
+	}
+	if routeCount, err := bird.ParseRouteCount(routeOut); err == nil && stats.lastCount != routeCount || stats.LimiterActive() {
+		// XXX: Number of routes might fluctuate, use basic log rate limiter:
+		// Log right away if new number differs from previous value by more than 1000.
+		// Otherwise start rate limiter, i.e. wait for either the change to exceed the
+		// threshold or for pre-defined number of checks to print the most recent value.
+		var diff uint64
+		lastCount := stats.lastCount
+		if routeCount < lastCount {
+			diff = lastCount - routeCount
+		} else {
+			diff = routeCount - lastCount
+		}
+		if stats.Skip(diff) {
+			return
+		}
+		// The number of routes maintained by routing service (includes all routes)
+		logger.Info("Total number routes", "count", routeCount, "out", strings.Split(routeOut, "\n"))
+		stats.lastCount = routeCount
+		// Fetch memory usage information
+		if memOut, err := fes.routingService.ShowMemory(ctx, lp); err == nil {
+			logger.Info("Memory usage", "memor", strings.Split(memOut, "\n"))
+		}
+	}
+}


### PR DESCRIPTION
## Description
Monitor BIRD route statistics.
BGP functionality in FE also accepts non-default routes, but a huge set of routing entries could have a negative effect on the system (e.g., increased memory usage).

As part of connectivity monitoring, print number of routes hosted by the default BIRD routing tables (master4/master6), and log memory usage.
Note: BIRD seems to block route related queries via the CLI during reconfiguration and during processing routes.

## Issue link
#453

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
