### PR TITLE
Fix metrics names and attributes

### DIFF
--- a/cmd/frontend/internal/frontend/metrics.go
+++ b/cmd/frontend/internal/frontend/metrics.go
@@ -77,7 +77,7 @@ func (gm *GatewayMetrics) Collect() error {
 	_, err = gm.meter.Int64ObservableGauge(
 		meridioMetrics.MERIDIO_ATTRACTOR_GATEWAY_IMPORTED_ROUTES,
 		metric.WithUnit("routes"),
-		metric.WithDescription("Counts number of routes imported for a gateway."),
+		metric.WithDescription("Number of routes imported for a gateway."),
 		metric.WithInt64Callback(func(ctx context.Context, observer metric.Int64Observer) error {
 			return gm.observe(
 				ctx,
@@ -96,7 +96,7 @@ func (gm *GatewayMetrics) Collect() error {
 	_, err = gm.meter.Int64ObservableGauge(
 		meridioMetrics.MERIDIO_ATTRACTOR_GATEWAY_EXPORTED_ROUTES,
 		metric.WithUnit("routes"),
-		metric.WithDescription("Counts number of routes exported for a gateway."),
+		metric.WithDescription("Number of routes exported for a gateway."),
 		metric.WithInt64Callback(func(ctx context.Context, observer metric.Int64Observer) error {
 			return gm.observe(
 				ctx,
@@ -115,7 +115,7 @@ func (gm *GatewayMetrics) Collect() error {
 	_, err = gm.meter.Int64ObservableGauge(
 		meridioMetrics.MERIDIO_ATTRACTOR_GATEWAY_PREFERRED_ROUTES,
 		metric.WithUnit("routes"),
-		metric.WithDescription("Counts number of routes preferred for a gateway."),
+		metric.WithDescription("Number of routes preferred for a gateway."),
 		metric.WithInt64Callback(func(ctx context.Context, observer metric.Int64Observer) error {
 			return gm.observe(
 				ctx,
@@ -151,9 +151,9 @@ func (gm *GatewayMetrics) observe(ctx context.Context, observer metric.Int64Obse
 		}
 
 		metricAttributes := []metric.ObserveOption{
-			metric.WithAttributes(attribute.String("Protocol", getProtocolName(gateway))),
-			metric.WithAttributes(attribute.String("Gateway", gateway.Name)),
-			metric.WithAttributes(attribute.String("IP", gateway.Address)),
+			metric.WithAttributes(attribute.String("protocol", getProtocolName(gateway))),
+			metric.WithAttributes(attribute.String("gateway", gateway.Name)),
+			metric.WithAttributes(attribute.String("gateway_ip", gateway.Address)),
 		}
 		metricAttributes = append(metricAttributes, gm.metricAttributes...)
 

--- a/cmd/frontend/internal/frontend/metrics.go
+++ b/cmd/frontend/internal/frontend/metrics.go
@@ -74,8 +74,8 @@ func (gm *GatewayMetrics) Collect() error {
 		return fmt.Errorf("frontend metrics, failed to RoutingService.LookupCli: %w", err)
 	}
 
-	_, err = gm.meter.Int64ObservableCounter(
-		meridioMetrics.MERIDIO_ATTRACTOR_GATEWAY_ROUTES_IMPORTED,
+	_, err = gm.meter.Int64ObservableGauge(
+		meridioMetrics.MERIDIO_ATTRACTOR_GATEWAY_IMPORTED_ROUTES,
 		metric.WithUnit("routes"),
 		metric.WithDescription("Counts number of routes imported for a gateway."),
 		metric.WithInt64Callback(func(ctx context.Context, observer metric.Int64Observer) error {
@@ -90,11 +90,11 @@ func (gm *GatewayMetrics) Collect() error {
 		}),
 	)
 	if err != nil {
-		return fmt.Errorf("frontend metrics, failed to Int64ObservableCounter (%s): %w", meridioMetrics.MERIDIO_ATTRACTOR_GATEWAY_ROUTES_IMPORTED, err)
+		return fmt.Errorf("frontend metrics, failed to Int64ObservableGauge (%s): %w", meridioMetrics.MERIDIO_ATTRACTOR_GATEWAY_IMPORTED_ROUTES, err)
 	}
 
-	_, err = gm.meter.Int64ObservableCounter(
-		meridioMetrics.MERIDIO_ATTRACTOR_GATEWAY_ROUTES_EXPORTED,
+	_, err = gm.meter.Int64ObservableGauge(
+		meridioMetrics.MERIDIO_ATTRACTOR_GATEWAY_EXPORTED_ROUTES,
 		metric.WithUnit("routes"),
 		metric.WithDescription("Counts number of routes exported for a gateway."),
 		metric.WithInt64Callback(func(ctx context.Context, observer metric.Int64Observer) error {
@@ -109,11 +109,11 @@ func (gm *GatewayMetrics) Collect() error {
 		}),
 	)
 	if err != nil {
-		return fmt.Errorf("frontend metrics, failed to Int64ObservableCounter (%s): %w", meridioMetrics.MERIDIO_ATTRACTOR_GATEWAY_ROUTES_EXPORTED, err)
+		return fmt.Errorf("frontend metrics, failed to Int64ObservableGauge (%s): %w", meridioMetrics.MERIDIO_ATTRACTOR_GATEWAY_EXPORTED_ROUTES, err)
 	}
 
-	_, err = gm.meter.Int64ObservableCounter(
-		meridioMetrics.MERIDIO_ATTRACTOR_GATEWAY_ROUTES_PREFERRED,
+	_, err = gm.meter.Int64ObservableGauge(
+		meridioMetrics.MERIDIO_ATTRACTOR_GATEWAY_PREFERRED_ROUTES,
 		metric.WithUnit("routes"),
 		metric.WithDescription("Counts number of routes preferred for a gateway."),
 		metric.WithInt64Callback(func(ctx context.Context, observer metric.Int64Observer) error {
@@ -128,7 +128,7 @@ func (gm *GatewayMetrics) Collect() error {
 		}),
 	)
 	if err != nil {
-		return fmt.Errorf("frontend metrics, failed to Int64ObservableCounter (%s): %w", meridioMetrics.MERIDIO_ATTRACTOR_GATEWAY_ROUTES_PREFERRED, err)
+		return fmt.Errorf("frontend metrics, failed to Int64ObservableGauge (%s): %w", meridioMetrics.MERIDIO_ATTRACTOR_GATEWAY_PREFERRED_ROUTES, err)
 	}
 	return nil
 }

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -114,7 +114,6 @@ func main() {
 	}
 
 	gatewayMetrics := frontend.NewGatewayMetrics([]metric.ObserveOption{
-		metric.WithAttributes(attribute.String("Hostname", hostname)),
 		metric.WithAttributes(attribute.String("Trench", config.TrenchName)),
 		metric.WithAttributes(attribute.String("Attractor", config.AttractorName)),
 	})
@@ -162,7 +161,6 @@ func main() {
 	go watchConfig(ctx, cancel, c, fe)
 
 	interfaceMetrics := linuxKernel.NewInterfaceMetrics([]metric.ObserveOption{
-		metric.WithAttributes(attribute.String("Hostname", hostname)),
 		metric.WithAttributes(attribute.String("Trench", config.TrenchName)),
 		metric.WithAttributes(attribute.String("Attractor", config.AttractorName)),
 	})

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -114,8 +114,8 @@ func main() {
 	}
 
 	gatewayMetrics := frontend.NewGatewayMetrics([]metric.ObserveOption{
-		metric.WithAttributes(attribute.String("Trench", config.TrenchName)),
-		metric.WithAttributes(attribute.String("Attractor", config.AttractorName)),
+		metric.WithAttributes(attribute.String("trench", config.TrenchName)),
+		metric.WithAttributes(attribute.String("attractor", config.AttractorName)),
 	})
 
 	// connect loadbalancer
@@ -161,8 +161,8 @@ func main() {
 	go watchConfig(ctx, cancel, c, fe)
 
 	interfaceMetrics := linuxKernel.NewInterfaceMetrics([]metric.ObserveOption{
-		metric.WithAttributes(attribute.String("Trench", config.TrenchName)),
-		metric.WithAttributes(attribute.String("Attractor", config.AttractorName)),
+		metric.WithAttributes(attribute.String("trench", config.TrenchName)),
+		metric.WithAttributes(attribute.String("attractor", config.AttractorName)),
 	})
 	interfaceMetrics.Register(config.ExternalInterface)
 

--- a/cmd/stateless-lb/main.go
+++ b/cmd/stateless-lb/main.go
@@ -193,8 +193,8 @@ func main() {
 	}
 
 	interfaceMetrics := linuxKernel.NewInterfaceMetrics([]metric.ObserveOption{
-		metric.WithAttributes(attribute.String("Trench", config.TrenchName)),
-		metric.WithAttributes(attribute.String("Conduit", config.ConduitName)),
+		metric.WithAttributes(attribute.String("trench", config.TrenchName)),
+		metric.WithAttributes(attribute.String("conduit", config.ConduitName)),
 	})
 
 	lbFactory := nfqlb.NewLbFactory(nfqlb.WithNFQueue(config.Nfqueue))

--- a/cmd/stateless-lb/main.go
+++ b/cmd/stateless-lb/main.go
@@ -187,13 +187,12 @@ func main() {
 		log.Fatal(logger, "Unable to get hostname", "error", err)
 	}
 
-	targetHitsMetrics, err := target.NewTargetHitsMetrics(hostname)
+	targetHitsMetrics, err := target.NewTargetHitsMetrics()
 	if err != nil {
 		log.Fatal(logger, "Unable to init lb target metrics", "error", err)
 	}
 
 	interfaceMetrics := linuxKernel.NewInterfaceMetrics([]metric.ObserveOption{
-		metric.WithAttributes(attribute.String("Hostname", hostname)),
 		metric.WithAttributes(attribute.String("Trench", config.TrenchName)),
 		metric.WithAttributes(attribute.String("Conduit", config.ConduitName)),
 	})
@@ -377,7 +376,6 @@ func main() {
 			}
 
 			err = flow.CollectMetrics(
-				flow.WithHostname(hostname),
 				flow.WithTrenchName(config.TrenchName),
 				flow.WithConduitName(config.ConduitName),
 			)

--- a/docs/observability/dashboard.json
+++ b/docs/observability/dashboard.json
@@ -54,7 +54,8 @@
                                 "value": 80
                             }
                         ]
-                    }
+                    },
+                    "unitScale": true
                 },
                 "overrides": []
             },
@@ -77,7 +78,7 @@
                 },
                 "showHeader": true
             },
-            "pluginVersion": "10.1.5",
+            "pluginVersion": "10.3.3",
             "targets": [
                 {
                     "datasource": {
@@ -87,7 +88,7 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "meridio_conduit_stream_target_hits_packets_total",
+                    "expr": "meridio_conduit_stream_target_hit_packets_total",
                     "format": "table",
                     "fullMetaSearch": false,
                     "includeNullMetadata": true,
@@ -105,7 +106,7 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "meridio_conduit_stream_target_hits_bytes_total",
+                    "expr": "meridio_conduit_stream_target_hit_bytes_total",
                     "format": "table",
                     "fullMetaSearch": false,
                     "hide": false,
@@ -135,12 +136,10 @@
                             "instance": true,
                             "job": true,
                             "namespace": true,
-                            "otel_scope_name": true,
-                            "pod": true
+                            "otel_scope_name": true
                         },
                         "indexByName": {
                             "Conduit": 1,
-                            "Hostname": 3,
                             "IPs": 5,
                             "Identifier": 4,
                             "Stream": 2,
@@ -154,7 +153,7 @@
                             "job": 11,
                             "namespace": 12,
                             "otel_scope_name": 13,
-                            "pod": 14
+                            "pod": 3
                         },
                         "renameByName": {
                             "Value #packets": ""
@@ -166,10 +165,6 @@
                     "options": {
                         "fields": {
                             "Conduit": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
-                            "Hostname": {
                                 "aggregations": [],
                                 "operation": "groupby"
                             },
@@ -200,6 +195,10 @@
                                     "lastNotNull"
                                 ],
                                 "operation": "aggregate"
+                            },
+                            "pod": {
+                                "aggregations": [],
+                                "operation": "groupby"
                             }
                         }
                     }
@@ -208,11 +207,13 @@
                     "id": "organize",
                     "options": {
                         "excludeByName": {},
+                        "includeByName": {},
                         "indexByName": {},
                         "renameByName": {
                             "Identifier": "",
                             "Value #bytes (lastNotNull)": "Bytes",
-                            "Value #packets (lastNotNull)": "Packets"
+                            "Value #packets (lastNotNull)": "Packets",
+                            "pod": "Pod"
                         }
                     }
                 }
@@ -249,7 +250,8 @@
                                 "value": 80
                             }
                         ]
-                    }
+                    },
+                    "unitScale": true
                 },
                 "overrides": []
             },
@@ -272,7 +274,7 @@
                 },
                 "showHeader": true
             },
-            "pluginVersion": "10.1.5",
+            "pluginVersion": "10.3.3",
             "targets": [
                 {
                     "datasource": {
@@ -300,7 +302,6 @@
                     "options": {
                         "excludeByName": {
                             "Flow": false,
-                            "Hostname": false,
                             "Time": true,
                             "__name__": true,
                             "container": true,
@@ -310,13 +311,13 @@
                             "job": true,
                             "namespace": true,
                             "otel_scope_name": true,
-                            "pod": true,
+                            "pod": false,
                             "service": true
                         },
+                        "includeByName": {},
                         "indexByName": {
                             "Conduit": 2,
                             "Flow": 4,
-                            "Hostname": 5,
                             "Stream": 3,
                             "Time": 0,
                             "Trench": 1,
@@ -328,11 +329,13 @@
                             "instance": 10,
                             "job": 11,
                             "namespace": 12,
-                            "pod": 13,
+                            "pod": 5,
                             "service": 14
                         },
                         "renameByName": {
-                            "Value": "Packets"
+                            "Flow": "",
+                            "Value": "Packets",
+                            "pod": "Pod"
                         }
                     }
                 }
@@ -350,6 +353,7 @@
                         "mode": "palette-classic"
                     },
                     "custom": {
+                        "axisBorderShow": false,
                         "axisCenteredZero": false,
                         "axisColorMode": "text",
                         "axisLabel": "",
@@ -393,7 +397,8 @@
                                 "value": 80
                             }
                         ]
-                    }
+                    },
+                    "unitScale": true
                 },
                 "overrides": []
             },
@@ -447,6 +452,7 @@
                         "mode": "palette-classic"
                     },
                     "custom": {
+                        "axisBorderShow": false,
                         "axisCenteredZero": false,
                         "axisColorMode": "text",
                         "axisLabel": "",
@@ -490,7 +496,8 @@
                                 "value": 80
                             }
                         ]
-                    }
+                    },
+                    "unitScale": true
                 },
                 "overrides": []
             },
@@ -523,7 +530,7 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "sum by(Trench, Conduit, Stream) (rate(meridio_conduit_stream_target_hits_packets_total[$__rate_interval]))",
+                    "expr": "sum by(Trench, Conduit, Stream) (rate(meridio_conduit_stream_target_hit_packets_total[$__rate_interval]))",
                     "format": "time_series",
                     "fullMetaSearch": false,
                     "hide": false,
@@ -550,6 +557,7 @@
                         "mode": "palette-classic"
                     },
                     "custom": {
+                        "axisBorderShow": false,
                         "axisCenteredZero": false,
                         "axisColorMode": "text",
                         "axisLabel": "",
@@ -593,7 +601,8 @@
                                 "value": 80
                             }
                         ]
-                    }
+                    },
+                    "unitScale": true
                 },
                 "overrides": []
             },
@@ -626,7 +635,7 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "sum by(Trench, Conduit, Stream) (rate(meridio_conduit_stream_target_hits_bytes_total[$__rate_interval]))",
+                    "expr": "sum by(Trench, Conduit, Stream) (rate(meridio_conduit_stream_target_hit_bytes_total[$__rate_interval]))",
                     "format": "time_series",
                     "fullMetaSearch": false,
                     "hide": false,
@@ -672,7 +681,8 @@
                                 "value": 80
                             }
                         ]
-                    }
+                    },
+                    "unitScale": true
                 },
                 "overrides": []
             },
@@ -695,7 +705,7 @@
                 },
                 "showHeader": true
             },
-            "pluginVersion": "10.1.5",
+            "pluginVersion": "10.3.3",
             "targets": [
                 {
                     "datasource": {
@@ -866,13 +876,11 @@
                             "instance": true,
                             "job": true,
                             "namespace": true,
-                            "otel_scope_name": true,
-                            "pod": true
+                            "otel_scope_name": true
                         },
                         "indexByName": {
                             "Attractor": 1,
                             "Conduit": 2,
-                            "Hostname": 3,
                             "Interface_Name": 4,
                             "Time": 5,
                             "Trench": 0,
@@ -891,7 +899,7 @@
                             "job": 10,
                             "namespace": 11,
                             "otel_scope_name": 12,
-                            "pod": 13
+                            "pod": 3
                         },
                         "renameByName": {}
                     }
@@ -908,11 +916,15 @@
                                 "aggregations": [],
                                 "operation": "groupby"
                             },
-                            "Hostname": {
+                            "IPs": {
                                 "aggregations": [],
                                 "operation": "groupby"
                             },
                             "Interface_Name": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "MAC_Address": {
                                 "aggregations": [],
                                 "operation": "groupby"
                             },
@@ -967,6 +979,10 @@
                                     "lastNotNull"
                                 ],
                                 "operation": "aggregate"
+                            },
+                            "pod": {
+                                "aggregations": [],
+                                "operation": "groupby"
                             }
                         }
                     }
@@ -975,6 +991,7 @@
                     "id": "organize",
                     "options": {
                         "excludeByName": {},
+                        "includeByName": {},
                         "indexByName": {},
                         "renameByName": {
                             "Value #rx bytes (lastNotNull)": "RX Bytes",
@@ -984,7 +1001,8 @@
                             "Value #tx bytes (lastNotNull)": "TX Bytes",
                             "Value #tx dropped (lastNotNull)": "TX Dropped",
                             "Value #tx errors (lastNotNull)": "TX Errors",
-                            "Value #tx packets (lastNotNull)": "TX Packets"
+                            "Value #tx packets (lastNotNull)": "TX Packets",
+                            "pod": "Pod"
                         }
                     }
                 }
@@ -1002,6 +1020,7 @@
                         "mode": "palette-classic"
                     },
                     "custom": {
+                        "axisBorderShow": false,
                         "axisCenteredZero": false,
                         "axisColorMode": "text",
                         "axisLabel": "",
@@ -1045,7 +1064,8 @@
                                 "value": 80
                             }
                         ]
-                    }
+                    },
+                    "unitScale": true
                 },
                 "overrides": []
             },
@@ -1256,12 +1276,13 @@
                                 "value": 80
                             }
                         ]
-                    }
+                    },
+                    "unitScale": true
                 },
                 "overrides": []
             },
             "gridPos": {
-                "h": 15,
+                "h": 9,
                 "w": 24,
                 "x": 0,
                 "y": 48
@@ -1279,7 +1300,7 @@
                 },
                 "showHeader": true
             },
-            "pluginVersion": "10.1.5",
+            "pluginVersion": "10.3.3",
             "targets": [
                 {
                     "datasource": {
@@ -1289,7 +1310,7 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "meridio_attracted_gateway_routes_exported_total",
+                    "expr": "meridio_attractor_gateway_exported_routes",
                     "format": "table",
                     "fullMetaSearch": false,
                     "includeNullMetadata": true,
@@ -1307,7 +1328,7 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "meridio_attracted_gateway_routes_imported_total",
+                    "expr": "meridio_attractor_gateway_imported_routes",
                     "format": "table",
                     "fullMetaSearch": false,
                     "hide": false,
@@ -1326,7 +1347,7 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "meridio_attracted_gateway_routes_preferred_total",
+                    "expr": "meridio_attractor_gateway_preferred_routes",
                     "format": "table",
                     "fullMetaSearch": false,
                     "hide": false,
@@ -1355,13 +1376,11 @@
                             "instance": true,
                             "job": true,
                             "namespace": true,
-                            "otel_scope_name": true,
-                            "pod": true
+                            "otel_scope_name": true
                         },
                         "indexByName": {
                             "Attractor": 1,
                             "Gateway": 2,
-                            "Hostname": 3,
                             "IP": 4,
                             "Protocol": 5,
                             "Time": 7,
@@ -1374,7 +1393,7 @@
                             "job": 12,
                             "namespace": 13,
                             "otel_scope_name": 14,
-                            "pod": 15
+                            "pod": 3
                         },
                         "renameByName": {}
                     }
@@ -1388,10 +1407,6 @@
                                 "operation": "groupby"
                             },
                             "Gateway": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
-                            "Hostname": {
                                 "aggregations": [],
                                 "operation": "groupby"
                             },
@@ -1424,6 +1439,10 @@
                                     "lastNotNull"
                                 ],
                                 "operation": "aggregate"
+                            },
+                            "pod": {
+                                "aggregations": [],
+                                "operation": "groupby"
                             }
                         }
                     }
@@ -1432,11 +1451,14 @@
                     "id": "organize",
                     "options": {
                         "excludeByName": {},
+                        "includeByName": {},
                         "indexByName": {},
                         "renameByName": {
+                            "Gateway": "",
                             "Value #Exported (lastNotNull)": "Exported",
                             "Value #Imported (lastNotNull)": "Imported",
-                            "Value #Preferred (lastNotNull)": "Preferred"
+                            "Value #Preferred (lastNotNull)": "Preferred",
+                            "pod": "Pod"
                         }
                     }
                 }
@@ -1445,8 +1467,7 @@
         }
     ],
     "refresh": "5s",
-    "schemaVersion": 38,
-    "style": "dark",
+    "schemaVersion": 39,
     "tags": [],
     "templating": {
         "list": [
@@ -1464,13 +1485,13 @@
         ]
     },
     "time": {
-        "from": "now-15m",
+        "from": "now-5m",
         "to": "now"
     },
     "timepicker": {},
     "timezone": "",
     "title": "Meridio",
     "uid": "f0339d9f-4744-441c-972b-f8b294fb7ff8",
-    "version": 2,
+    "version": 3,
     "weekStart": ""
 }

--- a/docs/observability/dashboard.json
+++ b/docs/observability/dashboard.json
@@ -18,7 +18,7 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
-    "id": 28,
+    "id": 29,
     "links": [],
     "liveNow": false,
     "panels": [
@@ -139,21 +139,21 @@
                             "otel_scope_name": true
                         },
                         "indexByName": {
-                            "Conduit": 1,
-                            "IPs": 5,
-                            "Identifier": 4,
-                            "Stream": 2,
                             "Time": 6,
-                            "Trench": 0,
                             "Value": 15,
                             "__name__": 7,
+                            "conduit": 1,
                             "container": 8,
                             "endpoint": 9,
+                            "identifier": 4,
                             "instance": 10,
+                            "target_ips": 5,
                             "job": 11,
                             "namespace": 12,
                             "otel_scope_name": 13,
-                            "pod": 3
+                            "pod": 3,
+                            "stream": 2,
+                            "trench": 0
                         },
                         "renameByName": {
                             "Value #packets": ""
@@ -164,26 +164,6 @@
                     "id": "groupBy",
                     "options": {
                         "fields": {
-                            "Conduit": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
-                            "IPs": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
-                            "Identifier": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
-                            "Stream": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
-                            "Trench": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
                             "Value #bytes": {
                                 "aggregations": [
                                     "lastNotNull"
@@ -196,7 +176,27 @@
                                 ],
                                 "operation": "aggregate"
                             },
+                            "conduit": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "identifier": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "target_ips": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
                             "pod": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "stream": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "trench": {
                                 "aggregations": [],
                                 "operation": "groupby"
                             }
@@ -210,10 +210,14 @@
                         "includeByName": {},
                         "indexByName": {},
                         "renameByName": {
-                            "Identifier": "",
                             "Value #bytes (lastNotNull)": "Bytes",
                             "Value #packets (lastNotNull)": "Packets",
-                            "pod": "Pod"
+                            "conduit": "Conduit",
+                            "identifier": "Identifier",
+                            "target_ips": "Target IPs",
+                            "pod": "Pod",
+                            "stream": "Stream",
+                            "trench": "Trench"
                         }
                     }
                 }
@@ -301,12 +305,12 @@
                     "id": "organize",
                     "options": {
                         "excludeByName": {
-                            "Flow": false,
                             "Time": true,
                             "__name__": true,
                             "container": true,
                             "endpoint": true,
                             "exported_job": true,
+                            "flow": false,
                             "instance": true,
                             "job": true,
                             "namespace": true,
@@ -316,26 +320,29 @@
                         },
                         "includeByName": {},
                         "indexByName": {
-                            "Conduit": 2,
-                            "Flow": 4,
-                            "Stream": 3,
                             "Time": 0,
-                            "Trench": 1,
                             "Value": 15,
                             "__name__": 6,
+                            "conduit": 2,
                             "container": 7,
                             "endpoint": 8,
                             "exported_job": 9,
+                            "flow": 4,
                             "instance": 10,
                             "job": 11,
                             "namespace": 12,
                             "pod": 5,
-                            "service": 14
+                            "service": 14,
+                            "stream": 3,
+                            "trench": 1
                         },
                         "renameByName": {
-                            "Flow": "",
                             "Value": "Packets",
-                            "pod": "Pod"
+                            "conduit": "Conduit",
+                            "flow": "Flow",
+                            "pod": "Pod",
+                            "stream": "Stream",
+                            "trench": "Trench"
                         }
                     }
                 }
@@ -429,10 +436,10 @@
                     },
                     "disableTextWrap": false,
                     "editorMode": "builder",
-                    "expr": "sum by(Flow, Stream, Conduit, Trench) (rate(meridio_conduit_stream_flow_matches_total[$__rate_interval]))",
+                    "expr": "sum by(flow, stream, conduit, trench) (rate(meridio_conduit_stream_flow_matches_total[$__rate_interval]))",
                     "fullMetaSearch": false,
                     "includeNullMetadata": true,
-                    "legendFormat": "{{Flow}}.{{Stream}}.{{Conduit}}.{{Trench}}",
+                    "legendFormat": "{{flow}}.{{stream}}.{{conduit}}.{{trench}}",
                     "range": true,
                     "refId": "A",
                     "useBackend": false
@@ -530,13 +537,13 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "sum by(Trench, Conduit, Stream) (rate(meridio_conduit_stream_target_hit_packets_total[$__rate_interval]))",
+                    "expr": "sum by(trench, conduit, stream) (rate(meridio_conduit_stream_target_hit_packets_total[$__rate_interval]))",
                     "format": "time_series",
                     "fullMetaSearch": false,
                     "hide": false,
                     "includeNullMetadata": false,
                     "instant": false,
-                    "legendFormat": "{{Stream}}.{{Conduit}}.{{Trench}}",
+                    "legendFormat": "{{stream}}.{{conduit}}.{{trench}}",
                     "range": true,
                     "refId": "packets",
                     "useBackend": false
@@ -635,13 +642,13 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "sum by(Trench, Conduit, Stream) (rate(meridio_conduit_stream_target_hit_bytes_total[$__rate_interval]))",
+                    "expr": "sum by(trench, conduit, stream) (rate(meridio_conduit_stream_target_hit_bytes_total[$__rate_interval]))",
                     "format": "time_series",
                     "fullMetaSearch": false,
                     "hide": false,
                     "includeNullMetadata": false,
                     "instant": false,
-                    "legendFormat": "{{Stream}}.{{Conduit}}.{{Trench}}",
+                    "legendFormat": "{{stream}}.{{conduit}}.{{trench}}",
                     "range": true,
                     "refId": "packets",
                     "useBackend": false
@@ -879,11 +886,7 @@
                             "otel_scope_name": true
                         },
                         "indexByName": {
-                            "Attractor": 1,
-                            "Conduit": 2,
-                            "Interface_Name": 4,
                             "Time": 5,
-                            "Trench": 0,
                             "Value #rx bytes": 14,
                             "Value #rx dropped": 20,
                             "Value #rx errors": 18,
@@ -893,13 +896,17 @@
                             "Value #tx errors": 19,
                             "Value #tx packets": 17,
                             "__name__": 6,
+                            "attractor": 1,
+                            "conduit": 2,
                             "container": 7,
                             "endpoint": 8,
                             "instance": 9,
+                            "interface_name": 4,
                             "job": 10,
                             "namespace": 11,
                             "otel_scope_name": 12,
-                            "pod": 3
+                            "pod": 3,
+                            "trench": 0
                         },
                         "renameByName": {}
                     }
@@ -908,30 +915,6 @@
                     "id": "groupBy",
                     "options": {
                         "fields": {
-                            "Attractor": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
-                            "Conduit": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
-                            "IPs": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
-                            "Interface_Name": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
-                            "MAC_Address": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
-                            "Trench": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
                             "Value #rx bytes": {
                                 "aggregations": [
                                     "lastNotNull"
@@ -980,7 +963,31 @@
                                 ],
                                 "operation": "aggregate"
                             },
+                            "attractor": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "conduit": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "interface_name": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "ips": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "mac_address": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
                             "pod": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "trench": {
                                 "aggregations": [],
                                 "operation": "groupby"
                             }
@@ -1002,7 +1009,13 @@
                             "Value #tx dropped (lastNotNull)": "TX Dropped",
                             "Value #tx errors (lastNotNull)": "TX Errors",
                             "Value #tx packets (lastNotNull)": "TX Packets",
-                            "pod": "Pod"
+                            "attractor": "Attractor",
+                            "conduit": "Conduit",
+                            "interface_name": "Interface Name",
+                            "ips": "IPs",
+                            "mac_address": "MAC Address",
+                            "pod": "Pod",
+                            "trench": "Trench"
                         }
                     }
                 }
@@ -1098,12 +1111,12 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "sum by(Trench, Conduit, Attractor) (rate(meridio_interface_rx_bytes_total[$__rate_interval]))",
+                    "expr": "sum by(trench, conduit, attractor) (rate(meridio_interface_rx_bytes_total[$__rate_interval]))",
                     "format": "time_series",
                     "fullMetaSearch": false,
                     "includeNullMetadata": true,
                     "instant": false,
-                    "legendFormat": "rx_bytes.{{Conduit}}{{Attractor}}.{{Trench}}",
+                    "legendFormat": "rx_bytes.{{conduit}}{{attractor}}.{{trench}}",
                     "range": true,
                     "refId": "rx bytes",
                     "useBackend": false
@@ -1116,13 +1129,13 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "sum by(Trench, Conduit, Attractor) (rate(meridio_interface_tx_bytes_total[$__rate_interval]))",
+                    "expr": "sum by(trench, conduit, attractor) (rate(meridio_interface_tx_bytes_total[$__rate_interval]))",
                     "format": "time_series",
                     "fullMetaSearch": false,
                     "hide": false,
                     "includeNullMetadata": true,
                     "instant": false,
-                    "legendFormat": "tx_bytes.{{Conduit}}{{Attractor}}.{{Trench}}",
+                    "legendFormat": "tx_bytes.{{conduit}}{{attractor}}.{{trench}}",
                     "range": true,
                     "refId": "tx bytes",
                     "useBackend": false
@@ -1135,13 +1148,13 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "sum by(Trench, Conduit, Attractor) (rate(meridio_interface_rx_packets_total[$__rate_interval]))",
+                    "expr": "sum by(trench, conduit, attractor) (rate(meridio_interface_rx_packets_total[$__rate_interval]))",
                     "format": "time_series",
                     "fullMetaSearch": false,
                     "hide": false,
                     "includeNullMetadata": true,
                     "instant": false,
-                    "legendFormat": "rx_packets.{{Conduit}}{{Attractor}}.{{Trench}}",
+                    "legendFormat": "rx_packets.{{conduit}}{{attractor}}.{{trench}}",
                     "range": true,
                     "refId": "rx packets",
                     "useBackend": false
@@ -1154,13 +1167,13 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "sum by(Trench, Conduit, Attractor) (rate(meridio_interface_tx_packets_total[$__rate_interval]))",
+                    "expr": "sum by(trench, conduit, attractor) (rate(meridio_interface_tx_packets_total[$__rate_interval]))",
                     "format": "time_series",
                     "fullMetaSearch": false,
                     "hide": false,
                     "includeNullMetadata": true,
                     "instant": false,
-                    "legendFormat": "tx_packets.{{Conduit}}{{Attractor}}.{{Trench}}",
+                    "legendFormat": "tx_packets.{{conduit}}{{attractor}}.{{trench}}",
                     "range": true,
                     "refId": "tx packets",
                     "useBackend": false
@@ -1173,13 +1186,13 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "sum by(Trench, Conduit, Attractor) (rate(meridio_interface_rx_errors_total[$__rate_interval]))",
+                    "expr": "sum by(trench, conduit, attractor) (rate(meridio_interface_rx_errors_total[$__rate_interval]))",
                     "format": "time_series",
                     "fullMetaSearch": false,
                     "hide": false,
                     "includeNullMetadata": true,
                     "instant": false,
-                    "legendFormat": "rx_errors.{{Conduit}}{{Attractor}}.{{Trench}}",
+                    "legendFormat": "rx_errors.{{conduit}}{{attractor}}.{{trench}}",
                     "range": true,
                     "refId": "rx errors",
                     "useBackend": false
@@ -1192,13 +1205,13 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "sum by(Trench, Conduit, Attractor) (rate(meridio_interface_tx_errors_total[$__rate_interval]))",
+                    "expr": "sum by(trench, conduit, attractor) (rate(meridio_interface_tx_errors_total[$__rate_interval]))",
                     "format": "time_series",
                     "fullMetaSearch": false,
                     "hide": false,
                     "includeNullMetadata": true,
                     "instant": false,
-                    "legendFormat": "tx_errors.{{Conduit}}{{Attractor}}.{{Trench}}",
+                    "legendFormat": "tx_errors.{{conduit}}{{attractor}}.{{trench}}",
                     "range": true,
                     "refId": "tx errors",
                     "useBackend": false
@@ -1211,13 +1224,13 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "sum by(Trench, Conduit, Attractor) (rate(meridio_interface_rx_dropped_total[$__rate_interval]))",
+                    "expr": "sum by(trench, conduit, attractor) (rate(meridio_interface_rx_dropped_total[$__rate_interval]))",
                     "format": "time_series",
                     "fullMetaSearch": false,
                     "hide": false,
                     "includeNullMetadata": true,
                     "instant": false,
-                    "legendFormat": "rx_dropped.{{Conduit}}{{Attractor}}.{{Trench}}",
+                    "legendFormat": "rx_dropped.{{conduit}}{{attractor}}.{{trench}}",
                     "range": true,
                     "refId": "rx dropped",
                     "useBackend": false
@@ -1230,13 +1243,13 @@
                     "disableTextWrap": false,
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "sum by(Trench, Conduit, Attractor) (rate(meridio_interface_tx_dropped_total[$__rate_interval]))",
+                    "expr": "sum by(trench, conduit, attractor) (rate(meridio_interface_tx_dropped_total[$__rate_interval]))",
                     "format": "time_series",
                     "fullMetaSearch": false,
                     "hide": false,
                     "includeNullMetadata": true,
                     "instant": false,
-                    "legendFormat": "tx_dropped.{{Conduit}}{{Attractor}}.{{Trench}}",
+                    "legendFormat": "tx_dropped.{{conduit}}{{attractor}}.{{trench}}",
                     "range": true,
                     "refId": "tx dropped",
                     "useBackend": false
@@ -1379,21 +1392,21 @@
                             "otel_scope_name": true
                         },
                         "indexByName": {
-                            "Attractor": 1,
-                            "Gateway": 2,
-                            "IP": 4,
-                            "Protocol": 5,
                             "Time": 7,
-                            "Trench": 0,
                             "Value": 6,
                             "__name__": 8,
+                            "attractor": 1,
                             "container": 9,
                             "endpoint": 10,
+                            "gateway": 2,
                             "instance": 11,
+                            "gateway_ip": 4,
                             "job": 12,
                             "namespace": 13,
                             "otel_scope_name": 14,
-                            "pod": 3
+                            "pod": 3,
+                            "protocol": 5,
+                            "trench": 0
                         },
                         "renameByName": {}
                     }
@@ -1402,26 +1415,6 @@
                     "id": "groupBy",
                     "options": {
                         "fields": {
-                            "Attractor": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
-                            "Gateway": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
-                            "IP": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
-                            "Protocol": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
-                            "Trench": {
-                                "aggregations": [],
-                                "operation": "groupby"
-                            },
                             "Value #Exported": {
                                 "aggregations": [
                                     "lastNotNull"
@@ -1440,7 +1433,27 @@
                                 ],
                                 "operation": "aggregate"
                             },
+                            "attractor": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "gateway": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "gateway_ip": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
                             "pod": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "protocol": {
+                                "aggregations": [],
+                                "operation": "groupby"
+                            },
+                            "trench": {
                                 "aggregations": [],
                                 "operation": "groupby"
                             }
@@ -1454,11 +1467,15 @@
                         "includeByName": {},
                         "indexByName": {},
                         "renameByName": {
-                            "Gateway": "",
                             "Value #Exported (lastNotNull)": "Exported",
                             "Value #Imported (lastNotNull)": "Imported",
                             "Value #Preferred (lastNotNull)": "Preferred",
-                            "pod": "Pod"
+                            "attractor": "Attractor",
+                            "gateway": "Gateway",
+                            "gateway_ip": "Gateway IP",
+                            "pod": "Pod",
+                            "protocol": "Protocol",
+                            "trench": "Trench"
                         }
                     }
                 }
@@ -1492,6 +1509,6 @@
     "timezone": "",
     "title": "Meridio",
     "uid": "f0339d9f-4744-441c-972b-f8b294fb7ff8",
-    "version": 3,
+    "version": 2,
     "weekStart": ""
 }

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -10,11 +10,12 @@ Counts number of `METRIC_TYPE` for a network interface.
 
 * Type: Counter
 * Attributes:
-   * Pod Name
    * Trench
    * Conduit (optional)
    * Attactor (optional)
    * Interface Name
+   * MAC Address
+   * IPs
 
 ### meridio.conduit.stream.flow.matches
 
@@ -22,13 +23,12 @@ Counts number of packets that have matched a flow.
 
 * Type: Counter
 * Attributes:
-   * Pod Name
    * Trench
    * Conduit
    * Stream
    * Flow
 
-### meridio.conduit.stream.target.hits.`METRIC_TYPE`
+### meridio.conduit.stream.target.hit.`METRIC_TYPE`
 
 `METRIC_TYPE`: packets, bytes
 
@@ -36,7 +36,6 @@ Counts number of `METRIC_TYPE` that have hit a target.
 
 * Type: Counter
 * Attributes:
-   * Pod Name
    * Trench
    * Conduit
    * Stream
@@ -49,20 +48,18 @@ Reports the latency with a target.
 
 * Type: Gauge
 * Attributes:
-   * Pod Name
    * Trench
    * Conduit
    * IP
 
-### meridio.attracted.gateway.routes.`METRIC_TYPE`
+### meridio.attractor.gateway.`METRIC_TYPE`.routes
 
 `METRIC_TYPE`: imported, exported, preferred
 
 Number of `METRIC_TYPE` routes for a gateway in the attractor instance.
 
-* Type: Counter
+* Type: Gauge
 * Attributes:
-   * Pod Name
    * Trench
    * Attactor
    * Gateway

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -40,7 +40,7 @@ Counts number of `METRIC_TYPE` that have hit a target.
    * Conduit
    * Stream
    * Identifier
-   * IPs
+   * Target IPs
 
 ### meridio.conduit.stream.target.latency (Planned)
 
@@ -50,7 +50,7 @@ Reports the latency with a target.
 * Attributes:
    * Trench
    * Conduit
-   * IP
+   * Target IP
 
 ### meridio.attractor.gateway.`METRIC_TYPE`.routes
 
@@ -63,5 +63,5 @@ Number of `METRIC_TYPE` routes for a gateway in the attractor instance.
    * Trench
    * Attactor
    * Gateway
-   * IP
+   * Gateway IP
    * Protocol

--- a/docs/observability/readme.md
+++ b/docs/observability/readme.md
@@ -24,7 +24,7 @@ kubectl apply -f - <<EOF
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: stateless-lb-frontend-attractor-a-1-service-monitor
+  name: stateless-lb-frontend-service-monitor
   labels:
     release: prometheus
 spec:
@@ -49,4 +49,4 @@ The dashboard of this demo can be accessed by exposing the grafana service with 
 
 ### Install Meridio
 
-Make sure the `NSM_METRICS_ENABLED` environement variable is set to true in the stateless-lb container.
+Make sure the `NSM_METRICS_ENABLED` environement variable is set to true in the stateless-lb container and `NFE_METRICS_ENABLED` environement variable is set to true in the frontend container.

--- a/pkg/kernel/metrics.go
+++ b/pkg/kernel/metrics.go
@@ -222,7 +222,7 @@ func (im *InterfaceMetrics) observe(ctx context.Context, observer metric.Int64Ob
 			continue
 		}
 		metricAttributes = append(metricAttributes, metric.WithAttributes(attribute.String("MAC Address", link.Attrs().HardwareAddr.String())))
-		metricAttributes = append(metricAttributes, metric.WithAttributes(attribute.StringSlice("IP Addresses", listIPs(link))))
+		metricAttributes = append(metricAttributes, metric.WithAttributes(attribute.StringSlice("IPs", listIPs(link))))
 		observer.Observe(
 			valueFunc(link.Attrs().Statistics),
 			metricAttributes...,

--- a/pkg/kernel/metrics.go
+++ b/pkg/kernel/metrics.go
@@ -214,15 +214,15 @@ func (im *InterfaceMetrics) observe(ctx context.Context, observer metric.Int64Ob
 
 	for interfaceName := range im.interfaces {
 		metricAttributes := []metric.ObserveOption{
-			metric.WithAttributes(attribute.String("Interface Name", interfaceName)),
+			metric.WithAttributes(attribute.String("interface_name", interfaceName)),
 		}
 		metricAttributes = append(metricAttributes, im.metricAttributes...)
 		link := getLinkByName(interfaceName)
 		if link == nil {
 			continue
 		}
-		metricAttributes = append(metricAttributes, metric.WithAttributes(attribute.String("MAC Address", link.Attrs().HardwareAddr.String())))
-		metricAttributes = append(metricAttributes, metric.WithAttributes(attribute.StringSlice("IPs", listIPs(link))))
+		metricAttributes = append(metricAttributes, metric.WithAttributes(attribute.String("mac_address", link.Attrs().HardwareAddr.String())))
+		metricAttributes = append(metricAttributes, metric.WithAttributes(attribute.StringSlice("ips", listIPs(link))))
 		observer.Observe(
 			valueFunc(link.Attrs().Statistics),
 			metricAttributes...,

--- a/pkg/loadbalancer/flow/metrics.go
+++ b/pkg/loadbalancer/flow/metrics.go
@@ -48,10 +48,10 @@ func CollectMetrics(options ...option) error {
 			for _, fs := range flowStats {
 				observer.Observe(
 					int64(fs.GetMatchesCount()),
-					metric.WithAttributes(attribute.String("Trench", config.trenchName)),
-					metric.WithAttributes(attribute.String("Conduit", config.conduitName)),
-					metric.WithAttributes(attribute.String("Stream", fs.GetFlow().GetStream().GetName())),
-					metric.WithAttributes(attribute.String("Flow", fs.GetFlow().GetName())),
+					metric.WithAttributes(attribute.String("trench", config.trenchName)),
+					metric.WithAttributes(attribute.String("conduit", config.conduitName)),
+					metric.WithAttributes(attribute.String("stream", fs.GetFlow().GetStream().GetName())),
+					metric.WithAttributes(attribute.String("flow", fs.GetFlow().GetName())),
 				)
 			}
 			return nil

--- a/pkg/loadbalancer/flow/metrics.go
+++ b/pkg/loadbalancer/flow/metrics.go
@@ -48,7 +48,6 @@ func CollectMetrics(options ...option) error {
 			for _, fs := range flowStats {
 				observer.Observe(
 					int64(fs.GetMatchesCount()),
-					metric.WithAttributes(attribute.String("Hostname", config.hostname)),
 					metric.WithAttributes(attribute.String("Trench", config.trenchName)),
 					metric.WithAttributes(attribute.String("Conduit", config.conduitName)),
 					metric.WithAttributes(attribute.String("Stream", fs.GetFlow().GetStream().GetName())),
@@ -88,7 +87,6 @@ func nfqlbGetFlowStats() ([]FlowStat, error) {
 type config struct {
 	getFlowStatsFunc GetFlowStats
 	meter            metric.Meter
-	hostname         string
 	trenchName       string
 	conduitName      string
 }
@@ -114,13 +112,6 @@ func WithMeter(meter metric.Meter) option {
 func WithGetFlowStatsFunc(getFlowStatsFunc GetFlowStats) option {
 	return func(c *config) {
 		c.getFlowStatsFunc = getFlowStatsFunc
-	}
-}
-
-// WithHostname specifies the hostname attribute.
-func WithHostname(hostname string) option {
-	return func(c *config) {
-		c.hostname = hostname
 	}
 }
 

--- a/pkg/loadbalancer/target/metrics.go
+++ b/pkg/loadbalancer/target/metrics.go
@@ -38,7 +38,6 @@ const (
 )
 
 type HitsMetrics struct {
-	hostname      string
 	meter         metric.Meter
 	targets       map[int]*nspAPI.Target
 	fwmarkChains  map[int]*nftables.Chain
@@ -48,10 +47,9 @@ type HitsMetrics struct {
 	mu            sync.Mutex
 }
 
-func NewTargetHitsMetrics(hostname string) (*HitsMetrics, error) {
+func NewTargetHitsMetrics() (*HitsMetrics, error) {
 	meter := otel.GetMeterProvider().Meter(meridioMetrics.METER_NAME)
 	hm := &HitsMetrics{
-		hostname:     hostname,
 		meter:        meter,
 		targets:      map[int]*nspAPI.Target{},
 		fwmarkChains: map[int]*nftables.Chain{},
@@ -233,7 +231,7 @@ func (hm *HitsMetrics) Unregister(id int) error {
 // Collect collects the metrics for the all the target rules.
 func (hm *HitsMetrics) Collect() error {
 	_, err := hm.meter.Int64ObservableCounter(
-		meridioMetrics.MERIDIO_CONDUIT_STREAM_TARGET_HITS_PACKETS,
+		meridioMetrics.MERIDIO_CONDUIT_STREAM_TARGET_HIT_PACKETS,
 		metric.WithUnit("packets"), // TODO: what unit must be set?
 		metric.WithDescription("Counts number of packets that have hit a target."),
 		metric.WithInt64Callback(func(ctx context.Context, observer metric.Int64Observer) error {
@@ -262,7 +260,6 @@ func (hm *HitsMetrics) Collect() error {
 
 				observer.Observe(
 					int64(metrics.Packets),
-					metric.WithAttributes(attribute.String("Hostname", hm.hostname)),
 					metric.WithAttributes(attribute.String("Trench", trenchName)),
 					metric.WithAttributes(attribute.String("Conduit", conduitName)),
 					metric.WithAttributes(attribute.String("Stream", streamName)),
@@ -278,7 +275,7 @@ func (hm *HitsMetrics) Collect() error {
 	}
 
 	_, err = hm.meter.Int64ObservableCounter(
-		meridioMetrics.MERIDIO_CONDUIT_STREAM_TARGET_HITS_BYTES,
+		meridioMetrics.MERIDIO_CONDUIT_STREAM_TARGET_HIT_BYTES,
 		metric.WithUnit("bytes"), // TODO: what unit must be set?
 		metric.WithDescription("Counts number of bytes that have hit a target."),
 		metric.WithInt64Callback(func(ctx context.Context, observer metric.Int64Observer) error {
@@ -307,7 +304,6 @@ func (hm *HitsMetrics) Collect() error {
 
 				observer.Observe(
 					int64(metrics.Bytes),
-					metric.WithAttributes(attribute.String("Hostname", hm.hostname)),
 					metric.WithAttributes(attribute.String("Trench", trenchName)),
 					metric.WithAttributes(attribute.String("Conduit", conduitName)),
 					metric.WithAttributes(attribute.String("Stream", streamName)),

--- a/pkg/loadbalancer/target/metrics.go
+++ b/pkg/loadbalancer/target/metrics.go
@@ -260,11 +260,11 @@ func (hm *HitsMetrics) Collect() error {
 
 				observer.Observe(
 					int64(metrics.Packets),
-					metric.WithAttributes(attribute.String("Trench", trenchName)),
-					metric.WithAttributes(attribute.String("Conduit", conduitName)),
-					metric.WithAttributes(attribute.String("Stream", streamName)),
-					metric.WithAttributes(attribute.Int("Identifier", targetID)),
-					metric.WithAttributes(attribute.StringSlice("IPs", target.GetIps())),
+					metric.WithAttributes(attribute.String("trench", trenchName)),
+					metric.WithAttributes(attribute.String("conduit", conduitName)),
+					metric.WithAttributes(attribute.String("stream", streamName)),
+					metric.WithAttributes(attribute.Int("identifier", targetID)),
+					metric.WithAttributes(attribute.StringSlice("target_ips", target.GetIps())),
 				)
 			}
 			return nil
@@ -304,11 +304,11 @@ func (hm *HitsMetrics) Collect() error {
 
 				observer.Observe(
 					int64(metrics.Bytes),
-					metric.WithAttributes(attribute.String("Trench", trenchName)),
-					metric.WithAttributes(attribute.String("Conduit", conduitName)),
-					metric.WithAttributes(attribute.String("Stream", streamName)),
-					metric.WithAttributes(attribute.Int("Identifier", targetID)),
-					metric.WithAttributes(attribute.StringSlice("IPs", target.GetIps())),
+					metric.WithAttributes(attribute.String("trench", trenchName)),
+					metric.WithAttributes(attribute.String("conduit", conduitName)),
+					metric.WithAttributes(attribute.String("stream", streamName)),
+					metric.WithAttributes(attribute.Int("identifier", targetID)),
+					metric.WithAttributes(attribute.StringSlice("target_ips", target.GetIps())),
 				)
 			}
 			return nil

--- a/pkg/metrics/const.go
+++ b/pkg/metrics/const.go
@@ -18,8 +18,8 @@ package metrics
 
 const (
 	MERIDIO_CONDUIT_STREAM_FLOW_MATCHES        = "meridio.conduit.stream.flow.matches"
-	MERIDIO_CONDUIT_STREAM_TARGET_HITS_PACKETS = "meridio.conduit.stream.target.hits.packets"
-	MERIDIO_CONDUIT_STREAM_TARGET_HITS_BYTES   = "meridio.conduit.stream.target.hits.bytes"
+	MERIDIO_CONDUIT_STREAM_TARGET_HIT_PACKETS  = "meridio.conduit.stream.target.hit.packets"
+	MERIDIO_CONDUIT_STREAM_TARGET_HIT_BYTES    = "meridio.conduit.stream.target.hit.bytes"
 	MERIDIO_INTERFACE_RX_PACKETS               = "meridio.interface.rx_packets"
 	MERIDIO_INTERFACE_TX_PACKET                = "meridio.interface.tx_packets"
 	MERIDIO_INTERFACE_RX_BYTES                 = "meridio.interface.rx_bytes"
@@ -28,9 +28,9 @@ const (
 	MERIDIO_INTERFACE_TX_ERRORS                = "meridio.interface.tx_errors"
 	MERIDIO_INTERFACE_RX_DROPPED               = "meridio.interface.rx_dropped"
 	MERIDIO_INTERFACE_TX_DROPPED               = "meridio.interface.tx_dropped"
-	MERIDIO_ATTRACTOR_GATEWAY_ROUTES_IMPORTED  = "meridio.attracted.gateway.routes.imported"
-	MERIDIO_ATTRACTOR_GATEWAY_ROUTES_EXPORTED  = "meridio.attracted.gateway.routes.exported"
-	MERIDIO_ATTRACTOR_GATEWAY_ROUTES_PREFERRED = "meridio.attracted.gateway.routes.preferred"
+	MERIDIO_ATTRACTOR_GATEWAY_IMPORTED_ROUTES  = "meridio.attractor.gateway.imported.routes"
+	MERIDIO_ATTRACTOR_GATEWAY_EXPORTED_ROUTES  = "meridio.attractor.gateway.exported.routes"
+	MERIDIO_ATTRACTOR_GATEWAY_PREFERRED_ROUTES = "meridio.attractor.gateway.preferred.routes"
 
 	METER_NAME = "Meridio"
 )


### PR DESCRIPTION
## Description

* meridio.conduit.stream.target.hits.METRIC_TYPE to meridio.conduit.stream.target.hit.METRIC_TYPE
* meridio.attracted.gateway.routes.METRIC_TYPE to meridio.attractor.gateway.METRIC_TYPE.routes
* Rename hostname from attributes since open telemetry SDK already adds the pod name
* meridio.attractor.gateway.routes.METRIC_TYPE type as gauge instead of counter
* Fix documentation and dashboard

## Issue link

## Checklist

- Purpose
    - [ ] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [x] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
