### PR TITLE
Target hits metrics

### DIFF
--- a/docs/observability/dashboard.json
+++ b/docs/observability/dashboard.json
@@ -18,10 +18,424 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
-    "id": 28,
+    "id": 29,
     "links": [],
     "liveNow": false,
     "panels": [
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "custom": {
+                        "align": "auto",
+                        "cellOptions": {
+                            "type": "auto"
+                        },
+                        "filterable": false,
+                        "inspect": false,
+                        "minWidth": 150
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 20,
+                "w": 12,
+                "x": 0,
+                "y": 0
+            },
+            "id": 3,
+            "options": {
+                "cellHeight": "sm",
+                "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                        "sum"
+                    ],
+                    "show": false
+                },
+                "showHeader": true
+            },
+            "pluginVersion": "10.1.5",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "disableTextWrap": false,
+                    "editorMode": "builder",
+                    "exemplar": false,
+                    "expr": "meridio_conduit_stream_target_hits_packets_total",
+                    "format": "table",
+                    "fullMetaSearch": false,
+                    "includeNullMetadata": true,
+                    "instant": true,
+                    "legendFormat": "__auto",
+                    "range": false,
+                    "refId": "packets",
+                    "useBackend": false
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "disableTextWrap": false,
+                    "editorMode": "builder",
+                    "exemplar": false,
+                    "expr": "meridio_conduit_stream_target_hits_bytes_total",
+                    "format": "table",
+                    "fullMetaSearch": false,
+                    "hide": false,
+                    "includeNullMetadata": true,
+                    "instant": true,
+                    "legendFormat": "__auto",
+                    "range": false,
+                    "refId": "bytes",
+                    "useBackend": false
+                }
+            ],
+            "title": "Target Hits",
+            "transformations": [
+                {
+                    "id": "merge",
+                    "options": {}
+                },
+                {
+                    "id": "organize",
+                    "options": {
+                        "excludeByName": {
+                            "Time": true,
+                            "Value": false,
+                            "__name__": true,
+                            "container": true,
+                            "endpoint": true,
+                            "instance": true,
+                            "job": true,
+                            "namespace": true,
+                            "otel_scope_name": true,
+                            "pod": true
+                        },
+                        "indexByName": {
+                            "Conduit": 1,
+                            "Hostname": 3,
+                            "IPs": 5,
+                            "Identifier": 4,
+                            "Stream": 2,
+                            "Time": 6,
+                            "Trench": 0,
+                            "Value": 15,
+                            "__name__": 7,
+                            "container": 8,
+                            "endpoint": 9,
+                            "instance": 10,
+                            "job": 11,
+                            "namespace": 12,
+                            "otel_scope_name": 13,
+                            "pod": 14
+                        },
+                        "renameByName": {
+                            "Value #packets": ""
+                        }
+                    }
+                },
+                {
+                    "id": "groupBy",
+                    "options": {
+                        "fields": {
+                            "Conduit": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "Hostname": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "IPs": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "Identifier": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "Stream": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "Trench": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "Value #bytes": {
+                                "aggregations": [
+                                    "lastNotNull"
+                                ],
+                                "operation": "aggregate"
+                            },
+                            "Value #packets": {
+                                "aggregations": [
+                                    "lastNotNull"
+                                ],
+                                "operation": "aggregate"
+                            }
+                        }
+                    }
+                },
+                {
+                    "id": "organize",
+                    "options": {
+                        "excludeByName": {},
+                        "indexByName": {},
+                        "renameByName": {
+                            "Identifier": "",
+                            "Value #bytes (lastNotNull)": "Bytes",
+                            "Value #packets (lastNotNull)": "Packets"
+                        }
+                    }
+                }
+            ],
+            "type": "table"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "custom": {
+                        "align": "auto",
+                        "cellOptions": {
+                            "type": "auto"
+                        },
+                        "inspect": false
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 12,
+                "w": 12,
+                "x": 12,
+                "y": 0
+            },
+            "id": 2,
+            "options": {
+                "cellHeight": "sm",
+                "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                        "sum"
+                    ],
+                    "show": false
+                },
+                "showHeader": true
+            },
+            "pluginVersion": "10.1.5",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "disableTextWrap": false,
+                    "editorMode": "builder",
+                    "exemplar": false,
+                    "expr": "meridio_conduit_stream_flow_matches_total",
+                    "format": "table",
+                    "fullMetaSearch": false,
+                    "includeNullMetadata": true,
+                    "instant": true,
+                    "legendFormat": "__auto",
+                    "range": false,
+                    "refId": "A",
+                    "useBackend": false
+                }
+            ],
+            "title": "Flow List",
+            "transformations": [
+                {
+                    "id": "organize",
+                    "options": {
+                        "excludeByName": {
+                            "Flow": false,
+                            "Hostname": false,
+                            "Time": true,
+                            "__name__": true,
+                            "container": true,
+                            "endpoint": true,
+                            "exported_job": true,
+                            "instance": true,
+                            "job": true,
+                            "namespace": true,
+                            "otel_scope_name": true,
+                            "pod": true,
+                            "service": true
+                        },
+                        "indexByName": {
+                            "Conduit": 2,
+                            "Flow": 4,
+                            "Hostname": 5,
+                            "Stream": 3,
+                            "Time": 0,
+                            "Trench": 1,
+                            "Value": 15,
+                            "__name__": 6,
+                            "container": 7,
+                            "endpoint": 8,
+                            "exported_job": 9,
+                            "instance": 10,
+                            "job": 11,
+                            "namespace": 12,
+                            "pod": 13,
+                            "service": 14
+                        },
+                        "renameByName": {
+                            "Value": "Packets"
+                        }
+                    }
+                }
+            ],
+            "type": "table"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 12
+            },
+            "id": 1,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "disableTextWrap": false,
+                    "editorMode": "builder",
+                    "expr": "sum by(Flow, Stream, Conduit, Trench) (rate(meridio_conduit_stream_flow_matches_total[$__rate_interval]))",
+                    "fullMetaSearch": false,
+                    "includeNullMetadata": true,
+                    "legendFormat": "{{Flow}}.{{Stream}}.{{Conduit}}.{{Trench}}",
+                    "range": true,
+                    "refId": "A",
+                    "useBackend": false
+                }
+            ],
+            "title": "Flow Match (packet per second)",
+            "type": "timeseries"
+        },
         {
             "datasource": {
                 "type": "prometheus",
@@ -84,9 +498,9 @@
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 0
+                "y": 20
             },
-            "id": 1,
+            "id": 5,
             "options": {
                 "legend": {
                     "calcs": [],
@@ -99,6 +513,7 @@
                     "sort": "none"
                 }
             },
+            "pluginVersion": "10.1.5",
             "targets": [
                 {
                     "datasource": {
@@ -107,16 +522,21 @@
                     },
                     "disableTextWrap": false,
                     "editorMode": "builder",
-                    "expr": "sum by(Flow, Stream, Conduit, Trench) (rate(meridio_conduit_stream_flow_matches_total[$__rate_interval]))",
+                    "exemplar": false,
+                    "expr": "sum by(Trench, Conduit, Stream) (rate(meridio_conduit_stream_target_hits_packets_total[$__rate_interval]))",
+                    "format": "time_series",
                     "fullMetaSearch": false,
-                    "includeNullMetadata": true,
-                    "legendFormat": "{{Flow}}.{{Stream}}.{{Conduit}}.{{Trench}}",
+                    "hide": false,
+                    "includeNullMetadata": false,
+                    "instant": false,
+                    "legendFormat": "{{Stream}}.{{Conduit}}.{{Trench}}",
                     "range": true,
-                    "refId": "A",
+                    "refId": "packets",
                     "useBackend": false
                 }
             ],
-            "title": "Flow Match (packet per second)",
+            "title": "Stream (packets per second)",
+            "transformations": [],
             "type": "timeseries"
         },
         {
@@ -127,14 +547,38 @@
             "fieldConfig": {
                 "defaults": {
                     "color": {
-                        "mode": "thresholds"
+                        "mode": "palette-classic"
                     },
                     "custom": {
-                        "align": "auto",
-                        "cellOptions": {
-                            "type": "auto"
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
                         },
-                        "inspect": false
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
                     },
                     "mappings": [],
                     "thresholds": {
@@ -154,25 +598,25 @@
                 "overrides": []
             },
             "gridPos": {
-                "h": 12,
+                "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 0
+                "y": 20
             },
-            "id": 2,
+            "id": 6,
             "options": {
-                "cellHeight": "sm",
-                "footer": {
-                    "countRows": false,
-                    "fields": "",
-                    "reducer": [
-                        "sum"
-                    ],
-                    "show": false
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
                 },
-                "showHeader": true
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
             },
-            "pluginVersion": "10.1.4",
+            "pluginVersion": "10.1.5",
             "targets": [
                 {
                     "datasource": {
@@ -182,60 +626,21 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "meridio_conduit_stream_flow_matches_total",
-                    "format": "table",
+                    "expr": "sum by(Trench, Conduit, Stream) (rate(meridio_conduit_stream_target_hits_bytes_total[$__rate_interval]))",
+                    "format": "time_series",
                     "fullMetaSearch": false,
-                    "includeNullMetadata": true,
-                    "instant": true,
-                    "legendFormat": "__auto",
-                    "range": false,
-                    "refId": "A",
+                    "hide": false,
+                    "includeNullMetadata": false,
+                    "instant": false,
+                    "legendFormat": "{{Stream}}.{{Conduit}}.{{Trench}}",
+                    "range": true,
+                    "refId": "packets",
                     "useBackend": false
                 }
             ],
-            "title": "Flow List",
-            "transformations": [
-                {
-                    "id": "organize",
-                    "options": {
-                        "excludeByName": {
-                            "Flow": false,
-                            "Hostname": false,
-                            "Time": true,
-                            "__name__": true,
-                            "container": true,
-                            "endpoint": true,
-                            "exported_job": true,
-                            "instance": true,
-                            "job": true,
-                            "namespace": true,
-                            "otel_scope_name": true,
-                            "pod": true,
-                            "service": true
-                        },
-                        "indexByName": {
-                            "Conduit": 2,
-                            "Flow": 4,
-                            "Hostname": 5,
-                            "Stream": 3,
-                            "Time": 0,
-                            "Trench": 1,
-                            "Value": 15,
-                            "__name__": 6,
-                            "container": 7,
-                            "endpoint": 8,
-                            "exported_job": 9,
-                            "instance": 10,
-                            "job": 11,
-                            "namespace": 12,
-                            "pod": 13,
-                            "service": 14
-                        },
-                        "renameByName": {}
-                    }
-                }
-            ],
-            "type": "table"
+            "title": "Stream (bytes per second)",
+            "transformations": [],
+            "type": "timeseries"
         }
     ],
     "refresh": "5s",
@@ -243,7 +648,19 @@
     "style": "dark",
     "tags": [],
     "templating": {
-        "list": []
+        "list": [
+            {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                },
+                "filters": [],
+                "hide": 0,
+                "name": "Filters",
+                "skipUrlSync": false,
+                "type": "adhoc"
+            }
+        ]
     },
     "time": {
         "from": "now-15m",

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -16,17 +16,6 @@ Counts number of `METRIC_TYPE` for a network interface.
    * Attactor (optional)
    * Interface Name
 
-### meridio.conduit.stream.status (Planned)
-
-Stream status in the conduit instance.
-
-* Type: Gauge (Health Metric)
-* Attributes:
-   * Pod Name
-   * Trench
-   * Conduit
-   * Stream
-
 ### meridio.conduit.stream.flow.matches
 
 Counts number of packets that have matched a flow.
@@ -39,9 +28,21 @@ Counts number of packets that have matched a flow.
    * Stream
    * Flow
 
-### meridio.conduit.stream.target.packet.hits (Planned)
+### meridio.conduit.stream.target.hits.packets
 
 Counts number of packets that have hit a target.
+
+* Type: Counter
+* Attributes:
+   * Pod Name
+   * Trench
+   * Conduit
+   * Stream
+   * Target (identifier + IPs)
+
+### meridio.conduit.stream.target.hits.bytes
+
+Counts number of bytes that have hit a target.
 
 * Type: Counter
 * Attributes:

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -28,21 +28,11 @@ Counts number of packets that have matched a flow.
    * Stream
    * Flow
 
-### meridio.conduit.stream.target.hits.packets
+### meridio.conduit.stream.target.hits.`METRIC_TYPE`
 
-Counts number of packets that have hit a target.
+`METRIC_TYPE`: packets, bytes
 
-* Type: Counter
-* Attributes:
-   * Pod Name
-   * Trench
-   * Conduit
-   * Stream
-   * Target (identifier + IPs)
-
-### meridio.conduit.stream.target.hits.bytes
-
-Counts number of bytes that have hit a target.
+Counts number of `METRIC_TYPE` that have hit a target.
 
 * Type: Counter
 * Attributes:
@@ -50,7 +40,8 @@ Counts number of bytes that have hit a target.
    * Trench
    * Conduit
    * Stream
-   * Target (identifier + IPs)
+   * Identifier
+   * IPs
 
 ### meridio.conduit.stream.target.latency (Planned)
 

--- a/pkg/loadbalancer/stream/loadbalancer.go
+++ b/pkg/loadbalancer/stream/loadbalancer.go
@@ -170,11 +170,11 @@ func (lb *LoadBalancer) AddTarget(target types.Target) error {
 	if exists {
 		return errors.New("the target is already registered")
 	}
-	err := target.Configure(lb.IdentifierOffset) // TODO: avoid multiple identical ip rule entries (e.g. after container crash)
+	err := target.Configure() // TODO: avoid multiple identical ip rule entries (e.g. after container crash)
 	if err != nil {
 		lb.addPendingTarget(target)
 		returnErr := err
-		err = target.Delete(lb.IdentifierOffset)
+		err = target.Delete()
 		if err != nil {
 			return fmt.Errorf("%w; %v", err, returnErr)
 		}
@@ -184,7 +184,7 @@ func (lb *LoadBalancer) AddTarget(target types.Target) error {
 	if err != nil {
 		lb.addPendingTarget(target)
 		returnErr := err
-		err = target.Delete(lb.IdentifierOffset)
+		err = target.Delete()
 		if err != nil {
 			return fmt.Errorf("%w; %v", err, returnErr)
 		}
@@ -208,7 +208,7 @@ func (lb *LoadBalancer) RemoveTarget(identifier int) error {
 	if err != nil {
 		errFinal = fmt.Errorf("%w; %v", errFinal, err) // todo
 	}
-	err = target.Delete(lb.IdentifierOffset)
+	err = target.Delete()
 	if err != nil {
 		errFinal = fmt.Errorf("%w; %v", errFinal, err) // todo
 	}
@@ -347,7 +347,7 @@ func (lb *LoadBalancer) setTargets(targets []*nspAPI.Target) error {
 	var errFinal error
 	newTargetsMap := make(map[int]types.Target)
 	for _, target := range targets {
-		t, err := NewTarget(target, lb.netUtils, lb.targetHitsMetrics)
+		t, err := NewTarget(target, lb.netUtils, lb.targetHitsMetrics, lb.IdentifierOffset)
 		if err != nil {
 			continue
 		}

--- a/pkg/loadbalancer/target/metrics.go
+++ b/pkg/loadbalancer/target/metrics.go
@@ -1,0 +1,304 @@
+/*
+Copyright (c) 2023 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package target
+
+import (
+	"context"
+	"encoding/binary"
+	"sync"
+
+	"github.com/google/nftables"
+	"github.com/google/nftables/expr"
+	nspAPI "github.com/nordix/meridio/api/nsp/v1"
+	meridioMetrics "github.com/nordix/meridio/pkg/metrics"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	tableName = "meridio-metrics"
+	chainName = "target-hits"
+)
+
+type HitsMetrics struct {
+	hostname string
+	meter    metric.Meter
+	targets  map[int]*nspAPI.Target
+	table    *nftables.Table
+	chain    *nftables.Chain
+	mu       sync.Mutex
+}
+
+func NewTargetHitsMetrics(hostname string) (*HitsMetrics, error) {
+	meter := otel.GetMeterProvider().Meter(meridioMetrics.METER_NAME)
+	hm := &HitsMetrics{
+		hostname: hostname,
+		meter:    meter,
+		targets:  map[int]*nspAPI.Target{},
+	}
+
+	err := hm.init()
+	if err != nil {
+		return nil, err
+	}
+
+	return hm, nil
+}
+
+// init creates the nftables table and chain.
+func (hm *HitsMetrics) init() error {
+	conn := &nftables.Conn{}
+
+	hm.table = conn.AddTable(&nftables.Table{
+		Family: nftables.TableFamilyINet,
+		Name:   tableName,
+	})
+
+	hm.chain = conn.AddChain(&nftables.Chain{
+		Name:     chainName,
+		Table:    hm.table,
+		Type:     nftables.ChainTypeFilter,
+		Hooknum:  nftables.ChainHookPostrouting,
+		Priority: nftables.ChainPriorityRef(-500),
+	})
+
+	return conn.Flush()
+}
+
+// Register adds a target as nftables rule in the postrouting chain
+func (hm *HitsMetrics) Register(id int, target *nspAPI.Target) error {
+	hm.mu.Lock()
+	defer hm.mu.Unlock()
+
+	targetMetrics, err := hm.getMetrics()
+	if err != nil {
+		return err
+	}
+
+	hm.targets[id] = target
+
+	_, exists := targetMetrics[id]
+	if exists {
+		return nil
+	}
+
+	conn := &nftables.Conn{}
+
+	// nft --debug all add rule inet meridio-metrics target-hits meta mark 0x13dc counter
+	// [ meta load mark => reg 1 ]
+	// [ cmp eq reg 1 0x000013dc ]
+	// [ counter pkts 0 bytes 0 ]
+	_ = conn.AddRule(&nftables.Rule{
+		Table: hm.table,
+		Chain: hm.chain,
+		// Handle: ,
+		Exprs: []expr.Any{
+			&expr.Meta{
+				Key:      expr.MetaKeyMARK,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     encodeID(id),
+			},
+			&expr.Counter{
+				Bytes:   0,
+				Packets: 0,
+			},
+		},
+	})
+
+	return conn.Flush()
+}
+
+// Unregister removes the nftables rule of a target from the postrouting chain
+func (hm *HitsMetrics) Unregister(id int) error {
+	hm.mu.Lock()
+	defer hm.mu.Unlock()
+
+	delete(hm.targets, id)
+
+	targetMetrics, err := hm.getRules()
+	if err != nil {
+		return err
+	}
+
+	rule, exists := targetMetrics[id]
+	if !exists {
+		return nil
+	}
+
+	conn := &nftables.Conn{}
+
+	err = conn.DelRule(rule)
+	if err != nil {
+		return err
+	}
+
+	return conn.Flush()
+}
+
+// Collect collects the metrics for the all the target rules.
+func (hm *HitsMetrics) Collect() error {
+	_, err := hm.meter.Int64ObservableCounter(
+		meridioMetrics.MERIDIO_CONDUIT_STREAM_TARGET_HITS_PACKETS,
+		metric.WithUnit("packets"), // TODO: what unit must be set?
+		metric.WithDescription("Counts number of packets that have hit a target."),
+		metric.WithInt64Callback(func(ctx context.Context, observer metric.Int64Observer) error {
+			targetMetrics, err := hm.getMetrics()
+			if err != nil {
+				return err
+			}
+			for targetID, metrics := range targetMetrics {
+				// Find the registred target for the collected counter
+				hm.mu.Lock()
+				target, exists := hm.targets[targetID]
+				hm.mu.Unlock()
+				if !exists {
+					continue
+				}
+
+				if target.GetStream() == nil ||
+					target.GetStream().GetConduit() == nil ||
+					target.GetStream().GetConduit().GetTrench() == nil {
+					continue
+				}
+
+				streamName := target.GetStream().GetName()
+				conduitName := target.GetStream().GetConduit().GetName()
+				trenchName := target.GetStream().GetConduit().GetTrench().GetName()
+
+				observer.Observe(
+					int64(metrics.Packets),
+					metric.WithAttributes(attribute.String("Hostname", hm.hostname)),
+					metric.WithAttributes(attribute.String("Trench", trenchName)),
+					metric.WithAttributes(attribute.String("Conduit", conduitName)),
+					metric.WithAttributes(attribute.String("Stream", streamName)),
+					metric.WithAttributes(attribute.Int("Identifier", targetID)),
+					metric.WithAttributes(attribute.StringSlice("IPs", target.GetIps())),
+				)
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = hm.meter.Int64ObservableCounter(
+		meridioMetrics.MERIDIO_CONDUIT_STREAM_TARGET_HITS_BYTES,
+		metric.WithUnit("bytes"), // TODO: what unit must be set?
+		metric.WithDescription("Counts number of bytes that have hit a target."),
+		metric.WithInt64Callback(func(ctx context.Context, observer metric.Int64Observer) error {
+			targetMetrics, err := hm.getMetrics()
+			if err != nil {
+				return err
+			}
+			for targetID, metrics := range targetMetrics {
+				// Find the registred target for the collected counter
+				hm.mu.Lock()
+				target, exists := hm.targets[targetID]
+				hm.mu.Unlock()
+				if !exists {
+					continue
+				}
+
+				if target.GetStream() == nil ||
+					target.GetStream().GetConduit() == nil ||
+					target.GetStream().GetConduit().GetTrench() == nil {
+					continue
+				}
+
+				streamName := target.GetStream().GetName()
+				conduitName := target.GetStream().GetConduit().GetName()
+				trenchName := target.GetStream().GetConduit().GetTrench().GetName()
+
+				observer.Observe(
+					int64(metrics.Bytes),
+					metric.WithAttributes(attribute.String("Hostname", hm.hostname)),
+					metric.WithAttributes(attribute.String("Trench", trenchName)),
+					metric.WithAttributes(attribute.String("Conduit", conduitName)),
+					metric.WithAttributes(attribute.String("Stream", streamName)),
+					metric.WithAttributes(attribute.Int("Identifier", targetID)),
+					metric.WithAttributes(attribute.StringSlice("IPs", target.GetIps())),
+				)
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// getMetrics gets all the rules in the postrouting chain and export the fwmark as key and
+// the metrics/counter as value
+func (hm *HitsMetrics) getMetrics() (map[int]*expr.Counter, error) {
+	counters := map[int]*expr.Counter{}
+
+	rules, err := hm.getRules()
+	if err != nil {
+		return nil, err
+	}
+
+	for id, rule := range rules {
+		counterExpr := rule.Exprs[2].(*expr.Counter)
+		if counterExpr == nil {
+			continue
+		}
+
+		counters[id] = counterExpr
+	}
+
+	return counters, nil
+}
+
+func (hm *HitsMetrics) getRules() (map[int]*nftables.Rule, error) {
+	conn := &nftables.Conn{}
+
+	rules, err := conn.GetRules(hm.table, hm.chain)
+	if err != nil {
+		return nil, err
+	}
+
+	rulesMap := map[int]*nftables.Rule{}
+
+	for _, rule := range rules {
+		cmpExpr := rule.Exprs[1].(*expr.Cmp)
+		if cmpExpr == nil {
+			continue
+		}
+
+		rulesMap[decodeID(cmpExpr.Data)] = rule
+	}
+
+	return rulesMap, nil
+}
+
+func encodeID(value int) []byte {
+	bs := make([]byte, 4)
+	binary.NativeEndian.PutUint32(bs, uint32(value))
+	return bs
+}
+
+func decodeID(value []byte) int {
+	return int(binary.NativeEndian.Uint32(value))
+}

--- a/pkg/loadbalancer/types/target.go
+++ b/pkg/loadbalancer/types/target.go
@@ -21,5 +21,5 @@ type Target interface {
 	GetIdentifier() int
 	Configure(identifierOffset int) error
 	Verify() bool
-	Delete() error
+	Delete(identifierOffset int) error
 }

--- a/pkg/loadbalancer/types/target.go
+++ b/pkg/loadbalancer/types/target.go
@@ -19,7 +19,7 @@ package types
 type Target interface {
 	GetIps() []string
 	GetIdentifier() int
-	Configure(identifierOffset int) error
+	Configure() error
 	Verify() bool
-	Delete(identifierOffset int) error
+	Delete() error
 }

--- a/pkg/metrics/const.go
+++ b/pkg/metrics/const.go
@@ -17,7 +17,9 @@ limitations under the License.
 package metrics
 
 const (
-	MERIDIO_CONDUIT_STREAM_FLOW_MATCHES = "meridio.conduit.stream.flow.matches"
+	MERIDIO_CONDUIT_STREAM_FLOW_MATCHES        = "meridio.conduit.stream.flow.matches"
+	MERIDIO_CONDUIT_STREAM_TARGET_HITS_PACKETS = "meridio.conduit.stream.target.hits.packets"
+	MERIDIO_CONDUIT_STREAM_TARGET_HITS_BYTES   = "meridio.conduit.stream.target.hits.bytes"
 
 	METER_NAME = "Meridio"
 )


### PR DESCRIPTION
## Description

Collect number of packets and bytes for each target. Metrics are collected based on nftables metrics on postrouting rules matching target identifier (fwmark).

Example of the new nftables table with 3 targets:
```
table inet meridio-metrics { # handle 1
        chain target-hits { # handle 1
                type filter hook postrouting priority -500; policy accept;
                meta mark 0x000013c3 counter packets 255 bytes 13668 # handle 2
                meta mark 0x000013d2 counter packets 310 bytes 16616 # handle 3
                meta mark 0x000013da counter packets 260 bytes 13936 # handle 4
        }
}
```

## Issue link

https://github.com/Nordix/Meridio/pull/428
https://github.com/Nordix/Meridio/issues/419

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
