### PR TITLE
Lb; during shutdown run all clean-up

### DIFF
--- a/cmd/stateless-lb/egress.go
+++ b/cmd/stateless-lb/egress.go
@@ -56,7 +56,7 @@ type FrontendNetworkService struct {
 }
 
 // Start -
-func (fns *FrontendNetworkService) Start() {
+func (fns *FrontendNetworkService) Start() error {
 	err := retry.Do(func() error {
 		var err error
 		fns.targetRegistryStream, err = fns.targetRegistryClient.Watch(fns.ctx, &nspAPI.Target{
@@ -71,9 +71,7 @@ func (fns *FrontendNetworkService) Start() {
 	}, retry.WithContext(fns.ctx),
 		retry.WithDelay(500*time.Millisecond),
 		retry.WithErrorIngnored())
-	if err != nil {
-		log.Fatal(fns.logger, "Start", "error", err)
-	}
+	return err
 }
 
 func (fns *FrontendNetworkService) recv() error {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -115,8 +115,9 @@ func (e *Endpoint) startWithoutRegister(ctx context.Context, additionalFunctiona
 }
 
 func (e *Endpoint) errorHandler(errCh <-chan error) {
-	err := <-errCh
-	e.logger.Error(err, "endpoint server errorHandler")
+	if err, ok := <-errCh; ok {
+		e.logger.Error(err, "endpoint server errorHandler")
+	}
 }
 
 func (e *Endpoint) getSource(ctx context.Context) (*workloadapi.X509Source, error) {

--- a/pkg/loadbalancer/types/nfqlb.go
+++ b/pkg/loadbalancer/types/nfqlb.go
@@ -32,7 +32,7 @@ type NFQueueLoadBalancer interface {
 }
 
 type NFQueueLoadBalancerFactory interface {
-	Start(ctx context.Context) context.Context
+	Start(ctx context.Context) error
 	New(name string, m int, n int) (NFQueueLoadBalancer, error)
 }
 

--- a/pkg/nsm/client.go
+++ b/pkg/nsm/client.go
@@ -26,7 +26,6 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/registry"
 	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
 	registryauthorize "github.com/networkservicemesh/sdk/pkg/registry/common/authorize"
-	"github.com/networkservicemesh/sdk/pkg/registry/common/clientinfo"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/sendfd"
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/spiffejwt"
@@ -85,7 +84,6 @@ func (apiClient *APIClient) setNetworkServiceEndpointRegistryClient() {
 		registryclient.WithDialOptions(clientOptions...),
 		registryclient.WithNSEAdditionalFunctionality(
 			expirationtime.NewNetworkServiceEndpointRegistryClient(time.Minute), // keep legacy nse lifetime (changed by https://github.com/networkservicemesh/sdk/pull/1404)
-			clientinfo.NewNetworkServiceEndpointRegistryClient(),
 			sendfd.NewNetworkServiceEndpointRegistryClient(),
 		),
 		registryclient.WithAuthorizeNSRegistryClient(registryauthorize.NewNetworkServiceRegistryClient()),


### PR DESCRIPTION
## Description
Due to a buried "Fatal" printout the LB failed to run all the clean-ups (e.g. NSE unregister) during shutdown.

## Issue link
NA

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
