### PR TITLE
Update minimum Kernel version supported to 5.15

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,4 +66,4 @@ To run Meridio, the following are required:
 * Kubernetes 1.21+
 * Spire
 * Network Service Mesh 1.5+
-* Linux Kernel 4.17+
+* Linux Kernel 5.15+


### PR DESCRIPTION
## Description

Introduced with https://github.com/Nordix/Meridio/pull/467, some nftables features might not be supported before Kernel 5.2. (see [changelogs 9.2](https://wiki.nftables.org/wiki-nftables/index.php/List_of_updates_in_the_nft_command_line_tool), `Use variable to define jump / goto chain`)

Some traffic disturbance can happen prior Kernel 5.3.18 and 5.14.21

## Issue link

## Checklist

- Purpose
    - [ ] Bug fix
    - [ ] New functionality
    - [x] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [ ] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
