### PR TITLE
LB logging and some improvements

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -41,6 +41,7 @@ import (
 	linuxKernel "github.com/nordix/meridio/pkg/kernel"
 	"github.com/nordix/meridio/pkg/nsm"
 	"github.com/nordix/meridio/pkg/nsm/interfacemonitor"
+	nsmmonitor "github.com/nordix/meridio/pkg/nsm/monitor"
 	"github.com/nordix/meridio/pkg/nsp"
 	"github.com/nordix/meridio/pkg/retry"
 
@@ -221,7 +222,7 @@ func main() {
 	}
 	defer cc.Close()
 	monitorClient := networkservice.NewMonitorConnectionClient(cc)
-	go proxy.NSMConnectionMonitor(ctx, config.Name, monitorClient)
+	go nsmmonitor.ConnectionMonitor(ctx, config.Name, monitorClient)
 
 	// create and start NSC that connects all remote NSE belonging to the right service
 	interfaceMonitorClient := interfacemonitor.NewClient(interfaceMonitor, p, netUtils)

--- a/pkg/kernel/neighbor/monitor.go
+++ b/pkg/kernel/neighbor/monitor.go
@@ -1,0 +1,133 @@
+/*
+Copyright (c) 2024 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package neighbor
+
+import (
+	"context"
+	"sync"
+
+	"github.com/vishvananda/netlink"
+)
+
+// NeighborMonitor -
+// Receive neighbor update messages from kernel and propagate them to
+// subscribers.
+type NeighborMonitor struct {
+	ch          chan netlink.NeighUpdate
+	done        chan struct{}
+	subscribers []NeighborMonitorSubscriber
+	stateMask   int
+	mu          sync.Mutex
+}
+
+// Subscribe -
+func (nm *NeighborMonitor) Subscribe(subscriber NeighborMonitorSubscriber) {
+	nm.mu.Lock()
+	defer nm.mu.Unlock()
+	nm.subscribers = append(nm.subscribers, subscriber)
+}
+
+// UnSubscribe -
+func (nm *NeighborMonitor) UnSubscribe(subscriber NeighborMonitorSubscriber) {
+	nm.mu.Lock()
+	defer nm.mu.Unlock()
+	for index, current := range nm.subscribers {
+		if subscriber == current {
+			nm.subscribers = append(nm.subscribers[:index], nm.subscribers[index+1:]...)
+		}
+	}
+}
+
+// update -
+// Passes neighbor events to subscribers.
+func (nm *NeighborMonitor) update(neigh netlink.NeighUpdate) {
+	nm.mu.Lock()
+	defer nm.mu.Unlock()
+	if nm.stateMask&neigh.State == 0 {
+		return
+	}
+	for _, subscriber := range nm.subscribers {
+		subscriber.NeighborUpdated(neigh)
+	}
+}
+
+// start -
+// Starts checking the event channel for updates.
+// And checks if context is still open.
+func (nm *NeighborMonitor) start(ctx context.Context) {
+	for {
+		select {
+		case update, ok := <-nm.ch:
+			if !ok {
+				nm.Close() // doesn't make much sense, since done channel must have been closed
+				return
+			}
+			nm.update(update)
+		case <-ctx.Done():
+			nm.Close()
+			nm.mu.Lock()
+			nm.subscribers = nm.subscribers[:0]
+			nm.mu.Unlock()
+			return
+		}
+	}
+}
+
+// Close -
+func (nm *NeighborMonitor) Close() {
+	close(nm.done)
+}
+
+// NewNeighborMonitor -
+// Creates a new neighbor monitor. Monitor is kept open until either Close()
+// is called or the context is closed.
+func NewNeighborMonitor(ctx context.Context, options ...Option) (*NeighborMonitor, error) {
+	opts := &neighOptions{
+		stateMask: 0xffffffff,
+	}
+	for _, opt := range options {
+		opt(opts)
+	}
+
+	neighborMonitor := &NeighborMonitor{
+		ch:        make(chan netlink.NeighUpdate),
+		done:      make(chan struct{}),
+		stateMask: opts.stateMask,
+	}
+
+	err := netlink.NeighSubscribe(neighborMonitor.ch, neighborMonitor.done)
+	if err != nil {
+		return nil, err
+	}
+	go neighborMonitor.start(ctx)
+
+	return neighborMonitor, nil
+}
+
+type Option func(o *neighOptions)
+
+type neighOptions struct {
+	stateMask int
+}
+
+// WithStateMask -
+// WithStateMask returns a new Option with the given state.
+func WithStateMask(stateMask int) Option {
+	return func(o *neighOptions) {
+		o.stateMask = stateMask
+	}
+}

--- a/pkg/kernel/neighbor/reachability.go
+++ b/pkg/kernel/neighbor/reachability.go
@@ -1,0 +1,185 @@
+/*
+Copyright (c) 2024 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package neighbor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/nordix/meridio/pkg/log"
+	"github.com/vishvananda/netlink"
+)
+
+var neighborStateToName = map[int]string{
+	netlink.NUD_NONE:       "NONE",
+	netlink.NUD_INCOMPLETE: "INCOMPLETE",
+	netlink.NUD_REACHABLE:  "REACHABLE",
+	netlink.NUD_STALE:      "STALE",
+	netlink.NUD_DELAY:      "DELAY",
+	netlink.NUD_PROBE:      "PROBE",
+	netlink.NUD_FAILED:     "FAILED",
+	netlink.NUD_NOARP:      "NOARP",
+	netlink.NUD_PERMANENT:  "PERMANENT",
+}
+
+// NeighborReachabilityDetector -
+// NeighborReachabilityDetector keeps track of certain neighbor entries for
+// registered IPs to determine if neighbor address resolution is successful.
+// If there is a change in reachability it triggers a logging event.
+// In order to receive neighbor updates NeighborReachabilityDetector relies on
+// NeighborMonitor.
+// Note: Only neighbor updates with states REACHABLE and FAILED are processed.
+type NeighborReachabilityDetector struct {
+	cache           map[string]*NeighborCacheEntry
+	name            string
+	neighborMonitor *NeighborMonitor
+	logger          logr.Logger
+	mu              sync.Mutex
+}
+
+type NeighborCacheEntry struct {
+	ip     net.IP    // for easy comparison with netlink.Neigh.IP
+	ts     time.Time // timestamp of the most recent change
+	tsLast time.Time // timestamp of the last "registered" occurence of the current update (for rate limiting)
+	neigh  *netlink.Neigh
+}
+
+// Register -
+// Registers IP addresses for which neighbor updates should be kept track of.
+// Accepts IPs of both 192.0.2.1/24 and 192.0.2.1 format (but strips mask).
+func (nrd *NeighborReachabilityDetector) Register(ips ...string) {
+	nrd.logger.V(1).Info("Register", "IPs", ips)
+	for _, ip := range ips {
+		ipParts := strings.Split(ip, "/")
+		ip := ipParts[0]
+		netIP := net.ParseIP(ip)
+		if netIP == nil {
+			continue
+		}
+		nrd.mu.Lock()
+		if _, ok := nrd.cache[ip]; !ok {
+			nrd.cache[ip] = &NeighborCacheEntry{ip: netIP}
+		}
+		nrd.mu.Unlock()
+	}
+}
+
+// Unregister -
+func (nrd *NeighborReachabilityDetector) Unregister(ips ...string) {
+	nrd.logger.V(1).Info("Unregister", "IPs", ips, "cacheLen", len(nrd.cache))
+	for _, ip := range ips {
+		ipParts := strings.Split(ip, "/")
+		ip := ipParts[0]
+		nrd.mu.Lock()
+		delete(nrd.cache, ip)
+		nrd.mu.Unlock()
+	}
+}
+
+// Close -
+// Close unsubscribes the detector from the neighbor monitor.
+func (nrd *NeighborReachabilityDetector) Close() {
+	if nrd.neighborMonitor != nil {
+		nrd.neighborMonitor.UnSubscribe(nrd)
+		nrd.logger.V(1).Info("Closed neighbor reachability detector")
+	}
+}
+
+// NeighborUpdated -
+// Process neighbor updates of interest referring to stored IPs.
+// Checks if neighbor reachability changes (incuding MAC address update), and
+// logs such events. Only FAILED <-> REACHABLE transitions are logged to keep
+// track of MAC address resolution outcome.
+//
+// Note: Must NOT spam logs with reachable printouts in case of intermittent
+// traffic causing recurring neighbor entry timeouts etc.
+func (nrd *NeighborReachabilityDetector) NeighborUpdated(neighborUpdate netlink.NeighUpdate) {
+	flags := netlink.NUD_FAILED | netlink.NUD_REACHABLE
+	if neighborUpdate.State&flags == 0 {
+		// update is neither FAILED nor REACHABLE
+		return
+	}
+
+	nrd.mu.Lock()
+	defer nrd.mu.Unlock()
+	for ip, cacheEntry := range nrd.cache {
+		if !cacheEntry.ip.Equal(neighborUpdate.IP) {
+			continue
+		}
+		neigh := &neighborUpdate.Neigh
+		// store neighbor update in case:
+		// - no Neigh entry in cache yet
+		// - FAILED <-> REACHABLE transition based on the last stored update
+		// - MAC address is updated
+		if cacheEntry.neigh == nil ||
+			(cacheEntry.neigh.State|neigh.State)&flags == flags ||
+			!bytes.Equal(cacheEntry.neigh.HardwareAddr, neigh.HardwareAddr) {
+			cacheEntry.neigh = neigh
+			cacheEntry.ts = time.Now()
+			cacheEntry.tsLast = cacheEntry.ts
+			logger := nrd.logger.WithValues(
+				"IP", ip,
+				"state", neighborStateToName[cacheEntry.neigh.State])
+			if len(neigh.HardwareAddr) > 0 {
+				logger = logger.WithValues("MAC", cacheEntry.neigh.HardwareAddr.String())
+			}
+			logger.V(1).Info("neighbor update", "neigh", neighborUpdate.Neigh)
+			break
+		}
+		// long lasting neighbor resolution failure, allow one additional log
+		//  printout per hour
+		if cacheEntry.neigh != nil &&
+			(cacheEntry.neigh.State&neigh.State)&netlink.NUD_FAILED != 0 &&
+			cacheEntry.tsLast.Add(time.Hour).Before(time.Now()) {
+			cacheEntry.tsLast = time.Now() // update timestamp
+			nrd.logger.V(1).Info("neighbor update",
+				"IP", ip,
+				"state", neighborStateToName[cacheEntry.neigh.State],
+				"since", cacheEntry.ts,
+				"neigh", neighborUpdate.Neigh)
+		}
+	}
+}
+
+// NewNeighborReachabilityDetector -
+// NewNeighborReachabilityDetector creates a new NeighborReachabilityDetector
+// and registers it at the neighbor monitor.
+func NewNeighborReachabilityDetector(ctx context.Context, name string, neighborMonitor *NeighborMonitor) (*NeighborReachabilityDetector, error) {
+	if neighborMonitor == nil {
+		return nil, fmt.Errorf("missing neighbor monitor")
+	}
+
+	neighborReachabilityDetector := &NeighborReachabilityDetector{
+		name:            name,
+		cache:           make(map[string]*NeighborCacheEntry),
+		neighborMonitor: neighborMonitor,
+		logger: log.FromContextOrGlobal(ctx).WithValues(
+			"name", name,
+			"class", "NeighborReachabilityDetector",
+		),
+	}
+	neighborMonitor.Subscribe(neighborReachabilityDetector)
+
+	neighborReachabilityDetector.logger.V(1).Info("Created neighbor reachability detector")
+	return neighborReachabilityDetector, nil
+}

--- a/pkg/kernel/neighbor/types.go
+++ b/pkg/kernel/neighbor/types.go
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2024 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package neighbor
+
+import "github.com/vishvananda/netlink"
+
+type NeighborMonitorSubscriber interface {
+	NeighborUpdated(netlink.NeighUpdate)
+}

--- a/pkg/loadbalancer/flow/metrics.go
+++ b/pkg/loadbalancer/flow/metrics.go
@@ -18,6 +18,7 @@ package flow
 
 import (
 	"context"
+	"fmt"
 
 	nspAPI "github.com/nordix/meridio/api/nsp/v1"
 	"github.com/nordix/meridio/pkg/loadbalancer/nfqlb"
@@ -58,7 +59,8 @@ func CollectMetrics(options ...option) error {
 		}),
 	)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create int64 observable counter (%s): %w",
+			meridioMetrics.MERIDIO_CONDUIT_STREAM_FLOW_MATCHES, err)
 	}
 
 	return nil
@@ -77,7 +79,7 @@ func nfqlbGetFlowStats() ([]FlowStat, error) {
 	for _, nfqlbFlowStat := range nfqlbFlowStats {
 		list = append(list, nfqlbFlowStat)
 	}
-	return list, err
+	return list, fmt.Errorf("failed to get nfqlb flow stats: %w", err)
 }
 
 type config struct {

--- a/pkg/loadbalancer/nfqlb/stats.go
+++ b/pkg/loadbalancer/nfqlb/stats.go
@@ -18,6 +18,7 @@ package nfqlb
 
 import (
 	"encoding/json"
+	"fmt"
 
 	nspAPI "github.com/nordix/meridio/api/nsp/v1"
 )
@@ -64,7 +65,7 @@ func GetFlowStats() ([]*FlowStats, error) {
 	nfqlbFss := []*nfqlbFlowStats{}
 	err = json.Unmarshal([]byte(jsonStatsStr), &nfqlbFss)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal flow stats (%v): %w", nfqlbFss, err)
 	}
 	for _, nfqlbFs := range nfqlbFss {
 		fs = append(fs, &FlowStats{

--- a/pkg/loadbalancer/stream/defrag.go
+++ b/pkg/loadbalancer/stream/defrag.go
@@ -17,6 +17,8 @@ limitations under the License.
 package stream
 
 import (
+	"fmt"
+
 	"github.com/google/nftables"
 	"github.com/google/nftables/binaryutil"
 	"github.com/google/nftables/expr"
@@ -95,7 +97,11 @@ func (d *Defrag) configure() error {
 		Hooknum:  nftables.ChainHookOutput,
 		Priority: nftables.ChainPriorityRaw,
 	})
-	return conn.Flush()
+	err := conn.Flush()
+	if err != nil {
+		return fmt.Errorf("failed to configure defrag table and chains: %w", err)
+	}
+	return nil
 }
 
 func (d *Defrag) setupRules() error {
@@ -181,7 +187,11 @@ func (d *Defrag) setupRules() error {
 		})
 	}
 
-	return conn.Flush()
+	err := conn.Flush()
+	if err != nil {
+		return fmt.Errorf("failed to setup defrag rules: %w", err)
+	}
+	return nil
 }
 
 func (d *Defrag) Delete() error {
@@ -192,5 +202,9 @@ func (d *Defrag) Delete() error {
 		conn.DelChain(chain)
 	}
 
-	return conn.Flush()
+	err := conn.Flush()
+	if err != nil {
+		return fmt.Errorf("failed to flush and delete defrag chains: %w", err)
+	}
+	return nil
 }

--- a/pkg/loadbalancer/stream/target.go
+++ b/pkg/loadbalancer/stream/target.go
@@ -87,7 +87,7 @@ func (t *target) Configure() error {
 		var fwMark networking.FWMarkRoute
 		fwMark, err := t.netUtils.NewFWMarkRoute(ip, offsetId, offsetId)
 		if err != nil {
-			return fmt.Errorf("faled to configure fwmark route for ip (%s): %w", ip, err)
+			return fmt.Errorf("failed to configure fwmark route for ip (%s): %w", ip, err)
 		}
 		t.fwMarks = append(t.fwMarks, fwMark)
 	}

--- a/pkg/loadbalancer/types/nfqlb.go
+++ b/pkg/loadbalancer/types/nfqlb.go
@@ -29,6 +29,7 @@ type NFQueueLoadBalancer interface {
 	Delete() error
 	SetFlow(flow *nspAPI.Flow) error
 	DeleteFlow(flow *nspAPI.Flow) error
+	GetName() string
 }
 
 type NFQueueLoadBalancerFactory interface {

--- a/pkg/utils/error.go
+++ b/pkg/utils/error.go
@@ -1,0 +1,25 @@
+/*
+Copyright (c) 2023 Nordix Foundation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import "fmt"
+
+// AppendErr -
+// Appends err to errFinal
+func AppendErr(errFinal, err error) error {
+	if errFinal == nil {
+		return err
+	}
+	return fmt.Errorf("%w; %w", errFinal, err)
+}


### PR DESCRIPTION
## Description
Improved logs to help troubleshooting.

other:
    - Monitor NSM connections the LB is involved in for DELETE
      and DOWN events for logging (functionality shared by lb and proxy)
    - Stream lb instance unsubscribes at interface monitor on delete
    - LB subscribes to native interface monitor to learn about
      interface removal to sync its interface list
    - Monitor Target reachability based on kernel neighbor events,
      and log changes

## Issue link
NA

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
