### PR TITLE
New internal gRPC health client instead of grpc-health-probe binary

### DIFF
--- a/cmd/ipam/main.go
+++ b/cmd/ipam/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -171,7 +171,7 @@ func main() {
 		health.IPAMSvc,
 		probe.WithAddress(fmt.Sprintf(":%d", config.Port)),
 		probe.WithSpiffe(),
-		probe.WithRPCTimeout(config.GRPCProbeRPCTimeout.String()),
+		probe.WithRPCTimeout(config.GRPCProbeRPCTimeout),
 	)
 
 	if err := startServer(ctx, server, listener); err != nil {

--- a/cmd/nsp/config.go
+++ b/cmd/nsp/config.go
@@ -20,10 +20,11 @@ import "time"
 
 // Config for the NSP
 type Config struct {
-	Namespace     string        `default:"default" desc:"Namespace the pod is running on" split_words:"true"`
-	Port          string        `default:"7778" desc:"Trench the pod is running on" split_words:"true"`
-	ConfigMapName string        `default:"meridio-configuration" desc:"Name of the ConfigMap containing the configuration" split_words:"true"`
-	Datasource    string        `default:"/run/nsp/data/registry.db" desc:"Path and file name of the sqlite database" split_words:"true"`
-	LogLevel      string        `default:"DEBUG" desc:"Log level" split_words:"true"`
-	EntryTimeout  time.Duration `default:"60s" desc:"Timeout of the entries" split_words:"true"`
+	Namespace           string        `default:"default" desc:"Namespace the pod is running on" split_words:"true"`
+	Port                string        `default:"7778" desc:"Trench the pod is running on" split_words:"true"`
+	ConfigMapName       string        `default:"meridio-configuration" desc:"Name of the ConfigMap containing the configuration" split_words:"true"`
+	Datasource          string        `default:"/run/nsp/data/registry.db" desc:"Path and file name of the sqlite database" split_words:"true"`
+	LogLevel            string        `default:"DEBUG" desc:"Log level" split_words:"true"`
+	EntryTimeout        time.Duration `default:"60s" desc:"Timeout of the entries" split_words:"true"`
+	GRPCProbeRPCTimeout time.Duration `default:"1s" desc:"RPC timeout of internal gRPC health probe" envconfig:"grpc_probe_rpc_timeout"`
 }

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -210,7 +210,7 @@ func main() {
 		health.NSMEndpointSvc,
 		probe.WithAddress(ep.Server.GetUrl()),
 		probe.WithSpiffe(),
-		probe.WithRPCTimeout(config.GRPCProbeRPCTimeout.String()),
+		probe.WithRPCTimeout(config.GRPCProbeRPCTimeout),
 	)
 
 	// connect NSP and start watching config events of interest

--- a/cmd/stateless-lb/main.go
+++ b/cmd/stateless-lb/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -238,7 +238,7 @@ func main() {
 		health.NSMEndpointSvc,
 		probe.WithAddress(ep.GetUrl()),
 		probe.WithSpiffe(),
-		probe.WithRPCTimeout(config.GRPCProbeRPCTimeout.String()),
+		probe.WithRPCTimeout(config.GRPCProbeRPCTimeout),
 	)
 
 	ctx = lbFactory.Start(ctx) // start nfqlb process in background

--- a/config/templates/charts/meridio/deployment/nsp.yaml
+++ b/config/templates/charts/meridio/deployment/nsp.yaml
@@ -44,11 +44,10 @@ spec:
             exec:
               command:
                 - /bin/grpc_health_probe
-                - -spiffe
-                - -addr=:7778
-                - -service=
+                - -addr=unix:///tmp/health.sock
+                - -service=Readiness
                 - -connect-timeout=400ms
-                - -rpc-timeout=1s
+                - -rpc-timeout=400ms
             failureThreshold: 5
             initialDelaySeconds: 0
             periodSeconds: 10

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -67,9 +67,7 @@ nsp:
   serviceName: nsp-service
   probe:
     readiness:
-      service: ""
-      addr: :7778
-      spiffe: true
+      service: "Readiness"
 
 ipFamily: ipv4  # ipv4 / ipv6 / dualstack
 

--- a/docs/components/nsp.md
+++ b/docs/components/nsp.md
@@ -63,7 +63,9 @@ An overview of the communications between all components is available [here](res
 
 The health check is provided by the [GRPC Health Checking Protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md). The status returned can be `UNKNOWN`, `SERVING`, `NOT_SERVING` or `SERVICE_UNKNOWN`.
 
-TODO
+Service | Description
+--- | ---
+NSP | Monitor status of the server
 
 ## Privileges
 

--- a/pkg/controllers/trench/nsp.go
+++ b/pkg/controllers/trench/nsp.go
@@ -58,6 +58,9 @@ func (i *NspStatefulSet) getEnvVars(allEnv []corev1.EnvVar) []corev1.EnvVar {
 		{Name: "NSP_NAMESPACE", Value: i.trench.ObjectMeta.Namespace},
 		{Name: "NSP_LOG_LEVEL", Value: common.GetLogLevel()},
 	}
+	if rpcTimeout := common.GetGRPCProbeRPCTimeout(); rpcTimeout != "" {
+		operatorEnv = append(operatorEnv, corev1.EnvVar{Name: "NSP_GRPC_PROBE_RPC_TIMEOUT", Value: rpcTimeout})
+	}
 	return common.CompileEnvironmentVariables(allEnv, operatorEnv)
 }
 

--- a/pkg/health/checker.go
+++ b/pkg/health/checker.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -32,6 +32,11 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
+type serviceSetElem struct{}
+type serviceSet map[string]serviceSetElem
+
+var serviceMember serviceSetElem
+
 type HealthServerStatusModifier interface {
 	SetServingStatus(service string, servingStatus grpc_health_v1.HealthCheckResponse_ServingStatus)
 	Shutdown()
@@ -40,19 +45,22 @@ type HealthServerStatusModifier interface {
 type Checker struct {
 	grpc_health_v1.HealthServer
 	HealthServerStatusModifier
-	ctx               context.Context
-	listener          net.Listener
-	server            *grpc.Server
-	address           *url.URL
-	subServices       map[string][]string // subservices associated with a probe service
-	subServiceToProbe map[string]string   // map subservice to probe service
-	mu                sync.RWMutex
+	ctx                context.Context
+	listener           net.Listener
+	server             *grpc.Server
+	address            *url.URL
+	probeToSubServices map[string]serviceSet // set of subservices associated with a probe service
+	subServiceToProbes map[string]serviceSet // set of probe services associated with a subservice
+	mu                 sync.RWMutex
 }
 
 // RegisterServices -
 // Registers subservices for a probe service whose serving status will
 // be deterimined by the serving status of the subservices.
-// Note: currently a subservice can only belong to one probe service
+// Notes:
+//   - A subservice can be part of multiple probe services
+//   - No check for duplicate registration (e.g. services previously
+//     registered for the same probe service are not removed)
 func (c *Checker) RegisterServices(probeSvc string, services ...string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -62,40 +70,47 @@ func (c *Checker) RegisterServices(probeSvc string, services ...string) {
 		"Health server: Register subservices", "probeSvc", probeSvc,
 		"services", services)
 
-	components, ok := c.subServices[probeSvc]
-	if !ok {
-		// probe service not registered yet
-		components = []string{}
-		c.subServices[probeSvc] = components
+	subServices, ok := c.probeToSubServices[probeSvc]
+	if !ok { // new probe service
+		subServices = make(serviceSet)
+		c.probeToSubServices[probeSvc] = subServices
 	}
 	c.HealthServerStatusModifier.SetServingStatus(probeSvc, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
 
-	// link subservices to the probe service
 	for _, s := range services {
-		c.subServiceToProbe[s] = probeSvc
+		subServices[s] = serviceMember // add subservices
+
+		// update map linking subservice to all related probe service
+		probeServices, ok := c.subServiceToProbes[s]
+		if !ok { // new subservice
+			probeServices = make(serviceSet)
+			c.subServiceToProbes[s] = probeServices
+		}
+		probeServices[probeSvc] = serviceMember
 		c.HealthServerStatusModifier.SetServingStatus(s, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
 	}
-	c.subServices[probeSvc] = append(components, services...)
 }
 
 // Check -
 // Re-implements Check() function of grpc_health_v1.HealthServer interface
 // in order to log if a probe service is about to fail.
 func (c *Checker) Check(ctx context.Context, in *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	var resp *grpc_health_v1.HealthCheckResponse
+	var err error
 
-	switch in.Service {
-	case Startup:
-		fallthrough
-	case Readiness:
-		fallthrough
-	case Liveness:
-		resp, err := c.HealthServer.Check(ctx, in)
-		if err == nil && resp.Status != grpc_health_v1.HealthCheckResponse_SERVING {
-			svcInfo := ""
-			// gather all related subservice' status to provide details on the failed probe
-			if len(c.subServices[in.Service]) > 0 {
-				svcInfo += `, subservices:[`
-				for _, s := range c.subServices[in.Service] {
+	logDetails := func(ctx context.Context) {
+		// gather all related subservice' status to provide details on the failed probe
+		var svcInfo string
+
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if len(c.probeToSubServices[in.Service]) > 0 {
+			svcInfo += `, subservices:[`
+			for s := range c.probeToSubServices[in.Service] {
+				select {
+				case <-ctx.Done():
+					return
+				default:
 					svcInfo += fmt.Sprintf("%v:", s)
 					status := `N/A,`
 					if resp, err := c.HealthServer.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: s}); err == nil {
@@ -103,17 +118,34 @@ func (c *Checker) Check(ctx context.Context, in *grpc_health_v1.HealthCheckReque
 					}
 					svcInfo += fmt.Sprintf("%v", status)
 				}
-				svcInfo += `]`
 			}
-			logger := log.FromContextOrGlobal(c.ctx)
-			logger.Info(
-				"Probe service", "Service", in.Service,
-				"Status", resp.Status, "svcInfo", svcInfo)
+			svcInfo += `]`
 		}
-		return resp, err
-	default:
-		return c.HealthServer.Check(ctx, in)
+		logger := log.FromContextOrGlobal(c.ctx)
+		logger.Info(
+			"Probe service", "Service", in.Service,
+			"Status", resp.Status, "svcInfo", svcInfo)
 	}
+
+	switch in.Service {
+	case Startup:
+		fallthrough
+	case Readiness:
+		fallthrough
+	case Liveness:
+		resp, err = c.HealthServer.Check(ctx, in)
+		if err == nil && resp.Status != grpc_health_v1.HealthCheckResponse_SERVING {
+			// gather all related subservice' status to provide details on the failed probe
+			logDetails(ctx)
+		}
+	default:
+		resp, err = c.HealthServer.Check(ctx, in)
+	}
+
+	if err != nil {
+		err = fmt.Errorf("%v check failed: %w", in.Service, err)
+	}
+	return resp, err
 }
 
 // Re-implements SetServingStatus function in order to evaluate probe service status
@@ -128,36 +160,38 @@ func (c *Checker) SetServingStatus(service string, servingStatus grpc_health_v1.
 	case Readiness:
 		fallthrough
 	case Liveness:
-		// in case of probe service only process serving status if no subservices
-		if components, ok := c.subServices[service]; ok && len(components) > 0 {
+		// for probe service (Startup/Readiness/Liveness) only process serving status if no subservices
+		if subServices, ok := c.probeToSubServices[service]; ok && len(subServices) > 0 {
 			break
 		}
 		c.HealthServerStatusModifier.SetServingStatus(service, servingStatus)
 	default:
 		{
 			c.HealthServerStatusModifier.SetServingStatus(service, servingStatus)
-			// determine serving status of the related probe service if any
-			if probeSvc, ok := c.subServiceToProbe[service]; ok {
-				// belongs to a probe service (i.e. it's a subservice)
-				if components, ok := c.subServices[probeSvc]; ok {
-					// probe has subservices; aggregate serving status of components to get the probe status
-					probeStatus := grpc_health_v1.HealthCheckResponse_NOT_SERVING
-					if grpc_health_v1.HealthCheckResponse_SERVING == servingStatus {
-						probeStatus = grpc_health_v1.HealthCheckResponse_SERVING
-						for _, component := range components {
-							// a subservice is not in SERVING status, the probe service must reflect it
-							resp, err := c.HealthServer.Check(c.ctx, &grpc_health_v1.HealthCheckRequest{Service: component})
-							if err != nil || (err == nil && resp.Status != grpc_health_v1.HealthCheckResponse_SERVING) {
-								probeStatus = grpc_health_v1.HealthCheckResponse_NOT_SERVING
-								break
+			// determine serving status of all related probe service if any
+			if probeServices, ok := c.subServiceToProbes[service]; ok {
+				for probeSvc := range probeServices {
+					// belongs to a probe service (i.e. it's a subservice)
+					if subServices, ok := c.probeToSubServices[probeSvc]; ok { // probe was linked to service so it must have subservices
+						// aggregate serving status of subservices to get the probe status
+						// (if status of input service is not SERVING no need to check subservices)
+						probeStatus := grpc_health_v1.HealthCheckResponse_NOT_SERVING
+						if grpc_health_v1.HealthCheckResponse_SERVING == servingStatus {
+							probeStatus = grpc_health_v1.HealthCheckResponse_SERVING
+							for subService := range subServices {
+								// a subservice is not in SERVING status, the probe service must reflect it
+								resp, err := c.HealthServer.Check(c.ctx, &grpc_health_v1.HealthCheckRequest{Service: subService})
+								if err != nil || (err == nil && resp.Status != grpc_health_v1.HealthCheckResponse_SERVING) {
+									probeStatus = grpc_health_v1.HealthCheckResponse_NOT_SERVING
+									break
+								}
 							}
 						}
+						c.HealthServerStatusModifier.SetServingStatus(probeSvc, probeStatus)
 					}
-					c.HealthServerStatusModifier.SetServingStatus(probeSvc, probeStatus)
 				}
 			}
 		}
-
 	}
 }
 
@@ -173,7 +207,11 @@ func (c *Checker) Start() error {
 		<-c.ctx.Done()
 		c.server.Stop()
 	}()
-	return c.server.Serve(c.listener)
+	err := c.server.Serve(c.listener)
+	if err != nil {
+		return fmt.Errorf("grpc health server serve failed: %w", err)
+	}
+	return nil
 }
 
 // NewChecker -
@@ -211,20 +249,20 @@ func NewChecker(options ...Option) (*Checker, error) {
 		// remove possible lingering unix socket
 		err := os.Remove(target)
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("Failed to remove existing socket file: %v", err)
+			return nil, fmt.Errorf("failed to remove existing socket file: %w", err)
 		}
 		// create path if needed
 		basePath := path.Dir(target)
 		if _, err = os.Stat(basePath); os.IsNotExist(err) {
 			if err = os.MkdirAll(basePath, os.ModePerm); err != nil {
-				return nil, fmt.Errorf("Failed to create path for %v: %v", target, err)
+				return nil, fmt.Errorf("failed to create path for %v: %w", target, err)
 			}
 		}
 	}
 	// create listener for the URL
 	lis, err := net.Listen(network, target)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("grpc health server listen failed: %w", err)
 	}
 
 	s := grpc.NewServer()
@@ -237,8 +275,8 @@ func NewChecker(options ...Option) (*Checker, error) {
 		server:                     s,
 		address:                    address,
 		ctx:                        opts.ctx,
-		subServices:                make(map[string][]string),
-		subServiceToProbe:          make(map[string]string),
+		probeToSubServices:         make(map[string]serviceSet),
+		subServiceToProbes:         make(map[string]serviceSet),
 	}
 
 	grpc_health_v1.RegisterHealthServer(s, checker)

--- a/pkg/health/const.go
+++ b/pkg/health/const.go
@@ -35,9 +35,11 @@ const (
 	TargetRegistryCliSvc string = "TargetRegistryCli"
 	StreamSvc            string = "Stream"
 	FlowSvc              string = "Flow"
+	NSPSvc               string = "NSP"
 )
 
 var LBReadinessServices []string = []string{NSPCliSvc, NSMEndpointSvc, EgressSvc, StreamSvc, FlowSvc}
 var FEReadinessServices []string = []string{NSPCliSvc, TargetRegistryCliSvc, EgressSvc}
 var ProxyReadinessServices []string = []string{IPAMCliSvc, NSPCliSvc, NSMEndpointSvc, EgressSvc}
 var IPAMReadinessServices []string = []string{NSPCliSvc, IPAMSvc}
+var NSPReadinessServices []string = []string{NSPSvc}

--- a/pkg/health/probe/option.go
+++ b/pkg/health/probe/option.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,58 +16,57 @@ limitations under the License.
 
 package probe
 
-import "fmt"
+import "time"
 
-// Option is an option pattern for GrpcHealthProbe
 type Option func(o *probeOptions)
 
-// WithCommand sets grpc health probe command name
-func WithCommand(cmd string) Option {
-	return func(o *probeOptions) {
-		o.cmd = cmd
-	}
-}
-
-// WithAddress sets address for grpc health probe
+// WithAddress sets address for probe
 func WithAddress(addr string) Option {
 	return func(o *probeOptions) {
-		o.addr = fmt.Sprintf("-addr=%v", addr)
+		o.addr = addr
 	}
 }
 
-// WithService sets service for grpc health probe
+// WithService sets service for probe
 func WithService(service string) Option {
 	return func(o *probeOptions) {
-		o.service = fmt.Sprintf("-service=%v", service)
+		o.service = service
 	}
 }
 
-// WithSpiffe sets spiffe option for grpc health probe
+// WithSpiffe sets spiffe option for probe
 func WithSpiffe() Option {
 	return func(o *probeOptions) {
-		o.spiffe = "-spiffe"
+		o.spiffe = true
 	}
 }
 
-// WithRPCTimeout RPC timeout for grpc health probe
-func WithRPCTimeout(rpcTimeout string) Option {
+// WithRPCTimeout sets RPC timeout for probe
+func WithRPCTimeout(rpcTimeout time.Duration) Option {
 	return func(o *probeOptions) {
-		o.rpcTimeout = fmt.Sprintf("-rpc-timeout=%v", rpcTimeout)
+		o.rpcTimeout = rpcTimeout
 	}
 }
 
-// WithConnectTimeout connect timeout for grpc health probe
-func WithConnectTimeout(connTimeout string) Option {
+// WithConnectTimeout sests connect timeout probe
+func WithConnectTimeout(connTimeout time.Duration) Option {
 	return func(o *probeOptions) {
-		o.connTimeout = fmt.Sprintf("-connect-timeout=%v", connTimeout)
+		o.connTimeout = connTimeout
+	}
+}
+
+// WithUserAgent sests user agent
+func WithUserAgent(userAgent string) Option {
+	return func(o *probeOptions) {
+		o.userAgent = userAgent
 	}
 }
 
 type probeOptions struct {
-	cmd         string
+	userAgent   string
 	addr        string
 	service     string
-	connTimeout string
-	rpcTimeout  string
-	spiffe      string
+	connTimeout time.Duration
+	rpcTimeout  time.Duration
+	spiffe      bool
 }

--- a/pkg/health/probe/probe.go
+++ b/pkg/health/probe/probe.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,78 +18,135 @@ package probe
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/nordix/meridio/pkg/health"
 	"github.com/nordix/meridio/pkg/log"
+	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
 )
 
-type GrpcHealthProbe struct {
-	cmd         string
+type HealthProbe struct {
+	userAgent   string
 	addr        string
 	service     string
-	connTimeout string
-	rpcTimeout  string
-	spiffe      string
+	connTimeout time.Duration
+	rpcTimeout  time.Duration
+	spiffe      bool
+	source      *workloadapi.X509Source
 }
 
-// NewGRPCHealthProbe -
-// Creates gRPC health checking probe
-func NewGRPCHealthProbe(options ...Option) (*GrpcHealthProbe, error) {
+// NewHealthProbe -
+// Create a new grpc health probe which is an alternate to grpc-health-probe binary
+// but does NOT require a new process to get spawned.
+// Thus, when using with the spiffe option the spire agents are not required to attest
+// new processes all the time when the probe is invoked.
+func NewHealthProbe(ctx context.Context, options ...Option) (*HealthProbe, error) {
+
 	opts := &probeOptions{
-		cmd:         "grpc_health_probe",
-		addr:        fmt.Sprintf("-addr=%v", health.DefaultURL),
-		service:     "-service=",
-		rpcTimeout:  "-rpc-timeout=400ms",
-		connTimeout: "-connect-timeout=400ms",
+		rpcTimeout:  time.Second,
+		connTimeout: time.Second,
+		userAgent:   "meridio-grpc-health-probe",
 	}
+
 	for _, opt := range options {
 		opt(opts)
 	}
-	_, err := exec.LookPath(opts.cmd)
-	if err != nil {
-		return nil, errors.New("GrpcHealthProbe not found, err: " + err.Error())
-	}
 
-	return &GrpcHealthProbe{
-		cmd:         opts.cmd,
+	hp := &HealthProbe{
+		userAgent:   opts.userAgent,
 		addr:        opts.addr,
 		service:     opts.service,
-		rpcTimeout:  opts.rpcTimeout,
 		connTimeout: opts.connTimeout,
+		rpcTimeout:  opts.rpcTimeout,
 		spiffe:      opts.spiffe,
-	}, nil
+	}
+
+	if hp.spiffe {
+		// fetch X509Source once to avoid recurring load on spire
+		source, err := workloadapi.NewX509Source(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error getting x509 source, %w", err)
+		}
+		svid, err := source.GetX509SVID()
+		if err != nil {
+			return nil, fmt.Errorf("error getting x509 svid, %w", err)
+		}
+		log.FromContextOrGlobal(ctx).V(1).Info("GetX509Source for health probe", "sVID", svid.ID)
+		hp.source = source
+	}
+
+	return hp, nil
 }
 
 // String -
-func (ghp *GrpcHealthProbe) String() string {
-	return fmt.Sprintf("%v %v %v %v %v %v", ghp.cmd, ghp.addr, ghp.service, ghp.connTimeout, ghp.rpcTimeout, ghp.spiffe)
+func (hp *HealthProbe) String() string {
+	return fmt.Sprintf("addr=%v, service=%v, userAgent=%v, connTimeout=%v, rpcTimeout=%v, spiffe=%v",
+		hp.addr, hp.service, hp.userAgent, hp.connTimeout.String(), hp.rpcTimeout.String(), hp.spiffe)
 }
 
-// Run -
-// Runs gRPC health checking probe
-// Returns nil if status is HealthCheckResponse_SERVING, and err otherwise
-func (ghp *GrpcHealthProbe) Run(ctx context.Context) error {
-	stdoutStderr, err := exec.CommandContext(ctx, ghp.cmd, ghp.addr, ghp.service,
-		ghp.connTimeout, ghp.rpcTimeout, ghp.spiffe).CombinedOutput()
+// Request -
+// Sends query to check health of gRPC services exposing their status through
+// gRPC Health Checking Protocol.
+//
+// Returns no error if queried service is SERVING.
+func (hp *HealthProbe) Request(ctx context.Context) error {
+	opts := []grpc.DialOption{
+		grpc.WithUserAgent(hp.userAgent),
+		grpc.WithBlock(),
+	}
+
+	if hp.spiffe {
+		opts = append(opts, grpc.WithTransportCredentials(
+			credentials.NewTLS(tlsconfig.MTLSClientConfig(hp.source, hp.source, tlsconfig.AuthorizeAny())),
+		))
+	} else {
+		opts = append(opts, grpc.WithTransportCredentials(
+			insecure.NewCredentials(),
+		))
+	}
+
+	dialCtx, dialCancel := context.WithTimeout(ctx, hp.connTimeout)
+	defer dialCancel()
+	conn, err := grpc.DialContext(dialCtx, hp.addr, opts...)
 	if err != nil {
-		return fmt.Errorf("gRPC Health Probe err: %v, %s", err, stdoutStderr)
+		return fmt.Errorf("failed to connect service %q, %w", hp.addr, err)
+	}
+	defer conn.Close()
+
+	rpcCtx, rpcCancel := context.WithTimeout(ctx, hp.rpcTimeout)
+	defer rpcCancel()
+	rpcCtx = metadata.NewOutgoingContext(rpcCtx, make(metadata.MD))
+	resp, err := grpc_health_v1.NewHealthClient(conn).Check(
+		rpcCtx,
+		&grpc_health_v1.HealthCheckRequest{
+			Service: hp.service,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("health rpc failed, %w", err)
+	}
+
+	if resp.GetStatus() != grpc_health_v1.HealthCheckResponse_SERVING {
+		return fmt.Errorf("service unhealthy, status: %q", resp.GetStatus().String())
 	}
 
 	return nil
 }
 
 // CreateAndRunGRPCHealthProbe -
-// Creates gRPC Health Probe and starts running it in background.
-// Registers probing results to Health Server retrieved from context.
-// TODO: configurable period, timeout
+// Creates and runs a gRPC health probe client and registers the status response
+// of the service to a local gRPC health server retrived from the context.
+// In the local health server the service is refered to by healthService string.
 func CreateAndRunGRPCHealthProbe(ctx context.Context, healthService string, options ...Option) {
-	// create the probe for the servie
-	ghp, err := NewGRPCHealthProbe(options...)
+	// create the probe for the service
+	ghp, err := NewHealthProbe(ctx, options...)
 	if err != nil {
 		log.Logger.Error(err, "Failed to create background gRPC Health Probe")
 		return
@@ -100,7 +157,7 @@ func CreateAndRunGRPCHealthProbe(ctx context.Context, healthService string, opti
 		cancelCtx, cancel := context.WithTimeout(ctx, 4*time.Second) // probe timeout
 		defer cancel()
 		servingStatus := grpc_health_v1.HealthCheckResponse_SERVING
-		if err := ghp.Run(cancelCtx); err != nil {
+		if err := ghp.Request(cancelCtx); err != nil {
 			servingStatus = grpc_health_v1.HealthCheckResponse_NOT_SERVING
 			log.Logger.V(1).Info("Background", "error", err)
 		}

--- a/pkg/nsp/registry/keepalive/keepalive.go
+++ b/pkg/nsp/registry/keepalive/keepalive.go
@@ -142,7 +142,7 @@ func (ka *KeepAlive) add(target *nspAPI.Target) {
 
 func (ka *KeepAlive) remove(ctx context.Context, target *nspAPI.Target) error {
 	delete(ka.targets, sqlite.GetTargetID(target))
-	log.Logger.Info("Unegister", "target", target)
+	log.Logger.Info("Unregister", "target", target)
 	if ka.TargetRegistry == nil {
 		return nil
 	}


### PR DESCRIPTION
## Description
Refer to the related issue.

Kubernetes native grpc probes are not introduced, because it does not seem to support servers using unix sockets (hence grpc-health-probe binary cannot be removed from the images):
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#httpgetaction-v1-core

## Issue link
#474 

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
