### PR TITLE
Reconfigure proxy on network interface delete events from kernel

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -272,12 +272,6 @@ func main() {
 
 	// Start watching config events of interest
 	configurationManagerClient := nspAPI.NewConfigurationManagerClient(nspConn)
-	if err != nil {
-		logger.Error(err, "Failed to create configuration manager client")
-		cancelSignalCtx()
-		return
-	}
-
 	logger.V(1).Info("Watch configuration")
 	err = retry.Do(func() error {
 		vipWatcher, err := configurationManagerClient.WatchVip(signalCtx, &nspAPI.Vip{

--- a/cmd/stateless-lb/main.go
+++ b/cmd/stateless-lb/main.go
@@ -277,7 +277,6 @@ func main() {
 	)
 
 	interfaceMonitorEndpoint := interfacemonitor.NewServer(interfaceMonitor, sns, netUtils)
-	interfaceMonitor.Subscribe(sns) // subscribe to pure netlink events to learn interface delete
 
 	// Note: naming the interface is left to NSM (refer to getNameFromConnection())
 	// However NSM does not seem to ensure uniqueness either. Might need to revisit...
@@ -615,7 +614,7 @@ func (sns *SimpleNetworkService) InterfaceCreated(intf networking.Iface) {
 	}
 	_ = intf.GetName() // fills the Name field of the interface if necessary
 	if _, ok := sns.interfaces.Load(intf.GetIndex()); !ok {
-		sns.logger.Info("InterfaceCreated", "interface", intf) // TODO: the inteface might be already in the map because InterfaceDeleted (likely) won't get called
+		sns.logger.Info("InterfaceCreated", "interface", intf)
 	}
 	if sns.serviceBlocked() {
 		// if service blocked, do not process new interface events (which

--- a/pkg/kernel/bridge.go
+++ b/pkg/kernel/bridge.go
@@ -129,11 +129,13 @@ func (b *Bridge) LinkInterface(intf networking.Iface) error {
 	}
 	interfaceLink, err := getLink(intf)
 	if err != nil {
-		return fmt.Errorf("failed to getLink interface while linking interface (%s): %w", intf.GetNameNoLoad(), err)
+		return fmt.Errorf("failed to getLink interface while linking interface (%s): %w",
+			intf.GetName(networking.WithNoLoad()), err)
 	}
 	err = netlink.LinkSetMaster(interfaceLink, bridgeLink)
 	if err != nil {
-		return fmt.Errorf("failed to LinkSetMaster while linking interface (%s - %s): %w", b.GetName(), intf.GetNameNoLoad(), err)
+		return fmt.Errorf("failed to LinkSetMaster while linking interface (%s - %s): %w",
+			b.GetName(), intf.GetName(networking.WithNoLoad()), err)
 	}
 	return nil
 }
@@ -145,12 +147,14 @@ func (b *Bridge) UnLinkInterface(intf networking.Iface) error {
 	b.removeFromlinkedInterfaces(intf)
 	interfaceLink, err := getLink(intf)
 	if err != nil {
-		return fmt.Errorf("failed to getLink interface while unlinking interface (%s): %w", intf.GetNameNoLoad(), err)
+		return fmt.Errorf("failed to getLink interface while unlinking interface (%s): %w",
+			intf.GetName(networking.WithNoLoad()), err)
 	}
 
 	err = netlink.LinkSetNoMaster(interfaceLink)
 	if err != nil {
-		return fmt.Errorf("failed to LinkSetNoMaster interface while unlinking interface (%s): %w", intf.GetNameNoLoad(), err)
+		return fmt.Errorf("failed to LinkSetNoMaster interface while unlinking interface (%s): %w",
+			intf.GetName(networking.WithNoLoad()), err)
 	}
 
 	return nil

--- a/pkg/kernel/interface.go
+++ b/pkg/kernel/interface.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"reflect"
+	"sort"
 
 	"github.com/nordix/meridio/pkg/networking"
 	"github.com/vishvananda/netlink"
@@ -136,7 +136,35 @@ func (intf *Interface) RemoveLocalPrefix(prefix string) error {
 }
 
 func (intf *Interface) Equals(iface networking.Iface) bool {
-	return reflect.DeepEqual(intf, iface)
+	if intf.index != iface.GetIndex() {
+		return false
+	}
+	if intf.GetInterfaceType() != iface.GetInterfaceType() {
+		return false
+	}
+	return equalStringList(intf.GetLocalPrefixes(), iface.GetLocalPrefixes()) &&
+		equalStringList(intf.GetNeighborPrefixes(), iface.GetNeighborPrefixes()) &&
+		equalStringList(intf.GetGatewayPrefixes(), iface.GetGatewayPrefixes())
+}
+
+func equalStringList(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	tmpa := make([]string, len(a))
+	tmpb := make([]string, len(b))
+	copy(tmpa, tmpa)
+	copy(tmpb, tmpb)
+	sort.Strings(tmpa)
+	sort.Strings(tmpb)
+
+	for i := range tmpa {
+		if tmpa[i] != tmpb[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func NewInterface(index int, options ...InterfaceOption) *Interface {

--- a/pkg/networking/ifaces.go
+++ b/pkg/networking/ifaces.go
@@ -25,10 +25,34 @@ const (
 
 type InterfaceType int
 
+type IfaceNameOptions struct {
+	NoResolve bool
+	NoLoad    bool
+}
+
+type IfaceNameOption func(*IfaceNameOptions)
+
+// WithNoResolve -
+// WithNoResolve implements option pattern for GetName function.
+// Tells not to resolve the interface name if not known.
+func WithNoResolve() IfaceNameOption {
+	return func(in *IfaceNameOptions) {
+		in.NoResolve = true
+	}
+}
+
+// WithNoLoad -
+// WithNoLoad implements option pattern for GetName function.
+// Tells not to load resolved interface name into the Name field of Interface struct.
+func WithNoLoad() IfaceNameOption {
+	return func(in *IfaceNameOptions) {
+		in.NoLoad = true
+	}
+}
+
 type Iface interface {
 	GetIndex() int
-	GetName() string
-	GetNameNoLoad() string
+	GetName(options ...IfaceNameOption) string
 
 	GetLocalPrefixes() []string
 	SetLocalPrefixes(localPrefixes []string)

--- a/pkg/networking/ifaces.go
+++ b/pkg/networking/ifaces.go
@@ -65,6 +65,7 @@ type Bridge interface {
 	LinkInterface(intf Iface) error
 	UnLinkInterface(intf Iface) error
 	InterfaceIsLinked(intf Iface) bool
+	FindLinkedInterfaceByIndex(index int) Iface
 }
 
 type FWMarkRoute interface {

--- a/pkg/nsm/interfacemonitor/server_test.go
+++ b/pkg/nsm/interfacemonitor/server_test.go
@@ -85,7 +85,7 @@ type ifaceMock struct {
 	name string
 }
 
-func (im *ifaceMock) GetName() string {
+func (im *ifaceMock) GetName(options ...networking.IfaceNameOption) string {
 	return im.name
 }
 


### PR DESCRIPTION
## Description
The so called nsm interfaceMonitor that is used by the Proxy for both its NSC and NSE connections from now on
forwards kernel originated interface delete events. This allows the Proxy to clean-up even if the network interface was no longer available by the time the associated NSM connection got closed.
(Thus, nexthop routes towards LBs can be removed in such cases.)

Note: Order of IP addresses in the IPContext might change between periodic NSM connection refreshes. Therefore, networking.Iface items must be compared by taking the above into consideration.

## Issue link
#517 

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
