### PR TITLE
e2e; allow non-default route advertisement in kind environment

### DIFF
--- a/docs/demo/scripts/kind/Dockerfile
+++ b/docs/demo/scripts/kind/Dockerfile
@@ -23,5 +23,6 @@ ARG BIRD_CONFIG_PATH=docs/demo/scripts/kind/bird
 COPY $BIRD_CONFIG_PATH/bird-common.conf /etc/bird/
 COPY $BIRD_CONFIG_PATH/bird-gw.conf /etc/bird/
 COPY $BIRD_CONFIG_PATH/bird-gw-no-default.conf /etc/bird/
+COPY $BIRD_CONFIG_PATH/bird-filler-net.conf /etc/bird/
 
 CMD sleep 5 ; /usr/sbin/bird -d -c /etc/bird/bird-gw.conf

--- a/docs/demo/scripts/kind/Makefile
+++ b/docs/demo/scripts/kind/Makefile
@@ -37,6 +37,7 @@ BUILD_STEPS ?= build tag push
 REGISTRY ?= registry.nordix.org/cloud-native/meridio
 VERSION ?= latest
 KIND_EXTERNAL_HOST_VERSION ?= $(VERSION)
+KIND_EXTERNAL_HOST_DEFAULT_ROUTE ?= yes
 
 OBSERVABILITY_ENABLED ?= false
 
@@ -123,7 +124,7 @@ kind-create: temp-dir kind kind-delete ## Create the Kind cluster
 
 .PHONY: kind-gateways
 kind-gateways: ## Create the Kind cluster gateways
-	./external-host.sh
+	./external-host.sh --default-route=$(KIND_EXTERNAL_HOST_DEFAULT_ROUTE)
 
 .PHONY: kind-gateways
 kind-delete-gateways: ## Delete the Kind gateways

--- a/docs/demo/scripts/kind/bird/bird-filler-net.conf
+++ b/docs/demo/scripts/kind/bird/bird-filler-net.conf
@@ -1,0 +1,802 @@
+# Some "filler" IPv4 networks that can be used to get announced by BGP.
+
+protocol static FILLER_NET4_6 {
+	ipv4 { preference 100; };
+	route 168.167.124.27/32 blackhole;
+}
+protocol static FILLER_NET4_7 {
+	ipv4 { preference 100; };
+	route 84.66.227.18/32 blackhole;
+}
+protocol static FILLER_NET4_8 {
+	ipv4 { preference 100; };
+	route 75.167.187.207/32 blackhole;
+}
+protocol static FILLER_NET4_9 {
+	ipv4 { preference 100; };
+	route 52.27.165.253/32 blackhole;
+}
+protocol static FILLER_NET4_10 {
+	ipv4 { preference 100; };
+	route 147.159.233.174/32 blackhole;
+}
+protocol static FILLER_NET4_11 {
+	ipv4 { preference 100; };
+	route 46.164.150.62/32 blackhole;
+}
+protocol static FILLER_NET4_12 {
+	ipv4 { preference 100; };
+	route 102.36.20.132/32 blackhole;
+}
+protocol static FILLER_NET4_13 {
+	ipv4 { preference 100; };
+	route 16.87.110.216/32 blackhole;
+}
+protocol static FILLER_NET4_14 {
+	ipv4 { preference 100; };
+	route 119.247.155.153/32 blackhole;
+}
+protocol static FILLER_NET4_15 {
+	ipv4 { preference 100; };
+	route 140.24.79.90/32 blackhole;
+}
+protocol static FILLER_NET4_16 {
+	ipv4 { preference 100; };
+	route 114.184.147.99/32 blackhole;
+}
+protocol static FILLER_NET4_17 {
+	ipv4 { preference 100; };
+	route 132.241.57.15/32 blackhole;
+}
+protocol static FILLER_NET4_18 {
+	ipv4 { preference 100; };
+	route 62.162.195.234/32 blackhole;
+}
+protocol static FILLER_NET4_19 {
+	ipv4 { preference 100; };
+	route 125.1.162.185/32 blackhole;
+}
+protocol static FILLER_NET4_20 {
+	ipv4 { preference 100; };
+	route 133.34.167.147/32 blackhole;
+}
+protocol static FILLER_NET4_21 {
+	ipv4 { preference 100; };
+	route 74.5.230.57/32 blackhole;
+}
+protocol static FILLER_NET4_22 {
+	ipv4 { preference 100; };
+	route 119.232.144.33/32 blackhole;
+}
+protocol static FILLER_NET4_23 {
+	ipv4 { preference 100; };
+	route 150.54.152.239/32 blackhole;
+}
+protocol static FILLER_NET4_24 {
+	ipv4 { preference 100; };
+	route 2.139.140.216/32 blackhole;
+}
+protocol static FILLER_NET4_25 {
+	ipv4 { preference 100; };
+	route 130.21.38.174/32 blackhole;
+}
+protocol static FILLER_NET4_26 {
+	ipv4 { preference 100; };
+	route 58.247.145.0/32 blackhole;
+}
+protocol static FILLER_NET4_27 {
+	ipv4 { preference 100; };
+	route 64.120.128.33/32 blackhole;
+}
+protocol static FILLER_NET4_28 {
+	ipv4 { preference 100; };
+	route 50.28.177.100/32 blackhole;
+}
+protocol static FILLER_NET4_29 {
+	ipv4 { preference 100; };
+	route 212.231.16.32/32 blackhole;
+}
+protocol static FILLER_NET4_30 {
+	ipv4 { preference 100; };
+	route 68.166.108.69/32 blackhole;
+}
+protocol static FILLER_NET4_31 {
+	ipv4 { preference 100; };
+	route 77.193.141.170/32 blackhole;
+}
+protocol static FILLER_NET4_32 {
+	ipv4 { preference 100; };
+	route 223.143.27.102/32 blackhole;
+}
+protocol static FILLER_NET4_33 {
+	ipv4 { preference 100; };
+	route 119.93.96.217/32 blackhole;
+}
+protocol static FILLER_NET4_34 {
+	ipv4 { preference 100; };
+	route 72.89.83.210/32 blackhole;
+}
+protocol static FILLER_NET4_35 {
+	ipv4 { preference 100; };
+	route 166.206.56.87/32 blackhole;
+}
+protocol static FILLER_NET4_36 {
+	ipv4 { preference 100; };
+	route 36.157.140.69/32 blackhole;
+}
+protocol static FILLER_NET4_37 {
+	ipv4 { preference 100; };
+	route 59.102.188.7/32 blackhole;
+}
+protocol static FILLER_NET4_38 {
+	ipv4 { preference 100; };
+	route 159.172.100.187/32 blackhole;
+}
+protocol static FILLER_NET4_39 {
+	ipv4 { preference 100; };
+	route 17.134.92.88/32 blackhole;
+}
+protocol static FILLER_NET4_40 {
+	ipv4 { preference 100; };
+	route 130.205.209.200/32 blackhole;
+}
+protocol static FILLER_NET4_41 {
+	ipv4 { preference 100; };
+	route 199.180.250.185/32 blackhole;
+}
+protocol static FILLER_NET4_42 {
+	ipv4 { preference 100; };
+	route 200.156.184.207/32 blackhole;
+}
+protocol static FILLER_NET4_43 {
+	ipv4 { preference 100; };
+	route 191.132.145.255/32 blackhole;
+}
+protocol static FILLER_NET4_44 {
+	ipv4 { preference 100; };
+	route 144.7.158.224/32 blackhole;
+}
+protocol static FILLER_NET4_45 {
+	ipv4 { preference 100; };
+	route 160.64.76.175/32 blackhole;
+}
+protocol static FILLER_NET4_46 {
+	ipv4 { preference 100; };
+	route 199.168.208.226/32 blackhole;
+}
+protocol static FILLER_NET4_47 {
+	ipv4 { preference 100; };
+	route 101.170.189.22/32 blackhole;
+}
+protocol static FILLER_NET4_48 {
+	ipv4 { preference 100; };
+	route 35.86.125.116/32 blackhole;
+}
+protocol static FILLER_NET4_49 {
+	ipv4 { preference 100; };
+	route 205.191.55.91/32 blackhole;
+}
+protocol static FILLER_NET4_50 {
+	ipv4 { preference 100; };
+	route 136.12.70.63/32 blackhole;
+}
+protocol static FILLER_NET4_51 {
+	ipv4 { preference 100; };
+	route 115.179.88.191/32 blackhole;
+}
+protocol static FILLER_NET4_52 {
+	ipv4 { preference 100; };
+	route 151.246.213.176/32 blackhole;
+}
+protocol static FILLER_NET4_53 {
+	ipv4 { preference 100; };
+	route 58.236.61.227/32 blackhole;
+}
+protocol static FILLER_NET4_54 {
+	ipv4 { preference 100; };
+	route 3.198.114.92/32 blackhole;
+}
+protocol static FILLER_NET4_55 {
+	ipv4 { preference 100; };
+	route 216.238.244.141/32 blackhole;
+}
+protocol static FILLER_NET4_56 {
+	ipv4 { preference 100; };
+	route 64.5.24.96/32 blackhole;
+}
+protocol static FILLER_NET4_57 {
+	ipv4 { preference 100; };
+	route 46.82.196.100/32 blackhole;
+}
+protocol static FILLER_NET4_58 {
+	ipv4 { preference 100; };
+	route 216.4.194.32/32 blackhole;
+}
+protocol static FILLER_NET4_59 {
+	ipv4 { preference 100; };
+	route 101.25.184.214/32 blackhole;
+}
+protocol static FILLER_NET4_60 {
+	ipv4 { preference 100; };
+	route 61.15.119.255/32 blackhole;
+}
+protocol static FILLER_NET4_61 {
+	ipv4 { preference 100; };
+	route 190.56.172.231/32 blackhole;
+}
+protocol static FILLER_NET4_62 {
+	ipv4 { preference 100; };
+	route 198.142.230.130/32 blackhole;
+}
+protocol static FILLER_NET4_63 {
+	ipv4 { preference 100; };
+	route 22.104.116.63/32 blackhole;
+}
+protocol static FILLER_NET4_64 {
+	ipv4 { preference 100; };
+	route 166.196.126.54/32 blackhole;
+}
+protocol static FILLER_NET4_65 {
+	ipv4 { preference 100; };
+	route 217.77.62.139/32 blackhole;
+}
+protocol static FILLER_NET4_66 {
+	ipv4 { preference 100; };
+	route 138.0.13.230/32 blackhole;
+}
+protocol static FILLER_NET4_67 {
+	ipv4 { preference 100; };
+	route 23.127.189.246/32 blackhole;
+}
+protocol static FILLER_NET4_68 {
+	ipv4 { preference 100; };
+	route 114.106.68.220/32 blackhole;
+}
+protocol static FILLER_NET4_69 {
+	ipv4 { preference 100; };
+	route 143.201.254.218/32 blackhole;
+}
+protocol static FILLER_NET4_70 {
+	ipv4 { preference 100; };
+	route 189.99.130.166/32 blackhole;
+}
+protocol static FILLER_NET4_71 {
+	ipv4 { preference 100; };
+	route 180.66.22.66/32 blackhole;
+}
+protocol static FILLER_NET4_72 {
+	ipv4 { preference 100; };
+	route 168.160.178.67/32 blackhole;
+}
+protocol static FILLER_NET4_73 {
+	ipv4 { preference 100; };
+	route 103.195.46.202/32 blackhole;
+}
+protocol static FILLER_NET4_74 {
+	ipv4 { preference 100; };
+	route 5.252.87.16/32 blackhole;
+}
+protocol static FILLER_NET4_75 {
+	ipv4 { preference 100; };
+	route 128.129.69.194/32 blackhole;
+}
+protocol static FILLER_NET4_76 {
+	ipv4 { preference 100; };
+	route 72.42.215.195/32 blackhole;
+}
+protocol static FILLER_NET4_77 {
+	ipv4 { preference 100; };
+	route 175.50.3.83/32 blackhole;
+}
+protocol static FILLER_NET4_78 {
+	ipv4 { preference 100; };
+	route 138.180.149.104/32 blackhole;
+}
+protocol static FILLER_NET4_79 {
+	ipv4 { preference 100; };
+	route 156.155.242.129/32 blackhole;
+}
+protocol static FILLER_NET4_80 {
+	ipv4 { preference 100; };
+	route 63.107.204.248/32 blackhole;
+}
+protocol static FILLER_NET4_81 {
+	ipv4 { preference 100; };
+	route 71.167.122.241/32 blackhole;
+}
+protocol static FILLER_NET4_82 {
+	ipv4 { preference 100; };
+	route 112.7.148.86/32 blackhole;
+}
+protocol static FILLER_NET4_83 {
+	ipv4 { preference 100; };
+	route 70.119.96.55/32 blackhole;
+}
+protocol static FILLER_NET4_84 {
+	ipv4 { preference 100; };
+	route 50.159.120.249/32 blackhole;
+}
+protocol static FILLER_NET4_85 {
+	ipv4 { preference 100; };
+	route 18.224.79.15/32 blackhole;
+}
+protocol static FILLER_NET4_86 {
+	ipv4 { preference 100; };
+	route 102.185.190.216/32 blackhole;
+}
+protocol static FILLER_NET4_87 {
+	ipv4 { preference 100; };
+	route 161.61.131.236/32 blackhole;
+}
+protocol static FILLER_NET4_88 {
+	ipv4 { preference 100; };
+	route 76.42.240.161/32 blackhole;
+}
+protocol static FILLER_NET4_89 {
+	ipv4 { preference 100; };
+	route 72.222.157.81/32 blackhole;
+}
+protocol static FILLER_NET4_90 {
+	ipv4 { preference 100; };
+	route 92.137.5.75/32 blackhole;
+}
+protocol static FILLER_NET4_91 {
+	ipv4 { preference 100; };
+	route 203.40.26.56/32 blackhole;
+}
+protocol static FILLER_NET4_92 {
+	ipv4 { preference 100; };
+	route 63.196.14.184/32 blackhole;
+}
+protocol static FILLER_NET4_93 {
+	ipv4 { preference 100; };
+	route 199.117.84.136/32 blackhole;
+}
+protocol static FILLER_NET4_94 {
+	ipv4 { preference 100; };
+	route 2.143.164.151/32 blackhole;
+}
+protocol static FILLER_NET4_95 {
+	ipv4 { preference 100; };
+	route 116.128.246.208/32 blackhole;
+}
+protocol static FILLER_NET4_96 {
+	ipv4 { preference 100; };
+	route 13.177.126.109/32 blackhole;
+}
+protocol static FILLER_NET4_97 {
+	ipv4 { preference 100; };
+	route 152.102.69.89/32 blackhole;
+}
+protocol static FILLER_NET4_98 {
+	ipv4 { preference 100; };
+	route 122.224.178.114/32 blackhole;
+}
+protocol static FILLER_NET4_99 {
+	ipv4 { preference 100; };
+	route 190.141.135.63/32 blackhole;
+}
+protocol static FILLER_NET4_100 {
+	ipv4 { preference 100; };
+	route 9.201.167.64/32 blackhole;
+}
+protocol static FILLER_NET4_101 {
+	ipv4 { preference 100; };
+	route 187.196.4.184/32 blackhole;
+}
+protocol static FILLER_NET4_102 {
+	ipv4 { preference 100; };
+	route 101.231.60.72/32 blackhole;
+}
+protocol static FILLER_NET4_103 {
+	ipv4 { preference 100; };
+	route 145.132.90.176/32 blackhole;
+}
+protocol static FILLER_NET4_104 {
+	ipv4 { preference 100; };
+	route 14.14.152.130/32 blackhole;
+}
+protocol static FILLER_NET4_105 {
+	ipv4 { preference 100; };
+	route 171.228.168.72/32 blackhole;
+}
+protocol static FILLER_NET4_100006 {
+	ipv4 { preference 100; };
+	route 128.0.2.0/24 blackhole;
+}
+protocol static FILLER_NET4_100007 {
+	ipv4 { preference 100; };
+	route 128.0.3.0/24 blackhole;
+}
+protocol static FILLER_NET4_100008 {
+	ipv4 { preference 100; };
+	route 128.0.4.0/24 blackhole;
+}
+protocol static FILLER_NET4_100009 {
+	ipv4 { preference 100; };
+	route 128.0.5.0/24 blackhole;
+}
+protocol static FILLER_NET4_100010 {
+	ipv4 { preference 100; };
+	route 128.0.6.0/24 blackhole;
+}
+protocol static FILLER_NET4_100011 {
+	ipv4 { preference 100; };
+	route 128.0.7.0/24 blackhole;
+}
+protocol static FILLER_NET4_100012 {
+	ipv4 { preference 100; };
+	route 128.0.8.0/24 blackhole;
+}
+protocol static FILLER_NET4_100013 {
+	ipv4 { preference 100; };
+	route 128.0.9.0/24 blackhole;
+}
+protocol static FILLER_NET4_100014 {
+	ipv4 { preference 100; };
+	route 128.0.10.0/24 blackhole;
+}
+protocol static FILLER_NET4_100015 {
+	ipv4 { preference 100; };
+	route 128.0.11.0/24 blackhole;
+}
+protocol static FILLER_NET4_100016 {
+	ipv4 { preference 100; };
+	route 128.0.12.0/24 blackhole;
+}
+protocol static FILLER_NET4_100017 {
+	ipv4 { preference 100; };
+	route 128.0.13.0/24 blackhole;
+}
+protocol static FILLER_NET4_100018 {
+	ipv4 { preference 100; };
+	route 128.0.14.0/24 blackhole;
+}
+protocol static FILLER_NET4_100019 {
+	ipv4 { preference 100; };
+	route 128.0.15.0/24 blackhole;
+}
+protocol static FILLER_NET4_100020 {
+	ipv4 { preference 100; };
+	route 128.0.16.0/24 blackhole;
+}
+protocol static FILLER_NET4_100021 {
+	ipv4 { preference 100; };
+	route 128.0.17.0/24 blackhole;
+}
+protocol static FILLER_NET4_100022 {
+	ipv4 { preference 100; };
+	route 128.0.18.0/24 blackhole;
+}
+protocol static FILLER_NET4_100023 {
+	ipv4 { preference 100; };
+	route 128.0.19.0/24 blackhole;
+}
+protocol static FILLER_NET4_100024 {
+	ipv4 { preference 100; };
+	route 128.0.20.0/24 blackhole;
+}
+protocol static FILLER_NET4_100025 {
+	ipv4 { preference 100; };
+	route 128.0.21.0/24 blackhole;
+}
+protocol static FILLER_NET4_100026 {
+	ipv4 { preference 100; };
+	route 128.0.22.0/24 blackhole;
+}
+protocol static FILLER_NET4_100027 {
+	ipv4 { preference 100; };
+	route 128.0.23.0/24 blackhole;
+}
+protocol static FILLER_NET4_100028 {
+	ipv4 { preference 100; };
+	route 128.0.24.0/24 blackhole;
+}
+protocol static FILLER_NET4_100029 {
+	ipv4 { preference 100; };
+	route 128.0.25.0/24 blackhole;
+}
+protocol static FILLER_NET4_100030 {
+	ipv4 { preference 100; };
+	route 128.0.26.0/24 blackhole;
+}
+protocol static FILLER_NET4_100031 {
+	ipv4 { preference 100; };
+	route 128.0.27.0/24 blackhole;
+}
+protocol static FILLER_NET4_100032 {
+	ipv4 { preference 100; };
+	route 128.0.28.0/24 blackhole;
+}
+protocol static FILLER_NET4_100033 {
+	ipv4 { preference 100; };
+	route 128.0.29.0/24 blackhole;
+}
+protocol static FILLER_NET4_100034 {
+	ipv4 { preference 100; };
+	route 128.0.30.0/24 blackhole;
+}
+protocol static FILLER_NET4_100035 {
+	ipv4 { preference 100; };
+	route 128.0.31.0/24 blackhole;
+}
+protocol static FILLER_NET4_100036 {
+	ipv4 { preference 100; };
+	route 128.0.32.0/24 blackhole;
+}
+protocol static FILLER_NET4_100037 {
+	ipv4 { preference 100; };
+	route 128.0.33.0/24 blackhole;
+}
+protocol static FILLER_NET4_100038 {
+	ipv4 { preference 100; };
+	route 128.0.34.0/24 blackhole;
+}
+protocol static FILLER_NET4_100039 {
+	ipv4 { preference 100; };
+	route 128.0.35.0/24 blackhole;
+}
+protocol static FILLER_NET4_100040 {
+	ipv4 { preference 100; };
+	route 128.0.36.0/24 blackhole;
+}
+protocol static FILLER_NET4_100041 {
+	ipv4 { preference 100; };
+	route 128.0.37.0/24 blackhole;
+}
+protocol static FILLER_NET4_100042 {
+	ipv4 { preference 100; };
+	route 128.0.38.0/24 blackhole;
+}
+protocol static FILLER_NET4_100043 {
+	ipv4 { preference 100; };
+	route 128.0.39.0/24 blackhole;
+}
+protocol static FILLER_NET4_100044 {
+	ipv4 { preference 100; };
+	route 128.0.40.0/24 blackhole;
+}
+protocol static FILLER_NET4_100045 {
+	ipv4 { preference 100; };
+	route 128.0.41.0/24 blackhole;
+}
+protocol static FILLER_NET4_100046 {
+	ipv4 { preference 100; };
+	route 128.0.42.0/24 blackhole;
+}
+protocol static FILLER_NET4_100047 {
+	ipv4 { preference 100; };
+	route 128.0.43.0/24 blackhole;
+}
+protocol static FILLER_NET4_100048 {
+	ipv4 { preference 100; };
+	route 128.0.44.0/24 blackhole;
+}
+protocol static FILLER_NET4_100049 {
+	ipv4 { preference 100; };
+	route 128.0.45.0/24 blackhole;
+}
+protocol static FILLER_NET4_100050 {
+	ipv4 { preference 100; };
+	route 128.0.46.0/24 blackhole;
+}
+protocol static FILLER_NET4_100051 {
+	ipv4 { preference 100; };
+	route 128.0.47.0/24 blackhole;
+}
+protocol static FILLER_NET4_100052 {
+	ipv4 { preference 100; };
+	route 128.0.48.0/24 blackhole;
+}
+protocol static FILLER_NET4_100053 {
+	ipv4 { preference 100; };
+	route 128.0.49.0/24 blackhole;
+}
+protocol static FILLER_NET4_100054 {
+	ipv4 { preference 100; };
+	route 128.0.50.0/24 blackhole;
+}
+protocol static FILLER_NET4_100055 {
+	ipv4 { preference 100; };
+	route 128.0.51.0/24 blackhole;
+}
+protocol static FILLER_NET4_100056 {
+	ipv4 { preference 100; };
+	route 128.0.52.0/24 blackhole;
+}
+protocol static FILLER_NET4_100057 {
+	ipv4 { preference 100; };
+	route 128.0.53.0/24 blackhole;
+}
+protocol static FILLER_NET4_100058 {
+	ipv4 { preference 100; };
+	route 128.0.54.0/24 blackhole;
+}
+protocol static FILLER_NET4_100059 {
+	ipv4 { preference 100; };
+	route 128.0.55.0/24 blackhole;
+}
+protocol static FILLER_NET4_100060 {
+	ipv4 { preference 100; };
+	route 128.0.56.0/24 blackhole;
+}
+protocol static FILLER_NET4_100061 {
+	ipv4 { preference 100; };
+	route 128.0.57.0/24 blackhole;
+}
+protocol static FILLER_NET4_100062 {
+	ipv4 { preference 100; };
+	route 128.0.58.0/24 blackhole;
+}
+protocol static FILLER_NET4_100063 {
+	ipv4 { preference 100; };
+	route 128.0.59.0/24 blackhole;
+}
+protocol static FILLER_NET4_100064 {
+	ipv4 { preference 100; };
+	route 128.0.60.0/24 blackhole;
+}
+protocol static FILLER_NET4_100065 {
+	ipv4 { preference 100; };
+	route 128.0.61.0/24 blackhole;
+}
+protocol static FILLER_NET4_100066 {
+	ipv4 { preference 100; };
+	route 128.0.62.0/24 blackhole;
+}
+protocol static FILLER_NET4_100067 {
+	ipv4 { preference 100; };
+	route 128.0.63.0/24 blackhole;
+}
+protocol static FILLER_NET4_100068 {
+	ipv4 { preference 100; };
+	route 128.0.64.0/24 blackhole;
+}
+protocol static FILLER_NET4_100069 {
+	ipv4 { preference 100; };
+	route 128.0.65.0/24 blackhole;
+}
+protocol static FILLER_NET4_100070 {
+	ipv4 { preference 100; };
+	route 128.0.66.0/24 blackhole;
+}
+protocol static FILLER_NET4_100071 {
+	ipv4 { preference 100; };
+	route 128.0.67.0/24 blackhole;
+}
+protocol static FILLER_NET4_100072 {
+	ipv4 { preference 100; };
+	route 128.0.68.0/24 blackhole;
+}
+protocol static FILLER_NET4_100073 {
+	ipv4 { preference 100; };
+	route 128.0.69.0/24 blackhole;
+}
+protocol static FILLER_NET4_100074 {
+	ipv4 { preference 100; };
+	route 128.0.70.0/24 blackhole;
+}
+protocol static FILLER_NET4_100075 {
+	ipv4 { preference 100; };
+	route 128.0.71.0/24 blackhole;
+}
+protocol static FILLER_NET4_100076 {
+	ipv4 { preference 100; };
+	route 128.0.72.0/24 blackhole;
+}
+protocol static FILLER_NET4_100077 {
+	ipv4 { preference 100; };
+	route 128.0.73.0/24 blackhole;
+}
+protocol static FILLER_NET4_100078 {
+	ipv4 { preference 100; };
+	route 128.0.74.0/24 blackhole;
+}
+protocol static FILLER_NET4_100079 {
+	ipv4 { preference 100; };
+	route 128.0.75.0/24 blackhole;
+}
+protocol static FILLER_NET4_100080 {
+	ipv4 { preference 100; };
+	route 128.0.76.0/24 blackhole;
+}
+protocol static FILLER_NET4_100081 {
+	ipv4 { preference 100; };
+	route 128.0.77.0/24 blackhole;
+}
+protocol static FILLER_NET4_100082 {
+	ipv4 { preference 100; };
+	route 128.0.78.0/24 blackhole;
+}
+protocol static FILLER_NET4_100083 {
+	ipv4 { preference 100; };
+	route 128.0.79.0/24 blackhole;
+}
+protocol static FILLER_NET4_100084 {
+	ipv4 { preference 100; };
+	route 128.0.80.0/24 blackhole;
+}
+protocol static FILLER_NET4_100085 {
+	ipv4 { preference 100; };
+	route 128.0.81.0/24 blackhole;
+}
+protocol static FILLER_NET4_100086 {
+	ipv4 { preference 100; };
+	route 128.0.82.0/24 blackhole;
+}
+protocol static FILLER_NET4_100087 {
+	ipv4 { preference 100; };
+	route 128.0.83.0/24 blackhole;
+}
+protocol static FILLER_NET4_100088 {
+	ipv4 { preference 100; };
+	route 128.0.84.0/24 blackhole;
+}
+protocol static FILLER_NET4_100089 {
+	ipv4 { preference 100; };
+	route 128.0.85.0/24 blackhole;
+}
+protocol static FILLER_NET4_100090 {
+	ipv4 { preference 100; };
+	route 128.0.86.0/24 blackhole;
+}
+protocol static FILLER_NET4_100091 {
+	ipv4 { preference 100; };
+	route 128.0.87.0/24 blackhole;
+}
+protocol static FILLER_NET4_100092 {
+	ipv4 { preference 100; };
+	route 128.0.88.0/24 blackhole;
+}
+protocol static FILLER_NET4_100093 {
+	ipv4 { preference 100; };
+	route 128.0.89.0/24 blackhole;
+}
+protocol static FILLER_NET4_100094 {
+	ipv4 { preference 100; };
+	route 128.0.90.0/24 blackhole;
+}
+protocol static FILLER_NET4_100095 {
+	ipv4 { preference 100; };
+	route 128.0.91.0/24 blackhole;
+}
+protocol static FILLER_NET4_100096 {
+	ipv4 { preference 100; };
+	route 128.0.92.0/24 blackhole;
+}
+protocol static FILLER_NET4_100097 {
+	ipv4 { preference 100; };
+	route 128.0.93.0/24 blackhole;
+}
+protocol static FILLER_NET4_100098 {
+	ipv4 { preference 100; };
+	route 128.0.94.0/24 blackhole;
+}
+protocol static FILLER_NET4_100099 {
+	ipv4 { preference 100; };
+	route 128.0.95.0/24 blackhole;
+}
+protocol static FILLER_NET4_100100 {
+	ipv4 { preference 100; };
+	route 128.0.96.0/24 blackhole;
+}
+protocol static FILLER_NET4_100101 {
+	ipv4 { preference 100; };
+	route 128.0.97.0/24 blackhole;
+}
+protocol static FILLER_NET4_100102 {
+	ipv4 { preference 100; };
+	route 128.0.98.0/24 blackhole;
+}
+protocol static FILLER_NET4_100103 {
+	ipv4 { preference 100; };
+	route 128.0.99.0/24 blackhole;
+}
+protocol static FILLER_NET4_100104 {
+	ipv4 { preference 100; };
+	route 128.0.100.0/24 blackhole;
+}
+protocol static FILLER_NET4_100105 {
+	ipv4 { preference 100; };
+	route 128.0.101.0/24 blackhole;
+}

--- a/docs/demo/scripts/kind/bird/bird-gw-no-default.conf
+++ b/docs/demo/scripts/kind/bird/bird-gw-no-default.conf
@@ -1,4 +1,5 @@
 include "bird-common.conf";
+include "bird-filler-net.conf";
 
 
 # Register below routes into BIRD through static blackhole routes.

--- a/test/e2e/environment/kind-operator/dualstack/configuration/conduit-destination-port-nats.yaml
+++ b/test/e2e/environment/kind-operator/dualstack/configuration/conduit-destination-port-nats.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Flow
 metadata:
   name: flow-a-z-tcp
@@ -22,7 +22,7 @@ spec:
   protocols:
   - tcp
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Conduit
 metadata:
   name: conduit-a-1

--- a/test/e2e/environment/kind-operator/dualstack/configuration/flow-byte-matches.yaml
+++ b/test/e2e/environment/kind-operator/dualstack/configuration/flow-byte-matches.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Flow
 metadata:
   name: flow-a-z-tcp

--- a/test/e2e/environment/kind-operator/dualstack/configuration/flow-destination-ports-range.yaml
+++ b/test/e2e/environment/kind-operator/dualstack/configuration/flow-destination-ports-range.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Flow
 metadata:
   name: flow-a-z-tcp

--- a/test/e2e/environment/kind-operator/dualstack/configuration/flow-priority.yaml
+++ b/test/e2e/environment/kind-operator/dualstack/configuration/flow-priority.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Flow
 metadata:
   name: flow-a-z-tcp

--- a/test/e2e/environment/kind-operator/dualstack/configuration/init-trench-a.yaml
+++ b/test/e2e/environment/kind-operator/dualstack/configuration/init-trench-a.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Trench
 metadata:
   name: trench-a
@@ -7,7 +7,7 @@ metadata:
 spec:
   ip-family: dualstack
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Attractor
 metadata:
   name: attractor-a-1
@@ -33,7 +33,7 @@ spec:
       vlan-id: 100
       base-interface: eth0
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Gateway
 metadata:
   name: gateway-v4-a-1
@@ -54,7 +54,7 @@ spec:
       min-rx: 300ms
       multiplier: 5
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Gateway
 metadata:
   name: gateway-v6-a-1
@@ -75,7 +75,7 @@ spec:
       min-rx: 300ms
       multiplier: 5
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Vip
 metadata:
   name: vip-a-1-v4
@@ -85,7 +85,7 @@ metadata:
 spec:
   address: "20.0.0.1/32"
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Vip
 metadata:
   name: vip-a-1-v6
@@ -95,7 +95,7 @@ metadata:
 spec:
   address: "2000::1/128"
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Conduit
 metadata:
   name: conduit-a-1
@@ -105,7 +105,7 @@ metadata:
 spec:
   type: stateless-lb
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Stream
 metadata:
   name: stream-a-i
@@ -115,7 +115,7 @@ metadata:
 spec:
   conduit: conduit-a-1
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Flow
 metadata:
   name: flow-a-z-tcp
@@ -138,7 +138,7 @@ spec:
   protocols:
   - tcp
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Flow
 metadata:
   name: flow-a-z-udp
@@ -161,7 +161,7 @@ spec:
   protocols:
   - udp
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Stream
 metadata:
   name: stream-a-ii
@@ -171,7 +171,7 @@ metadata:
 spec:
   conduit: conduit-a-1
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Flow
 metadata:
   name: flow-a-y-tcp
@@ -194,7 +194,7 @@ spec:
   protocols:
   - tcp
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Attractor
 metadata:
   name: attractor-a-2
@@ -220,7 +220,7 @@ spec:
       vlan-id: 101
       base-interface: eth0
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Gateway
 metadata:
   name: gateway-v4-a-2
@@ -241,7 +241,7 @@ spec:
       min-rx: 300ms
       multiplier: 5
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Gateway
 metadata:
   name: gateway-v6-a-2
@@ -262,7 +262,7 @@ spec:
       min-rx: 300ms
       multiplier: 5
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Vip
 metadata:
   name: vip-a-3-v4
@@ -272,7 +272,7 @@ metadata:
 spec:
   address: "40.0.0.1/32"
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Vip
 metadata:
   name: vip-a-3-v6
@@ -282,7 +282,7 @@ metadata:
 spec:
   address: "4000::1/128"
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Conduit
 metadata:
   name: conduit-a-2
@@ -292,7 +292,7 @@ metadata:
 spec:
   type: stateless-lb
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Stream
 metadata:
   name: stream-a-iv
@@ -302,7 +302,7 @@ metadata:
 spec:
   conduit: conduit-a-2
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Flow
 metadata:
   name: flow-a-w-tcp

--- a/test/e2e/environment/kind-operator/dualstack/configuration/init-trench-b.yaml
+++ b/test/e2e/environment/kind-operator/dualstack/configuration/init-trench-b.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Trench
 metadata:
   name: trench-b
@@ -7,7 +7,7 @@ metadata:
 spec:
   ip-family: dualstack
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Attractor
 metadata:
   name: attractor-b-1
@@ -33,7 +33,7 @@ spec:
       vlan-id: 200
       base-interface: eth0
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Gateway
 metadata:
   name: gateway-v4-b
@@ -54,7 +54,7 @@ spec:
       min-rx: 300ms
       multiplier: 5
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Gateway
 metadata:
   name: gateway-v6-b
@@ -75,7 +75,7 @@ spec:
       min-rx: 300ms
       multiplier: 5
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Vip
 metadata:
   name: vip-b-1-v4
@@ -85,7 +85,7 @@ metadata:
 spec:
   address: "20.0.0.1/32"
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Vip
 metadata:
   name: vip-b-1-v6
@@ -95,7 +95,7 @@ metadata:
 spec:
   address: "2000::1/128"
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Conduit
 metadata:
   name: conduit-b-1
@@ -105,7 +105,7 @@ metadata:
 spec:
   type: stateless-lb
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Stream
 metadata:
   name: stream-b-i
@@ -115,7 +115,7 @@ metadata:
 spec:
   conduit: conduit-b-1
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Flow
 metadata:
   name: flow-b-z-tcp

--- a/test/e2e/environment/kind-operator/dualstack/configuration/new-attractor-nsm-vlan.yaml
+++ b/test/e2e/environment/kind-operator/dualstack/configuration/new-attractor-nsm-vlan.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Attractor
 metadata:
   name: attractor-a-3
@@ -25,7 +25,7 @@ spec:
       vlan-id: 102
       base-interface: eth0
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Gateway
 metadata:
   name: gateway-v4-a-3
@@ -46,7 +46,7 @@ spec:
       min-rx: 300ms
       multiplier: 5
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Gateway
 metadata:
   name: gateway-v6-a-3
@@ -67,7 +67,7 @@ spec:
       min-rx: 300ms
       multiplier: 5
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Vip
 metadata:
   name: vip-a-2-v4
@@ -77,7 +77,7 @@ metadata:
 spec:
   address: "60.0.0.150/32"
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Vip
 metadata:
   name: vip-a-2-v6
@@ -87,7 +87,7 @@ metadata:
 spec:
   address: "6000::150/128"
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Conduit
 metadata:
   name: conduit-a-3
@@ -97,7 +97,7 @@ metadata:
 spec:
   type: stateless-lb
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Stream
 metadata:
   name: stream-a-iii
@@ -107,7 +107,7 @@ metadata:
 spec:
   conduit: conduit-a-3
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Flow
 metadata:
   name: flow-a-x-tcp

--- a/test/e2e/environment/kind-operator/dualstack/configuration/new-flow.yaml
+++ b/test/e2e/environment/kind-operator/dualstack/configuration/new-flow.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Flow
 metadata:
   name: flow-a-x-tcp

--- a/test/e2e/environment/kind-operator/dualstack/configuration/new-stream.yaml
+++ b/test/e2e/environment/kind-operator/dualstack/configuration/new-stream.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Stream
 metadata:
   name: stream-a-iii
@@ -9,7 +9,7 @@ metadata:
 spec:
   conduit: conduit-a-1
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Flow
 metadata:
   name: flow-a-x-tcp

--- a/test/e2e/environment/kind-operator/dualstack/configuration/new-vip.yaml
+++ b/test/e2e/environment/kind-operator/dualstack/configuration/new-vip.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Vip
 metadata:
   name: vip-a-2-v4
@@ -9,7 +9,7 @@ metadata:
 spec:
   address: "60.0.0.150/32"
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Vip
 metadata:
   name: vip-a-2-v6
@@ -19,7 +19,7 @@ metadata:
 spec:
   address: "6000::150/128"
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Attractor
 metadata:
   name: attractor-a-1
@@ -47,7 +47,7 @@ spec:
       vlan-id: 100
       base-interface: eth0
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Flow
 metadata:
   name: flow-a-z-tcp

--- a/test/e2e/environment/kind-operator/dualstack/configuration/stream-max-targets.yaml
+++ b/test/e2e/environment/kind-operator/dualstack/configuration/stream-max-targets.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Stream
 metadata:
   name: stream-a-iii
@@ -10,7 +10,7 @@ spec:
   conduit: conduit-a-1
   max-targets: 1
 ---
-apiVersion: meridio.nordix.org/v1alpha1
+apiVersion: meridio.nordix.org/v1
 kind: Flow
 metadata:
   name: flow-a-x-tcp


### PR DESCRIPTION
## Description
In kind environment e2e tests should cover gateway router setups where routers advertise non-default
routes instead of default routes.

Changes are straightforward, as they rely on external-host.sh script's existing `--default-route` parameter to decide on the setup. It can be configured through newly introduced KIND_EXTERNAL_HOST_DEFAULT_ROUTE parameter in docs/demo/scripts/kind/Makefile (defaults to `yes` i.e. default route advertisement).

example:
`make -s -C test/e2e/environment/kind-operator/ KUBERNETES_VERSION=v1.26 NSM_VERSION=v1.12.0 IP_FAMILY=dualstack KIND_EXTERNAL_HOST_DEFAULT_ROUTE=yes`

Note:
In kind-host image there's a dedicated BIRD config for the two cases. The networks currently advertised as non-default routes do work irrespective of the Trench or VLAN ID. (Changing the IP allocation in kind-host would require updating the respective BIRD config as well.)

## Issue link
NA

## Checklist

- Purpose
    - [ ] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [x] CI
- Test
    - [ ] Unit test
    - [x] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
