### PR TITLE
Fix X509 source leak in credentials pkg

### DIFF
--- a/pkg/security/credentials/credentials.go
+++ b/pkg/security/credentials/credentials.go
@@ -2,12 +2,18 @@ package credentials
 
 import (
 	"context"
+	"sync"
 
 	"github.com/nordix/meridio/pkg/log"
 	"github.com/spiffe/go-spiffe/v2/spiffegrpc/grpccredentials"
 	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 	"google.golang.org/grpc/credentials"
+)
+
+var (
+	mu         sync.Mutex
+	x509Source *workloadapi.X509Source
 )
 
 func GetClient(ctx context.Context) credentials.TransportCredentials {
@@ -33,18 +39,31 @@ func GetServerWithSource(ctx context.Context, source *workloadapi.X509Source) cr
 	return grpccredentials.MTLSServerCredentials(source, source, tlsAuthorizer)
 }
 
+// GetX509Source -
+// Returns a X509 source. Creates a new source if none exists yet.
+//
+// Note: Avoid creating new X509 whenever invoked as it each source
+// consumes additional resources.
+// TODO: According to the description of NewX509Source() the source
+// should be closed to release underlying resources. So, consider
+// adding a function that would take care of closing the source.
 func GetX509Source(ctx context.Context) *workloadapi.X509Source {
-	// todo: retry if source in nil or empty
-	logger := log.FromContextOrGlobal(ctx)
-	source, err := workloadapi.NewX509Source(ctx)
-	if err != nil {
-		logger.Error(err, "error getting x509 source")
-		return nil
+	mu.Lock()
+	defer mu.Unlock()
+
+	if x509Source == nil {
+		logger := log.FromContextOrGlobal(ctx)
+		source, err := workloadapi.NewX509Source(context.Background())
+		if err != nil {
+			logger.Error(err, "error getting x509 source")
+			return nil
+		}
+		if svid, err := source.GetX509SVID(); err != nil {
+			logger.Error(err, "error getting x509 svid")
+		} else {
+			logger.Info("GetX509Source", "sVID", svid.ID)
+		}
+		x509Source = source
 	}
-	if svid, err := source.GetX509SVID(); err != nil {
-		logger.Error(err, "error getting x509 svid")
-	} else {
-		logger.Info("GetX509Source", "sVID", svid.ID)
-	}
-	return source
+	return x509Source
 }


### PR DESCRIPTION
## Description
When using credentials pkg, a new X509 source was created upon each GetX509Source() call while the sources
were never closed thus the underlying resources were not released causing resource leakage (e.g. in the TAPA).

## Issue link
#500 

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
