### PR TITLE
Set mac address of bridge0 in proxy

### DIFF
--- a/pkg/kernel/bridge.go
+++ b/pkg/kernel/bridge.go
@@ -17,6 +17,8 @@ limitations under the License.
 package kernel
 
 import (
+	"fmt"
+
 	"github.com/nordix/meridio/pkg/networking"
 	"github.com/vishvananda/netlink"
 )
@@ -28,18 +30,23 @@ type Bridge struct {
 }
 
 func (b *Bridge) create() error {
+	mac, err := networking.GenerateMacAddress()
+	if err != nil {
+		return fmt.Errorf("failed to generate mac address (bridge): %w", err)
+	}
 	bridge := &netlink.Bridge{
 		LinkAttrs: netlink.LinkAttrs{
-			Name: b.name,
+			Name:         b.name,
+			HardwareAddr: mac,
 		},
 	}
-	err := netlink.LinkAdd(bridge)
+	err = netlink.LinkAdd(bridge)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to LinkAdd (bridge): %w", err)
 	}
 	err = netlink.LinkSetUp(bridge)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to LinkSetUp (bridge): %w", err)
 	}
 	b.index = bridge.Index
 	return nil

--- a/pkg/networking/mac.go
+++ b/pkg/networking/mac.go
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2023 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package networking
+
+import (
+	"crypto/rand"
+	"net"
+)
+
+// https://stackoverflow.com/questions/21018729/generate-mac-address-in-go
+func GenerateMacAddress() (net.HardwareAddr, error) {
+	buf := make([]byte, 6)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	buf[0] = (buf[0] | 2) & 0xfe // Set local bit, ensure unicast addres
+
+	return buf, nil
+}


### PR DESCRIPTION
## Description

Setting the bridge mac address prevents the address changes when an interface is attached/detached. This caused issue when connecting targets and stateless-lbs to the proxy. The ARP table of other connected pods were not updated instantly.

## Issue link

https://github.com/Nordix/Meridio/issues/471

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
