### PR TITLE
NFQLB Update to 1.2.0 to change hash mode

### DIFF
--- a/build/stateless-lb/Dockerfile
+++ b/build/stateless-lb/Dockerfile
@@ -19,8 +19,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags -static -X main.vers
 
 FROM ${base_image} as lb-builder
 WORKDIR /
-ADD https://github.com/Nordix/nfqueue-loadbalancer/releases/download/1.1.4/nfqlb-1.1.4.tar.xz /
-RUN tar --strip-components=1 -xf /nfqlb-1.1.4.tar.xz nfqlb-1.1.4/bin/nfqlb
+ADD https://github.com/Nordix/nfqueue-loadbalancer/releases/download/1.2.0/nfqlb-1.2.0.tar.xz /
+RUN tar --strip-components=1 -xf /nfqlb-1.2.0.tar.xz nfqlb-1.2.0/bin/nfqlb
 
 FROM ${base_image}
 ARG USER

--- a/pkg/loadbalancer/nfqlb/nfqlb.go
+++ b/pkg/loadbalancer/nfqlb/nfqlb.go
@@ -76,6 +76,7 @@ func (nf *nfqlbFactory) Start(ctx context.Context) error {
 		// "--nolb_fwmark=",
 		fmt.Sprintf("--queue=%s", nf.nfqueue),
 		fmt.Sprintf("--qlength=%d", qlength),
+		"--hash_mode=0",
 		// "--ft_shm=",
 		// "--ft_size=",
 		// "--ft_buckets=",


### PR DESCRIPTION
## Description

Set hash mode to 0 to load balance on tuple-5 using SCTP

## Issue link

https://github.com/Nordix/nfqueue-loadbalancer/pull/21

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [x] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
