### PR TITLE
Fix deadlock on UnsetIPContext

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -388,6 +388,7 @@ func (p *Proxy) ipReleaser(id string) {
 	p.connectionToReleaseMutex.Lock()
 	_, exists := p.connectionToReleaseMap[id]
 	if exists { // If an ipReleaser is already running for this connection Id
+		p.connectionToReleaseMutex.Unlock()
 		return
 	}
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Description

ipReleaser was not calling unlock on a return causing a deadlock in some cases.

## Issue link

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
