### PR TITLE
operator; BGP ports default to 179

### DIFF
--- a/api/v1/gateway_types.go
+++ b/api/v1/gateway_types.go
@@ -65,9 +65,17 @@ type BgpSpec struct {
 	// +optional
 	HoldTime string `json:"hold-time,omitempty"`
 
+	// +kubebuilder:default=179
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+
 	// BGP listening port of the Gateway Router.
 	// +optional
 	RemotePort *uint16 `json:"remote-port,omitempty"`
+
+	// +kubebuilder:default=179
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
 
 	// BGP listening port of the Attractor FrontEnds.
 	// +optional

--- a/config/crd/bases/meridio.nordix.org_gateways.yaml
+++ b/config/crd/bases/meridio.nordix.org_gateways.yaml
@@ -114,14 +114,20 @@ spec:
                     format: int32
                     type: integer
                   local-port:
+                    default: 179
                     description: BGP listening port of the Attractor FrontEnds.
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   remote-asn:
                     description: The ASN number of the Gateway Router
                     format: int32
                     type: integer
                   remote-port:
+                    default: 179
                     description: BGP listening port of the Gateway Router.
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                 type: object
               protocol:


### PR DESCRIPTION
## Description
In Gateway Custom Resource BGP port parameters default to 179.
It's not mandatory anymore to set these ports explicitly when defining a CR.

## Issue link
#405 

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
