### PR TITLE
NSM Request and API client improvements

### DIFF
--- a/cmd/ipam/config.go
+++ b/cmd/ipam/config.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2024 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -32,7 +33,7 @@ type Config struct {
 	NodePrefixLengthIPv6    int           `default:"64" desc:"node prefix length which will be allocated" envconfig:"node_prefix_length_ipv6"`
 	IPFamily                string        `default:"dualstack" desc:"ip family" envconfig:"ip_family"`
 	LogLevel                string        `default:"DEBUG" desc:"Log level" split_words:"true"`
-	GRPCKeepaliveTime       time.Duration `default:"30s" desc:"gRPC keepalive timeout"`
+	GRPCKeepaliveTime       time.Duration `default:"30s" desc:"gRPC keepalive timeout" envconfig:"grpc_keepalive_time"`
 	GRPCProbeRPCTimeout     time.Duration `default:"1s" desc:"RPC timeout of internal gRPC health probe" envconfig:"grpc_probe_rpc_timeout"`
 	GRPCMaxBackoff          time.Duration `default:"5s" desc:"Upper bound on gRPC connection backoff delay" envconfig:"grpc_max_backoff"`
 }

--- a/cmd/proxy/internal/config/config.go
+++ b/cmd/proxy/internal/config/config.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2024 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -42,7 +43,7 @@ type Config struct {
 	IPFamily            string        `default:"dualstack" desc:"ip family" envconfig:"ip_family"`
 	LogLevel            string        `default:"DEBUG" desc:"Log level" split_words:"true"`
 	MTU                 int           `default:"1500" desc:"Conduit MTU considered by local NSCs and NSE composing the network mesh" split_words:"true"`
-	GRPCKeepaliveTime   time.Duration `default:"30s" desc:"gRPC keepalive timeout"`
+	GRPCKeepaliveTime   time.Duration `default:"30s" desc:"gRPC keepalive timeout" envconfig:"grpc_keepalive_time"`
 	GRPCProbeRPCTimeout time.Duration `default:"1s" desc:"RPC timeout of internal gRPC health probe" envconfig:"grpc_probe_rpc_timeout"`
 	GRPCMaxBackoff      time.Duration `default:"5s" desc:"Upper bound on gRPC connection backoff delay" envconfig:"grpc_max_backoff"`
 	IPReleaseDelay      time.Duration `default:"20s" desc:"delay releasing IP address of NSM connection" envconfig:"ip_release_delay"`

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021-2023 Nordix Foundation
+Copyright (c) 2024 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -221,6 +222,7 @@ func main() {
 		DialTimeout:      config.DialTimeout,
 		RequestTimeout:   config.RequestTimeout,
 		MaxTokenLifetime: config.MaxTokenLifetime,
+		GRPCMaxBackoff:   config.GRPCMaxBackoff,
 	}
 	nsmAPIClient := nsm.NewAPIClient(ctx, apiClientConfig)
 	defer nsmAPIClient.Delete()

--- a/cmd/stateless-lb/main.go
+++ b/cmd/stateless-lb/main.go
@@ -251,6 +251,10 @@ func main() {
 			s.Stop() // graceful shutdown not finished in time, force stop immediately
 		case <-stopped:
 			waitTimer.Stop()
+			select {
+			case <-waitTimer.C:
+			default:
+			}
 		}
 	}()
 	// announces forwarding availability of streams (i.e. if the LB can forward traffic towards application targets)

--- a/cmd/stateless-lb/main.go
+++ b/cmd/stateless-lb/main.go
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2021-2024 Nordix Foundation
+Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2024 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -303,6 +304,7 @@ func main() {
 		DialTimeout:      config.DialTimeout,
 		RequestTimeout:   config.RequestTimeout,
 		MaxTokenLifetime: config.MaxTokenLifetime,
+		GRPCMaxBackoff:   config.GRPCMaxBackoff,
 	}
 	nsmAPIClient := nsm.NewAPIClient(context.Background(), apiClientConfig) // background context to allow endpoint unregistration on tear down
 	defer nsmAPIClient.Delete()

--- a/cmd/tapa/main.go
+++ b/cmd/tapa/main.go
@@ -196,6 +196,7 @@ func main() {
 		config.NSPServicePort,
 		config.NSPEntryTimeout,
 		config.GRPCMaxBackoff,
+		config.Timeout,
 		netUtils,
 	)
 	if err != nil {

--- a/cmd/tapa/main.go
+++ b/cmd/tapa/main.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2024 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -141,6 +142,7 @@ func main() {
 		DialTimeout:      config.DialTimeout,
 		RequestTimeout:   config.Timeout,
 		MaxTokenLifetime: config.MaxTokenLifetime,
+		GRPCMaxBackoff:   config.GRPCMaxBackoff,
 	}
 	nsmAPIClient := nsm.NewAPIClient(ctx, apiClientConfig)
 	defer nsmAPIClient.Delete()

--- a/docs/components/ipam.md
+++ b/docs/components/ipam.md
@@ -49,6 +49,9 @@ IPAM_CONDUIT_PREFIX_LENGTH_IPV6 | int | Conduit prefix length which will be allo
 IPAM_NODE_PREFIX_LENGTH_IPV6 | int | node prefix length which will be allocated | 64
 IPAM_IP_FAMILY | string | IP family (ipv4, ipv6, dualstack) | dualstack
 IPAM_LOG_LEVEL | string | Log level (TRACE, DEBUG, INFO, WARNING, ERROR, FATAL, PANIC) | DEBUG
+IPAM_GRPC_KEEPALIVE_TIME | time.Duration | gRPC keepalive timeout | 30s
+IPAM_GRPC_PROBE_RPC_TIMEOUT | time.Duration | RPC timeout of internal gRPC health probe | 1s
+IPAM_GRPC_MAX_BACKOFF | time.Duration | Upper bound on gRPC connection backoff delay | 5s
 
 ## Command Line 
 

--- a/docs/components/nsp.md
+++ b/docs/components/nsp.md
@@ -40,6 +40,8 @@ NSM_PORT | string | Trench the pod is running on | 7778
 NSM_CONFIG_MAP_NAME | string | Name of the ConfigMap containing the configuration | meridio-configuration
 NSM_DATASOURCE | string | Path and file name of the sqlite database | /run/nsp/data/registry.db
 NSM_LOG_LEVEL | string | Log level | DEBUG
+NSM_ENTRY_TIMEOUT | time.Duration | Timeout of the entries | 60s
+NSM_GRPC_PROBE_RPC_TIMEOUT | time.Duration | RPC timeout of internal gRPC health probe | 1s
 
 ## Command Line 
 

--- a/docs/components/proxy.md
+++ b/docs/components/proxy.md
@@ -39,6 +39,11 @@ NSM_NSP_SERVICE_NAME | string | IP (or domain) of the NSP Service | nsp-service
 NSM_NSP_SERVICE_PORT | int | port of the NSP Service | 7778
 NSM_IP_FAMILY | string | ip family | dualstack
 NSM_LOG_LEVEL | string | Log level | DEBUG
+NSM_MTU | int | Conduit MTU | 1500
+NSM_GRPC_KEEPALIVE_TIME | time.Duration | gRPC keepalive timeout | 30s
+NSM_GRPC_PROBE_RPC_TIMEOUT | time.Duration | RPC timeout of internal gRPC health probe | 1s
+NSM_GRPC_MAX_BACKOFF | time.Duration | Upper bound on gRPC connection backoff delay | 5s
+NSM_IP_RELEASE_DELAY | time.Duration | delay releasing IP address of NSM connection | 20s
 
 ## Command Line 
 

--- a/pkg/loadbalancer/stream/loadbalancer.go
+++ b/pkg/loadbalancer/stream/loadbalancer.go
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2021-2024 Nordix Foundation
+Copyright (c) 2021-2023 Nordix Foundation
+Copyright (c) 2024 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -480,6 +481,8 @@ func (lb *LoadBalancer) setTargets(targets []*nspAPI.Target) error {
 }
 
 // TODO: revisit if timeout based periodic check can be removed
+// TODO: Would be nice if a Target was not unconfigured in nfqlb upon
+// "Interface replaced during interface create event"
 func (lb *LoadBalancer) processPendingTargets(ctx context.Context) {
 	checkf := func() {
 		lb.mu.Lock()

--- a/pkg/nsm/config.go
+++ b/pkg/nsm/config.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2024 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,6 +30,7 @@ type Config struct {
 	DialTimeout      time.Duration
 	RequestTimeout   time.Duration
 	MaxTokenLifetime time.Duration
+	GRPCMaxBackoff   time.Duration
 }
 
 // IsValid checks if the configuration is valid


### PR DESCRIPTION
## Description
- Use environment variable Timeout to control NSM Request timeout in TAPA.
- Use GRPCMaxBackoff in nsmAPIClient as well to control max backoff in case of NSM Requests and such.
  (By limiting max backoff NSM related operation might succeed earlier for example after an NSMgr outage.)
- Timer resource clean-up improvements.

## Issue link
N/A

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [X] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [X] No
