### PR TITLE
TAPA logs and other improvements

### DIFF
--- a/pkg/ambassador/tap/conduit/manager_test.go
+++ b/pkg/ambassador/tap/conduit/manager_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package conduit_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -323,7 +324,7 @@ func Test_Manager_Close_While_Opening(t *testing.T) {
 	streamA.EXPECT().Open(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, nspStream *nspAPI.Stream) error {
 		wg.Done()
 		<-ctx.Done()
-		return ctx.Err()
+		return fmt.Errorf("streamA Open DoAndReturn: %w", ctx.Err())
 	}).AnyTimes()
 	// Check Close (Stream) has been called
 	streamA.EXPECT().Close(gomock.Any()).Return(nil)

--- a/pkg/ambassador/tap/stream/stream_test.go
+++ b/pkg/ambassador/tap/stream/stream_test.go
@@ -234,6 +234,15 @@ func Test_Open_Concurrent(t *testing.T) {
 		assert.Equal(t, identifier, identifierSelected)
 		return nil
 	}).After(secondRegister)
+	tr.EXPECT().Unregister(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, target *nspAPI.Target) error {
+		assert.NotNil(t, target)
+		assert.Equal(t, target.Ips, ips)
+		assert.Equal(t, target.Status, nspAPI.Target_DISABLED)
+		identifier, exists := target.Context[types.IdentifierKey]
+		assert.True(t, exists)
+		assert.Equal(t, identifier, concurrentIdentifier)
+		return nil
+	})
 
 	strm, err := stream.New(s, nil, cndt)
 	assert.Nil(t, err)

--- a/pkg/ambassador/tap/stream/targetregistry.go
+++ b/pkg/ambassador/tap/stream/targetregistry.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package stream
 
 import (
 	"context"
+	"fmt"
 
 	nspAPI "github.com/nordix/meridio/api/nsp/v1"
 )
@@ -34,23 +35,27 @@ func newTargetRegistryImpl(targetRegistryClient nspAPI.TargetRegistryClient) *ta
 }
 
 func (tri *targetRegistryImpl) Register(ctx context.Context, target *nspAPI.Target) error {
-	_, err := tri.TargetRegistryClient.Register(ctx, target)
-	return err
+	if _, err := tri.TargetRegistryClient.Register(ctx, target); err != nil {
+		return fmt.Errorf("target registry register error: %w", err)
+	}
+	return nil
 }
 
 func (tri *targetRegistryImpl) Unregister(ctx context.Context, target *nspAPI.Target) error {
-	_, err := tri.TargetRegistryClient.Unregister(ctx, target)
-	return err
+	if _, err := tri.TargetRegistryClient.Unregister(ctx, target); err != nil {
+		return fmt.Errorf("target registry unregister error: %w", err)
+	}
+	return nil
 }
 
 func (tri *targetRegistryImpl) GetTargets(ctx context.Context, target *nspAPI.Target) ([]*nspAPI.Target, error) {
 	watchClient, err := tri.TargetRegistryClient.Watch(ctx, target)
 	if err != nil {
-		return []*nspAPI.Target{}, err
+		return []*nspAPI.Target{}, fmt.Errorf("target registry failed to create watch client: %w", err)
 	}
 	responseTargets, err := watchClient.Recv()
 	if err != nil {
-		return []*nspAPI.Target{}, err
+		return []*nspAPI.Target{}, fmt.Errorf("target registry watch client receive error: %w", err)
 	}
 	return responseTargets.GetTargets(), nil
 }

--- a/pkg/ambassador/tap/trench/factory.go
+++ b/pkg/ambassador/tap/trench/factory.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ limitations under the License.
 package trench
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
@@ -74,7 +75,7 @@ func newConduitFactoryImpl(
 }
 
 func (cfi *conduitFactoryImpl) New(cndt *ambassadorAPI.Conduit) (types.Conduit, error) {
-	return conduit.New(cndt,
+	c, err := conduit.New(cndt,
 		cfi.TargetName,
 		cfi.Namespace,
 		cfi.NodeName,
@@ -85,4 +86,8 @@ func (cfi *conduitFactoryImpl) New(cndt *ambassadorAPI.Conduit) (types.Conduit, 
 		cfi.StreamRegistry,
 		cfi.NetUtils,
 		cfi.NSPEntryTimeout)
+	if err != nil {
+		err = fmt.Errorf("conduit factory failed to create conduit: %w", err)
+	}
+	return c, err
 }

--- a/pkg/ambassador/tap/trench/trench_test.go
+++ b/pkg/ambassador/tap/trench/trench_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ func Test_AddConduit_RemoveConduit(t *testing.T) {
 	conduitFactory := mocks.NewMockConduitFactory(ctrl)
 	conduitA := typesMocks.NewMockConduit(ctrl)
 	conduitFactory.EXPECT().New(gomock.Any()).Return(conduitA, nil)
-	conduitA.EXPECT().GetConduit().Return(c)
+	conduitA.EXPECT().GetConduit().Return(c).Times(2)
 	conduitA.EXPECT().Equals(gomock.Any()).Return(true)
 
 	conduitA.EXPECT().Connect(gomock.Any()).DoAndReturn(func(_ context.Context) error {

--- a/pkg/nsm/interfacename/client.go
+++ b/pkg/nsm/interfacename/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -43,7 +43,11 @@ func NewClient(prefix string, generator NameGenerator) networkservice.NetworkSer
 // It implements NetworkServiceClient for the interfacename package
 func (inc *interfaceNameClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
 	inc.SetInterfaceName(request)
-	return next.Client(ctx).Request(ctx, request, opts...)
+	conn, err := next.Client(ctx).Request(ctx, request, opts...)
+	if err != nil {
+		inc.UnsetInterfaceName(request)
+	}
+	return conn, err
 }
 
 // Close it does nothing except calling the next Close in the chain


### PR DESCRIPTION
## Description
Improved logs to help troubleshooting (wrapped errors during return to help identify the error source during debugging etc.).

other improvements:
TAPA;
- stream: Do not try to unregister target at target registry
  if stream has no identifier.
- stream: During open when identifier collision is observed,
  release offending identifier by unregistering at target registry.
- conduit: Compare VIPs received from configuration, and trigger
  NSM connection update upon change only.
- conduit: Log connection monitor events related to control plane
  change and connection close for visibility.
- conduit: Log when IPs of a NSM connection change. And initiate
  close and re-open of affected Streams through the stream manager.
- Custom interfacename client chain element releases interface name
  during failed Request() when NSM connection was not established earlier.

stateless-lb;
- Remove pending targets not part of the configuration (NSP) anymore.

## Issue link
NA

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
