### PR TITLE
metrics; fix collecting flow stats

### DIFF
--- a/pkg/loadbalancer/flow/metrics.go
+++ b/pkg/loadbalancer/flow/metrics.go
@@ -76,10 +76,13 @@ type FlowStat interface {
 func nfqlbGetFlowStats() ([]FlowStat, error) {
 	list := []FlowStat{}
 	nfqlbFlowStats, err := nfqlb.GetFlowStats()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get nfqlb flow stats: %w", err)
+	}
 	for _, nfqlbFlowStat := range nfqlbFlowStats {
 		list = append(list, nfqlbFlowStat)
 	}
-	return list, fmt.Errorf("failed to get nfqlb flow stats: %w", err)
+	return list, nil
 }
 
 type config struct {


### PR DESCRIPTION
## Description
Error wrapping improvements in LB broke the flow metrics collecting feature by returning an error all the time.

## Issue link
N/A
## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
