### PR TITLE
Liveness probe with subservices

### DIFF
--- a/cmd/frontend/internal/frontend/service.go
+++ b/cmd/frontend/internal/frontend/service.go
@@ -48,6 +48,7 @@ const rulePriorityVIP int = 100
 func NewFrontEndService(ctx context.Context, c *feConfig.Config) *FrontEndService {
 	logger := log.FromContextOrGlobal(ctx).WithValues("class", "FrontEndService")
 	targetRegistryClient := nspAPI.NewTargetRegistryClient(c.NSPConn)
+	logger.V(1).Info("Created Target Registry Client")
 
 	birdConfFile := c.BirdConfigPath + "/bird-fe-meridio.conf"
 	authCh := make(chan struct{}, 10)

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ func main() {
 
 	// create and start health server
 	ctx = health.CreateChecker(ctx)
-	if err := health.RegisterReadinesSubservices(ctx, health.FEReadinessServices...); err != nil {
+	if err := health.RegisterReadinessSubservices(ctx, health.FEReadinessServices...); err != nil {
 		logger.Error(err, "RegisterReadinesSubservices")
 	}
 
@@ -138,7 +138,6 @@ func main() {
 	}
 	fe := frontend.NewFrontEndService(ctx, c)
 	defer fe.CleanUp()
-	health.SetServingStatus(ctx, health.TargetRegistryCliSvc, true) // NewFrontEndService() creates Target Registry Client
 
 	if err := fe.Init(); err != nil {
 		cancel()

--- a/cmd/ipam/main.go
+++ b/cmd/ipam/main.go
@@ -95,8 +95,11 @@ func main() {
 
 	// create and start health server
 	ctx = health.CreateChecker(ctx)
-	if err := health.RegisterReadinesSubservices(ctx, health.IPAMReadinessServices...); err != nil {
-		logger.Error(err, "RegisterReadinesSubservices")
+	if err := health.RegisterReadinessSubservices(ctx, health.IPAMReadinessServices...); err != nil {
+		logger.Error(err, "RegisterReadinessSubservices")
+	}
+	if err := health.RegisterLivenessSubservices(ctx, health.IPAMLivenessServices...); err != nil {
+		logger.Error(err, "RegisterLivenessSubservices")
 	}
 
 	// connect NSP

--- a/cmd/nsp/main.go
+++ b/cmd/nsp/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -96,8 +96,11 @@ func main() {
 
 	// create and start health server
 	ctx = health.CreateChecker(ctx)
-	if err := health.RegisterReadinesSubservices(ctx, health.NSPReadinessServices...); err != nil {
-		logger.Error(err, "RegisterReadinesSubservices")
+	if err := health.RegisterReadinessSubservices(ctx, health.NSPReadinessServices...); err != nil {
+		logger.Error(err, "RegisterReadinessSubservices")
+	}
+	if err := health.RegisterLivenessSubservices(ctx, health.NSPLivenessServices...); err != nil {
+		logger.Error(err, "RegisterLivenessSubservices")
 	}
 
 	// configuration

--- a/cmd/nsp/main.go
+++ b/cmd/nsp/main.go
@@ -96,7 +96,7 @@ func main() {
 
 	// create and start health server
 	ctx = health.CreateChecker(ctx)
-	if err := health.RegisterReadinessSubservices(ctx, health.NSPReadinessServices...); err != nil {
+	if err := health.RegisterReadinessSubservices(ctx); err != nil {
 		logger.Error(err, "RegisterReadinessSubservices")
 	}
 	if err := health.RegisterLivenessSubservices(ctx, health.NSPLivenessServices...); err != nil {

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -104,8 +104,11 @@ func main() {
 
 	// create and start health server
 	ctx = health.CreateChecker(ctx)
-	if err := health.RegisterReadinesSubservices(ctx, health.ProxyReadinessServices...); err != nil {
-		logger.Error(err, "RegisterReadinesSubservices")
+	if err := health.RegisterReadinessSubservices(ctx, health.ProxyReadinessServices...); err != nil {
+		logger.Error(err, "RegisterReadinessSubservices")
+	}
+	if err := health.RegisterLivenessSubservices(ctx, health.ProxyLivenessServices...); err != nil {
+		logger.Error(err, "RegisterLivenessSubservices")
 	}
 
 	// context enabling graceful termiantion on signals

--- a/cmd/stateless-lb/main.go
+++ b/cmd/stateless-lb/main.go
@@ -126,8 +126,13 @@ func main() {
 
 	// create and start health server
 	ctx = health.CreateChecker(ctx)
-	if err := health.RegisterReadinesSubservices(ctx, health.LBReadinessServices...); err != nil {
-		logger.Error(err, "RegisterReadinesSubservices")
+	if err := health.RegisterReadinessSubservices(ctx, health.LBReadinessServices...); err != nil {
+		logger.Error(err, "RegisterReadinessSubservices")
+	}
+	// note: NSM endpoint service is hosted from early on by its server, thus it can be probed
+	// irrespective of its registration status at NSM
+	if err := health.RegisterLivenessSubservices(ctx, health.LBLivenessServices...); err != nil {
+		logger.Error(err, "RegisterLivenessSubservices")
 	}
 
 	logger.Info("Dial NSP", "NSPService", config.NSPService)

--- a/cmd/tapa/config.go
+++ b/cmd/tapa/config.go
@@ -23,19 +23,20 @@ import (
 
 // Config for the TAPA
 type Config struct {
-	Name             string        `default:"nsc" desc:"Name of the target"`
-	Node             string        `default:"" desc:"Node name the target is running on" split_words:"true"`
-	Namespace        string        `default:"default" desc:"Namespace the trenches to connect to are running on" split_words:"true"`
-	Socket           string        `default:"/ambassador.sock" desc:"Path of the socket file of the TAPA" split_words:"true"`
-	NSMSocket        url.URL       `default:"unix:///var/lib/networkservicemesh/nsm.io.sock" desc:"Path of the socket file of NSM" envconfig:"nsm_socket"`
-	NSPServiceName   string        `default:"nsp-service" desc:"Domain name of the NSP Service" envconfig:"nsp_service_name"`
-	NSPServicePort   int           `default:"7778" desc:"port of the NSP Service" envconfig:"nsp_service_port"`
-	Timeout          time.Duration `default:"15s" desc:"timeout of NSM request/close, NSP register/unregister..." split_words:"true"`
-	DialTimeout      time.Duration `default:"5s" desc:"timeout to dial NSMgr" split_words:"true"`
-	MaxTokenLifetime time.Duration `default:"24h" desc:"maximum lifetime of tokens" split_words:"true"`
-	LogLevel         string        `default:"DEBUG" desc:"Log level" split_words:"true"`
-	NSPEntryTimeout  time.Duration `default:"30s" desc:"Timeout of the entries" envconfig:"nsp_entry_timeout"`
-	GRPCMaxBackoff   time.Duration `default:"5s" desc:"Upper bound on gRPC connection backoff delay" envconfig:"grpc_max_backoff"`
+	Name                string        `default:"nsc" desc:"Name of the target"`
+	Node                string        `default:"" desc:"Node name the target is running on" split_words:"true"`
+	Namespace           string        `default:"default" desc:"Namespace the trenches to connect to are running on" split_words:"true"`
+	Socket              string        `default:"/ambassador.sock" desc:"Path of the socket file of the TAPA" split_words:"true"`
+	NSMSocket           url.URL       `default:"unix:///var/lib/networkservicemesh/nsm.io.sock" desc:"Path of the socket file of NSM" envconfig:"nsm_socket"`
+	NSPServiceName      string        `default:"nsp-service" desc:"Domain name of the NSP Service" envconfig:"nsp_service_name"`
+	NSPServicePort      int           `default:"7778" desc:"port of the NSP Service" envconfig:"nsp_service_port"`
+	Timeout             time.Duration `default:"15s" desc:"timeout of NSM request/close, NSP register/unregister..." split_words:"true"`
+	DialTimeout         time.Duration `default:"5s" desc:"timeout to dial NSMgr" split_words:"true"`
+	MaxTokenLifetime    time.Duration `default:"24h" desc:"maximum lifetime of tokens" split_words:"true"`
+	LogLevel            string        `default:"DEBUG" desc:"Log level" split_words:"true"`
+	NSPEntryTimeout     time.Duration `default:"30s" desc:"Timeout of the entries" envconfig:"nsp_entry_timeout"`
+	GRPCMaxBackoff      time.Duration `default:"5s" desc:"Upper bound on gRPC connection backoff delay" envconfig:"grpc_max_backoff"`
+	GRPCProbeRPCTimeout time.Duration `default:"1s" desc:"RPC timeout of internal gRPC health probe" envconfig:"grpc_probe_rpc_timeout"`
 }
 
 // IsValid checks if the configuration is valid

--- a/config/templates/charts/meridio/deployment/ipam.yaml
+++ b/config/templates/charts/meridio/deployment/ipam.yaml
@@ -57,7 +57,7 @@ spec:
               command:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
-                - -service=
+                - -service=Liveness
                 - -connect-timeout=400ms
                 - -rpc-timeout=400ms
             failureThreshold: 5

--- a/config/templates/charts/meridio/deployment/nsp.yaml
+++ b/config/templates/charts/meridio/deployment/nsp.yaml
@@ -58,7 +58,7 @@ spec:
               command:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
-                - -service=
+                - -service=Liveness
                 - -connect-timeout=400ms
                 - -rpc-timeout=400ms
             failureThreshold: 5

--- a/config/templates/charts/meridio/deployment/proxy.yaml
+++ b/config/templates/charts/meridio/deployment/proxy.yaml
@@ -60,7 +60,7 @@ spec:
               command:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
-                - -service=
+                - -service=Liveness
                 - -connect-timeout=400ms
                 - -rpc-timeout=400ms
             failureThreshold: 5

--- a/config/templates/charts/meridio/deployment/stateless-lb-frontend.yaml
+++ b/config/templates/charts/meridio/deployment/stateless-lb-frontend.yaml
@@ -86,7 +86,7 @@ spec:
               command:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
-                - -service=
+                - -service=Liveness
                 - -connect-timeout=400ms
                 - -rpc-timeout=400ms
             failureThreshold: 5

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -33,6 +33,8 @@ loadBalancer:
   probe:
     readiness:
       service: "Readiness"
+    liveness:
+      service: "Liveness"
 
 frontEnd:
   image: frontend
@@ -48,6 +50,8 @@ proxy:
   probe:
     readiness:
       service: "Readiness"
+    liveness:
+      service: "Liveness"
 
 ipam:
   image: ipam
@@ -58,6 +62,8 @@ ipam:
   probe:
     readiness:
       service: "Readiness"
+    liveness:
+      service: "Liveness"
 
 nsp:
   image: nsp
@@ -68,6 +74,8 @@ nsp:
   probe:
     readiness:
       service: "Readiness"
+    liveness:
+      service: "Liveness"
 
 ipFamily: ipv4  # ipv4 / ipv6 / dualstack
 

--- a/docs/components/frontend.md
+++ b/docs/components/frontend.md
@@ -80,8 +80,12 @@ The health check is provided by the [GRPC Health Checking Protocol](https://gith
 
 Service | Description
 --- | ---
-NSPCli | Monitor status of the connection to the NSP service
-Egress | Monitor the gateways connectivity
+Readiness | A unique service to be used by readiness probe to return status, can aggregate other lesser services
+
+Service | Probe | Description
+--- | --- | ---
+NSPCli | Readiness | Monitor status of the connection to the NSP service
+Egress | Readiness | Monitor the gateways connectivity
 
 ## Privileges
 

--- a/docs/components/frontend.md
+++ b/docs/components/frontend.md
@@ -81,7 +81,6 @@ The health check is provided by the [GRPC Health Checking Protocol](https://gith
 Service | Description
 --- | ---
 NSPCli | Monitor status of the connection to the NSP service
-TargetRegistryCli | Monitor status of the connection to the NSP Target Registry service
 Egress | Monitor the gateways connectivity
 
 ## Privileges

--- a/docs/components/ipam.md
+++ b/docs/components/ipam.md
@@ -74,8 +74,13 @@ The health check is provided by the [GRPC Health Checking Protocol](https://gith
 
 Service | Description
 --- | ---
-NSPCli | Monitor status of the connection to the NSP service
-IPAM | Monitor status of the server
+Liveness | A unique service to be used by liveness probe to return status, can aggregate other lesser services
+Readiness | A unique service to be used by readiness probe to return status, can aggregate other lesser services
+
+Service | Probe | Description
+--- | --- | ---
+NSPCli | Readiness | Monitor status of the connection to the NSP service
+IPAM | Liveness | Monitor status of the server
 
 ## Privileges
 

--- a/docs/components/nsp.md
+++ b/docs/components/nsp.md
@@ -65,7 +65,12 @@ The health check is provided by the [GRPC Health Checking Protocol](https://gith
 
 Service | Description
 --- | ---
-NSP | Monitor status of the server
+Liveness | A unique service to be used by liveness probe to return status, can aggregate other lesser services
+Readiness | A unique service to be used by readiness probe to return status, can aggregate other lesser services
+
+Service | Probe | Description
+--- | --- | ---
+NSP | Liveness | Monitor status of the server
 
 ## Privileges
 

--- a/docs/components/proxy.md
+++ b/docs/components/proxy.md
@@ -66,10 +66,15 @@ The health check is provided by the [GRPC Health Checking Protocol](https://gith
 
 Service | Description
 --- | ---
-IPAMCli | Monitor status of the connection to the IPAM service
-NSPCli | Monitor status of the connection to the NSP service
-NSMEndpoint | Monitor status of the NSE
-Egress | Check if at least 1 stateless-lb-frontend is connected
+Liveness | A unique service to be used by liveness probe to return status, can aggregate other lesser services
+Readiness | A unique service to be used by readiness probe to return status, can aggregate other lesser services
+
+Service | Probe | Description
+--- | --- | ---
+IPAMCli | Readiness | Monitor status of the connection to the IPAM service
+NSPCli | Readiness | Monitor status of the connection to the NSP service
+NSMEndpoint | Readiness,Liveness | Monitor status of the NSE
+Egress | Readiness | Check if at least 1 stateless-lb-frontend is connected
 
 ## Privileges
 

--- a/docs/components/stateless-lb.md
+++ b/docs/components/stateless-lb.md
@@ -55,11 +55,16 @@ The health check is provided by the [GRPC Health Checking Protocol](https://gith
 
 Service | Description
 --- | ---
-NSPCli | Monitor status of the connection to the NSP service
-NSMEndpoint | Monitor status of the NSE
-Egress | Monitor the frontend availability
-Stream | Check if at least 1 stream is serving
-Flow | Check if at least 1 flow is serving
+Liveness | A unique service to be used by liveness probe to return status, can aggregate other lesser services
+Readiness | A unique service to be used by readiness probe to return status, can aggregate other lesser services
+
+Service | Probe | Description
+--- | --- | ---
+NSPCli | Readiness | Monitor status of the connection to the NSP service
+NSMEndpoint | Readiness,Liveness | Monitor status of the NSE
+Egress | Readiness | Monitor the frontend availability
+Stream | Readiness | Check if at least 1 stream is serving
+Flow | Readiness | Check if at least 1 flow is serving
 
 ## Privileges
 

--- a/docs/components/tapa.md
+++ b/docs/components/tapa.md
@@ -56,6 +56,9 @@ MERIDIO_TIMEOUT | time.Duration | timeout of NSM request/close, NSP register/unr
 MERIDIO_DIAL_TIMEOUT | time.Duration | timeout to dial NSMgr | 5s
 MERIDIO_MAX_TOKEN_LIFETIME | time.Duration | maximum lifetime of tokens | 24h
 MERIDIO_LOG_LEVEL | string | Log level | DEBUG
+MERIDIO_NSP_ETRY_TIMEOUT | time.Duration | Timeout of the entries registered in NSP | 30s
+MERIDO_GRPC_MAX_BACKOFF | time.Duration | Upper bound on gRPC connection backoff delay | 5s
+MERIDIO_GRPC_PROBE_RPC_TIMEOUT | time.Duration | RPC timeout of internal gRPC health probes if any | 1s
 
 ## Command Line 
 
@@ -81,7 +84,15 @@ An overview of the communications between all components is available [here](res
 
 The health check is provided by the [GRPC Health Checking Protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md). The status returned can be `UNKNOWN`, `SERVING`, `NOT_SERVING` or `SERVICE_UNKNOWN`.
 
-TODO
+Service | Description
+--- | ---
+Liveness | A unique service to be used by liveness probe to return status, can aggregate other lesser services
+Startup | A unique service to be used by startup probe to return status, can aggregate other lesser services
+Readiness | A unique service to be used by readiness probe to return status, can aggregate other lesser services
+
+Service | Probe | Description
+--- | --- | ---
+AmbassadorSvc | Liveness | Monitor status of the Ambassador server
 
 ## Privileges
 

--- a/examples/target/deployments/helm/values.yaml
+++ b/examples/target/deployments/helm/values.yaml
@@ -34,19 +34,17 @@ nsp:
 
 readinessProbe:
   exec:
-    command: ["/bin/grpc_health_probe", "-addr=unix://{{ .Values.default.ambassadorSock }}", "-connect-timeout=100ms", "-rpc-timeout=150ms"]
+    command: ["/bin/grpc_health_probe", "-addr=unix:///tmp/health.sock", "-service=Readiness",  "-connect-timeout=100ms", "-rpc-timeout=150ms"]
   initialDelaySeconds: 0
 
 livenessProbe:
   exec:
-    command: ["/bin/grpc_health_probe", "-addr=unix:///tmp/health.sock", "-connect-timeout=100ms", "-rpc-timeout=150ms"]
-  initialDelaySeconds: 3
-  timeoutSeconds: 3
-  failureThreshold: 3
+    command: ["/bin/grpc_health_probe", "-addr=unix:///tmp/health.sock", "-service=Liveness", "-connect-timeout=100ms", "-rpc-timeout=150ms"]
+  initialDelaySeconds: 2
 
 startupProbe:
   exec:
-    command: ["/bin/grpc_health_probe", "-addr=unix:///tmp/health.sock", "-connect-timeout=100ms", "-rpc-timeout=150ms"]
+    command: ["/bin/grpc_health_probe", "-addr=unix:///tmp/health.sock", "-service=Startup", "-connect-timeout=100ms", "-rpc-timeout=150ms"]
   initialDelaySeconds: 0
   periodSeconds: 2
   timeoutSeconds: 2

--- a/pkg/health/const.go
+++ b/pkg/health/const.go
@@ -35,6 +35,7 @@ const (
 	StreamSvc      string = "Stream"
 	FlowSvc        string = "Flow"
 	NSPSvc         string = "NSP"
+	AmbassadorSvc  string = "Ambassador"
 )
 
 var LBReadinessServices []string = []string{NSPCliSvc, NSMEndpointSvc, EgressSvc, StreamSvc, FlowSvc}
@@ -44,5 +45,5 @@ var ProxyReadinessServices []string = []string{IPAMCliSvc, NSPCliSvc, NSMEndpoin
 var ProxyLivenessServices []string = []string{NSMEndpointSvc}
 var IPAMReadinessServices []string = []string{NSPCliSvc}
 var IPAMLivenessServices []string = []string{IPAMSvc}
-var NSPReadinessServices []string = []string{}
 var NSPLivenessServices []string = []string{NSPSvc}
+var TAPALivenessServices []string = []string{AmbassadorSvc}

--- a/pkg/health/const.go
+++ b/pkg/health/const.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -27,19 +27,22 @@ const (
 )
 
 const (
-	IPAMSvc              string = "IPAM"
-	IPAMCliSvc           string = "IPAMCli"
-	NSPCliSvc            string = "NSPCli"
-	EgressSvc            string = "Egress"
-	NSMEndpointSvc       string = "NSMEndpoint"
-	TargetRegistryCliSvc string = "TargetRegistryCli"
-	StreamSvc            string = "Stream"
-	FlowSvc              string = "Flow"
-	NSPSvc               string = "NSP"
+	IPAMSvc        string = "IPAM"
+	IPAMCliSvc     string = "IPAMCli"
+	NSPCliSvc      string = "NSPCli"
+	EgressSvc      string = "Egress"
+	NSMEndpointSvc string = "NSMEndpoint"
+	StreamSvc      string = "Stream"
+	FlowSvc        string = "Flow"
+	NSPSvc         string = "NSP"
 )
 
 var LBReadinessServices []string = []string{NSPCliSvc, NSMEndpointSvc, EgressSvc, StreamSvc, FlowSvc}
-var FEReadinessServices []string = []string{NSPCliSvc, TargetRegistryCliSvc, EgressSvc}
+var LBLivenessServices []string = []string{NSMEndpointSvc}
+var FEReadinessServices []string = []string{NSPCliSvc, EgressSvc}
 var ProxyReadinessServices []string = []string{IPAMCliSvc, NSPCliSvc, NSMEndpointSvc, EgressSvc}
-var IPAMReadinessServices []string = []string{NSPCliSvc, IPAMSvc}
-var NSPReadinessServices []string = []string{NSPSvc}
+var ProxyLivenessServices []string = []string{NSMEndpointSvc}
+var IPAMReadinessServices []string = []string{NSPCliSvc}
+var IPAMLivenessServices []string = []string{IPAMSvc}
+var NSPReadinessServices []string = []string{}
+var NSPLivenessServices []string = []string{NSPSvc}

--- a/pkg/health/probe/probe.go
+++ b/pkg/health/probe/probe.go
@@ -151,7 +151,7 @@ func CreateAndRunGRPCHealthProbe(ctx context.Context, healthService string, opti
 		log.Logger.Error(err, "Failed to create background gRPC Health Probe")
 		return
 	}
-	log.Logger.V(1).Info("Created background probe", "probe", ghp)
+	log.Logger.V(1).Info("Created background probe", "probe", ghp, "health service", healthService)
 
 	runf := func(ctx context.Context) error {
 		cancelCtx, cancel := context.WithTimeout(ctx, 4*time.Second) // probe timeout

--- a/pkg/health/wrapper.go
+++ b/pkg/health/wrapper.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -49,11 +49,21 @@ func CreateChecker(ctx context.Context, options ...Option) context.Context {
 	return WithHealthServer(ctx, healthChecker)
 }
 
-// RegisterReadinesSubservices -
+// RegisterReadinessSubservices -
 // Wraps Checker.RegisterServices() by fetching the health server (i.e. Checker) from context
-func RegisterReadinesSubservices(ctx context.Context, services ...string) error {
+func RegisterReadinessSubservices(ctx context.Context, services ...string) error {
 	if h := HealthServer(ctx); h != nil {
 		h.RegisterServices(Readiness, services...)
+		return nil
+	}
+	return errors.New("no health server in context")
+}
+
+// RegisterLivenessSubservices -
+// Wraps Checker.RegisterServices() by fetching the health server (i.e. Checker) from context
+func RegisterLivenessSubservices(ctx context.Context, services ...string) error {
+	if h := HealthServer(ctx); h != nil {
+		h.RegisterServices(Liveness, services...)
 		return nil
 	}
 	return errors.New("no health server in context")

--- a/pkg/health/wrapper.go
+++ b/pkg/health/wrapper.go
@@ -69,6 +69,16 @@ func RegisterLivenessSubservices(ctx context.Context, services ...string) error 
 	return errors.New("no health server in context")
 }
 
+// RegisterStartupSubservices -
+// Wraps Checker.RegisterServices() by fetching the health server (i.e. Checker) from context
+func RegisterStartupSubservices(ctx context.Context, services ...string) error {
+	if h := HealthServer(ctx); h != nil {
+		h.RegisterServices(Startup, services...)
+		return nil
+	}
+	return errors.New("no health server in context")
+}
+
 // SetServingStatus -
 // Wraps Checker.SetServingStatus() by fetching the health server (i.e. Checker) from context
 func SetServingStatus(ctx context.Context, service string, serving bool) {

--- a/pkg/health/wrapper_test.go
+++ b/pkg/health/wrapper_test.go
@@ -1,0 +1,433 @@
+/*
+Copyright (c) 2023 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/nordix/meridio/pkg/health"
+	"github.com/nordix/meridio/pkg/health/probe"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+var readinessServices []string = []string{"service-1", "service-2", "service-3", "service-4"}
+var livenessServices []string = []string{"service-1", "service-5"}
+
+func healthClient(ctx context.Context, address url.URL) error {
+	hp, err := probe.NewHealthProbe(ctx, probe.WithAddress(address.String()))
+	if err != nil {
+		return fmt.Errorf("failed to create health client, %v", err)
+	}
+
+	probeCtx, probeCancel := context.WithTimeout(ctx, 1*time.Second)
+	defer probeCancel()
+	if err := hp.Request(probeCtx); err != nil {
+		return fmt.Errorf("health client request failed: %v", err)
+	}
+
+	return nil
+}
+
+func TestCreateChecker(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	dir, err := os.MkdirTemp(os.TempDir(), t.Name())
+	require.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+
+	socket := path.Join(dir, "folder", "test.sock")
+	ctx, cancel := context.WithCancel(context.Background())
+	serverAddr := &url.URL{Scheme: "unix", Path: socket}
+	ctx = health.CreateChecker(ctx, health.WithURL(serverAddr))
+
+	// the returned context must contain health server i.e. the checker created above
+	hs := health.HealthServer(ctx)
+	require.NotNil(t, hs)
+
+	// use health client to secure health server is serving by the time cancel is called
+	err = healthClient(ctx, *serverAddr)
+	require.NoError(t, err)
+
+	cancel()
+	<-ctx.Done()
+}
+
+func TestSetServingStatus(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	dir, err := os.MkdirTemp(os.TempDir(), t.Name())
+	require.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+
+	socket := path.Join(dir, "folder", "test.sock")
+	ctx, cancel := context.WithCancel(context.Background())
+	serverAddr := &url.URL{Scheme: "unix", Path: socket}
+	ctx = health.CreateChecker(ctx, health.WithURL(serverAddr))
+
+	hs := health.HealthServer(ctx)
+	require.NotNil(t, hs)
+
+	var healthService string = "random-service"
+	var resp *grpc_health_v1.HealthCheckResponse
+	// health service not registered to the health server shall return error upon Check()
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: healthService})
+	require.Error(t, err)
+	require.Nil(t, resp)
+
+	// set health service status to NOT_SERVING while also registering it at the health server
+	health.SetServingStatus(ctx, healthService, false)
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: healthService})
+	require.NoError(t, err)
+	require.Equal(t, resp.Status, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+
+	// change health service status to SERVING
+	health.SetServingStatus(ctx, healthService, true)
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: healthService})
+	require.NoError(t, err)
+	require.Equal(t, resp.Status, grpc_health_v1.HealthCheckResponse_SERVING)
+
+	// use health client to secure health server is serving by the time cancel is called
+	err = healthClient(ctx, *serverAddr)
+	require.NoError(t, err)
+
+	cancel()
+	<-ctx.Done()
+}
+
+func TestRegisterReadinessSubservices_NewSubservices(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	dir, err := os.MkdirTemp(os.TempDir(), t.Name())
+	require.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+
+	socket := path.Join(dir, "folder", "test.sock")
+	ctx, cancel := context.WithCancel(context.Background())
+	serverAddr := &url.URL{Scheme: "unix", Path: socket}
+	ctx = health.CreateChecker(ctx, health.WithURL(serverAddr))
+
+	hs := health.HealthServer(ctx)
+	require.NotNil(t, hs)
+
+	// register subservices for Readiness probe
+	err = health.RegisterReadinessSubservices(ctx, readinessServices...)
+	require.NoError(t, err)
+
+	var resp *grpc_health_v1.HealthCheckResponse
+	// initial probe status must be NOT_SERVING because its subservices
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: health.Readiness})
+	require.NoError(t, err)
+	require.Equal(t, resp.Status, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+
+	// change status of subservices to SERVING
+	for _, service := range readinessServices {
+		health.SetServingStatus(ctx, service, true)
+	}
+	// probe service status must be SERVING
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: health.Readiness})
+	require.NoError(t, err)
+	require.Equal(t, resp.Status, grpc_health_v1.HealthCheckResponse_SERVING)
+
+	// set status of 1 subservice to NOT_SERVING
+	for _, service := range readinessServices {
+		health.SetServingStatus(ctx, service, false)
+		break
+	}
+	// probe service must be NOT_SERVING due to the above status change
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: health.Readiness})
+	require.NoError(t, err)
+	require.Equal(t, resp.Status, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+
+	// use health client to secure health server is serving by the time cancel is called
+	err = healthClient(ctx, *serverAddr)
+	require.NoError(t, err)
+
+	cancel()
+	<-ctx.Done()
+}
+
+func TestRegisterReadinessSubservices_ExistingServingSubservices(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	dir, err := os.MkdirTemp(os.TempDir(), t.Name())
+	require.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+
+	socket := path.Join(dir, "folder", "test.sock")
+	ctx, cancel := context.WithCancel(context.Background())
+	serverAddr := &url.URL{Scheme: "unix", Path: socket}
+	ctx = health.CreateChecker(ctx, health.WithURL(serverAddr))
+
+	hs := health.HealthServer(ctx)
+	require.NotNil(t, hs)
+
+	// register subservice with SERVING status
+	for _, service := range readinessServices {
+		health.SetServingStatus(ctx, service, true)
+	}
+
+	// register above subservices for Readiness probe
+	err = health.RegisterReadinessSubservices(ctx, readinessServices...)
+	require.NoError(t, err)
+
+	var resp *grpc_health_v1.HealthCheckResponse
+	// initial probe status must be SERVING because its subservices
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: health.Readiness})
+	require.NoError(t, err)
+	require.Equal(t, resp.Status, grpc_health_v1.HealthCheckResponse_SERVING)
+
+	// set status of 1 subservice to NOT_SERVING
+	for _, service := range readinessServices {
+		health.SetServingStatus(ctx, service, false)
+		break
+	}
+	// probe service must be NOT_SERVING due to the above status change
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: health.Readiness})
+	require.NoError(t, err)
+	require.Equal(t, resp.Status, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+
+	// use health client to secure health server is serving by the time cancel is called
+	err = healthClient(ctx, *serverAddr)
+	require.NoError(t, err)
+
+	cancel()
+	<-ctx.Done()
+}
+
+func TestRegisterReadinessSubservices_ExistingNotServingSubservices(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	dir, err := os.MkdirTemp(os.TempDir(), t.Name())
+	require.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+
+	socket := path.Join(dir, "folder", "test.sock")
+	ctx, cancel := context.WithCancel(context.Background())
+	serverAddr := &url.URL{Scheme: "unix", Path: socket}
+	ctx = health.CreateChecker(ctx, health.WithURL(serverAddr))
+
+	hs := health.HealthServer(ctx)
+	require.NotNil(t, hs)
+
+	// register subservice with NOT_SERVING status
+	for _, service := range readinessServices {
+		health.SetServingStatus(ctx, service, true)
+	}
+
+	// register above subservices for Readiness probe
+	err = health.RegisterReadinessSubservices(ctx, readinessServices...)
+	require.NoError(t, err)
+
+	var resp *grpc_health_v1.HealthCheckResponse
+	// initial probe status must be NOT_SERVING because its subservices
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: health.Readiness})
+	require.NoError(t, err)
+	require.Equal(t, resp.Status, grpc_health_v1.HealthCheckResponse_SERVING)
+
+	// change status of subservices to SERVING
+	for _, service := range readinessServices {
+		health.SetServingStatus(ctx, service, true)
+	}
+	// probe service status must be SERVING
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: health.Readiness})
+	require.NoError(t, err)
+	require.Equal(t, resp.Status, grpc_health_v1.HealthCheckResponse_SERVING)
+
+	// set status of 1 subservice to NOT_SERVING
+	for _, service := range readinessServices {
+		health.SetServingStatus(ctx, service, false)
+		break
+	}
+	// probe service must be NOT_SERVING due to the above status change
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: health.Readiness})
+	require.NoError(t, err)
+	require.Equal(t, resp.Status, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+
+	// use health client to secure health server is serving by the time cancel is called
+	err = healthClient(ctx, *serverAddr)
+	require.NoError(t, err)
+
+	cancel()
+	<-ctx.Done()
+}
+
+func TestRegisterLivenessSubservices_NewSubservices(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	dir, err := os.MkdirTemp(os.TempDir(), t.Name())
+	require.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+
+	socket := path.Join(dir, "folder", "test.sock")
+	ctx, cancel := context.WithCancel(context.Background())
+	serverAddr := &url.URL{Scheme: "unix", Path: socket}
+	ctx = health.CreateChecker(ctx, health.WithURL(serverAddr))
+
+	hs := health.HealthServer(ctx)
+	require.NotNil(t, hs)
+
+	// register subservices for Liveness probe
+	err = health.RegisterLivenessSubservices(ctx, livenessServices...)
+	require.NoError(t, err)
+
+	var resp *grpc_health_v1.HealthCheckResponse
+	// initial probe status must be NOT_SERVING because its subservices
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: health.Liveness})
+	require.NoError(t, err)
+	require.Equal(t, resp.Status, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+
+	// change status of subservices to SERVING
+	for _, service := range livenessServices {
+		health.SetServingStatus(ctx, service, true)
+	}
+	// probe service status must be SERVING
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: health.Liveness})
+	require.NoError(t, err)
+	require.Equal(t, resp.Status, grpc_health_v1.HealthCheckResponse_SERVING)
+
+	// set status of 1 subservice to NOT_SERVING
+	for _, service := range livenessServices {
+		health.SetServingStatus(ctx, service, false)
+		break
+	}
+	// probe service must be NOT_SERVING due to the above status change
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: health.Liveness})
+	require.NoError(t, err)
+	require.Equal(t, resp.Status, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+
+	// use health client to secure health server is serving by the time cancel is called
+	err = healthClient(ctx, *serverAddr)
+	require.NoError(t, err)
+
+	cancel()
+	<-ctx.Done()
+}
+
+func TestRegisterLivenessSubservices_EmptySubservices(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	emptyLivenessServices := []string{}
+	dir, err := os.MkdirTemp(os.TempDir(), t.Name())
+	require.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+
+	socket := path.Join(dir, "folder", "test.sock")
+	ctx, cancel := context.WithCancel(context.Background())
+	serverAddr := &url.URL{Scheme: "unix", Path: socket}
+	ctx = health.CreateChecker(ctx, health.WithURL(serverAddr))
+
+	hs := health.HealthServer(ctx)
+	require.NotNil(t, hs)
+
+	// register subservices for Liveness probe
+	err = health.RegisterLivenessSubservices(ctx, emptyLivenessServices...)
+	require.NoError(t, err)
+
+	var resp *grpc_health_v1.HealthCheckResponse
+	// initial probe status must be SERVING because there are no subservices
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: health.Liveness})
+	require.NoError(t, err)
+	require.Equal(t, resp.Status, grpc_health_v1.HealthCheckResponse_SERVING)
+
+	// can change probe status directly because there are no subservices
+	health.SetServingStatus(ctx, health.Liveness, false)
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: health.Liveness})
+	require.NoError(t, err)
+	require.Equal(t, resp.Status, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+
+	// use health client to secure health server is serving by the time cancel is called
+	err = healthClient(ctx, *serverAddr)
+	require.NoError(t, err)
+
+	cancel()
+	<-ctx.Done()
+}
+
+func TestRegisterLivenessSubservices_ExistingSharedSubservices(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	var sharedServices []string = []string{"service-1", "service-2", "service-3"}
+	readinessServices := sharedServices
+	livenessServices := sharedServices
+	var resp *grpc_health_v1.HealthCheckResponse
+	dir, err := os.MkdirTemp(os.TempDir(), t.Name())
+	require.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+
+	socket := path.Join(dir, "folder", "test.sock")
+	ctx, cancel := context.WithCancel(context.Background())
+	serverAddr := &url.URL{Scheme: "unix", Path: socket}
+	ctx = health.CreateChecker(ctx, health.WithURL(serverAddr))
+
+	hs := health.HealthServer(ctx)
+	require.NotNil(t, hs)
+
+	// register shared subservices with SERVING status
+	for _, service := range sharedServices {
+		health.SetServingStatus(ctx, service, true)
+	}
+
+	// register readiness subservices for Liveness probe
+	err = health.RegisterReadinessSubservices(ctx, readinessServices...)
+	require.NoError(t, err)
+	_, _ = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: health.Readiness})
+
+	// register liveness subservices for Liveness probe
+	err = health.RegisterLivenessSubservices(ctx, livenessServices...)
+	require.NoError(t, err)
+
+	// initial liveness probe status must be SERVING because the subservices are SERVING
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: health.Liveness})
+	require.NoError(t, err)
+	require.Equal(t, resp.Status, grpc_health_v1.HealthCheckResponse_SERVING)
+
+	// readiness probe status must be SERVING
+	resp, err = hs.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: health.Readiness})
+	require.NoError(t, err)
+	require.Equal(t, resp.Status, grpc_health_v1.HealthCheckResponse_SERVING)
+
+	// use health client to secure health server is serving by the time cancel is called
+	err = healthClient(ctx, *serverAddr)
+	require.NoError(t, err)
+
+	cancel()
+	<-ctx.Done()
+}


### PR DESCRIPTION
## Description
- NSP, IPAM, Proxy and LB register _Liveness_ probe service at custom gRPC health server.
- FE no longer checks Target Registry Client as part of Readiness.
- IPAM, NSP Readiness no longer includes their server status.
- Liveness probes in IPAM, NSP, Proxy and LB containers rely on service name "Liveness" to check status.
- Health server in TAPA hosts health services _Liveness_, _Startup_ and _Readiness_ out of the box. Ambassador server availability is returned as part of Liveness. (Example-target has been updated accordingly.) Note, it's not mandatory to use these health services in the kubernetes probe configuration, but using them could avoid the need of revisiting the probe configuration in the TAPA container if the recommended probe setup changes (the implementation would change in the background).

Note: There's a DR that does not recommend putting evaluation criteria inside startup probe which are related to service operation readiness which later can fail readiness. Thus startup probes do not check for server availability. (Although in case of IPAM and NSP this limitation would no longer stand.)

## Issue link
#480 

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [x] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
