### PR TITLE
ipam; introduce garbage collection logic

### DIFF
--- a/cmd/ipam/config.go
+++ b/cmd/ipam/config.go
@@ -21,19 +21,22 @@ import "time"
 
 // Config for the ipam
 type Config struct {
-	Port                    int           `default:"7777" desc:"Trench the pod is running on" split_words:"true"`
-	Datasource              string        `default:"/run/ipam/data/registry.db" desc:"Path and file name of the sqlite database" split_words:"true"`
-	TrenchName              string        `default:"default" desc:"Trench the pod is running on" split_words:"true"`
-	NSPService              string        `default:"nsp-service:7778" desc:"IP (or domain) and port of the NSP Service" split_words:"true"`
-	PrefixIPv4              string        `default:"169.255.0.0/16" desc:"ipv4 prefix from which the proxy prefixes will be allocated" envconfig:"prefix_ipv4"`
-	ConduitPrefixLengthIPv4 int           `default:"20" desc:"conduit prefix length which will be allocated" envconfig:"conduit_prefix_length_ipv4"`
-	NodePrefixLengthIPv4    int           `default:"24" desc:"node prefix length which will be allocated" envconfig:"node_prefix_length_ipv4"`
-	PrefixIPv6              string        `default:"fd00::/48" desc:"ipv4 prefix from which the proxy prefixes will be allocated" envconfig:"prefix_ipv6"`
-	ConduitPrefixLengthIPv6 int           `default:"56" desc:"conduit prefix length which will be allocated" envconfig:"conduit_prefix_length_ipv6"`
-	NodePrefixLengthIPv6    int           `default:"64" desc:"node prefix length which will be allocated" envconfig:"node_prefix_length_ipv6"`
-	IPFamily                string        `default:"dualstack" desc:"ip family" envconfig:"ip_family"`
-	LogLevel                string        `default:"DEBUG" desc:"Log level" split_words:"true"`
-	GRPCKeepaliveTime       time.Duration `default:"30s" desc:"gRPC keepalive timeout" envconfig:"grpc_keepalive_time"`
-	GRPCProbeRPCTimeout     time.Duration `default:"1s" desc:"RPC timeout of internal gRPC health probe" envconfig:"grpc_probe_rpc_timeout"`
-	GRPCMaxBackoff          time.Duration `default:"5s" desc:"Upper bound on gRPC connection backoff delay" envconfig:"grpc_max_backoff"`
+	Port                       int           `default:"7777" desc:"Trench the pod is running on" split_words:"true"`
+	Datasource                 string        `default:"/run/ipam/data/registry.db" desc:"Path and file name of the sqlite database" split_words:"true"`
+	TrenchName                 string        `default:"default" desc:"Trench the pod is running on" split_words:"true"`
+	NSPService                 string        `default:"nsp-service:7778" desc:"IP (or domain) and port of the NSP Service" split_words:"true"`
+	PrefixIPv4                 string        `default:"169.255.0.0/16" desc:"ipv4 prefix from which the proxy prefixes will be allocated" envconfig:"prefix_ipv4"`
+	ConduitPrefixLengthIPv4    int           `default:"20" desc:"conduit prefix length which will be allocated" envconfig:"conduit_prefix_length_ipv4"`
+	NodePrefixLengthIPv4       int           `default:"24" desc:"node prefix length which will be allocated" envconfig:"node_prefix_length_ipv4"`
+	PrefixIPv6                 string        `default:"fd00::/48" desc:"ipv4 prefix from which the proxy prefixes will be allocated" envconfig:"prefix_ipv6"`
+	ConduitPrefixLengthIPv6    int           `default:"56" desc:"conduit prefix length which will be allocated" envconfig:"conduit_prefix_length_ipv6"`
+	NodePrefixLengthIPv6       int           `default:"64" desc:"node prefix length which will be allocated" envconfig:"node_prefix_length_ipv6"`
+	IPFamily                   string        `default:"dualstack" desc:"ip family" envconfig:"ip_family"`
+	LogLevel                   string        `default:"DEBUG" desc:"Log level" split_words:"true"`
+	GRPCKeepaliveTime          time.Duration `default:"30s" desc:"gRPC keepalive timeout" envconfig:"grpc_keepalive_time"`
+	GRPCProbeRPCTimeout        time.Duration `default:"1s" desc:"RPC timeout of internal gRPC health probe" envconfig:"grpc_probe_rpc_timeout"`
+	GRPCMaxBackoff             time.Duration `default:"5s" desc:"Upper bound on gRPC connection backoff delay" envconfig:"grpc_max_backoff"`
+	GarbageCollectionEnabled   bool          `default:"true" desc:"IP garbage collection enabled or disabled" split_words:"true"`
+	GarbageCollectionInterval  time.Duration `default:"2h" desc:"Interval at which IP garbage collection is running" split_words:"true"`
+	GarbageCollectionThreshold time.Duration `default:"40m" desc:"IP record older than threshold is considered leftover" split_words:"true"`
 }

--- a/cmd/ipam/main.go
+++ b/cmd/ipam/main.go
@@ -103,6 +103,9 @@ func main() {
 
 	// create and start health server
 	ctx = health.CreateChecker(ctx)
+	if err := health.RegisterStartupSubservices(ctx); err != nil {
+		logger.Error(err, "RegisterStartupSubservices")
+	}
 	if err := health.RegisterReadinessSubservices(ctx, health.IPAMReadinessServices...); err != nil {
 		logger.Error(err, "RegisterReadinessSubservices")
 	}

--- a/cmd/ipam/main.go
+++ b/cmd/ipam/main.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021-2023 Nordix Foundation
+Copyright (c) 2024 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -157,7 +158,16 @@ func main() {
 
 	// cteate IPAM server
 	ipamServer, err := ipam.NewServer(
-		ctx, config.Datasource, config.TrenchName, conn, cidrs, prefixLengths)
+		ctx,
+		config.Datasource,
+		config.TrenchName,
+		conn,
+		cidrs,
+		prefixLengths,
+		config.GarbageCollectionEnabled,
+		config.GarbageCollectionInterval,
+		config.GarbageCollectionThreshold,
+	)
 	if err != nil {
 		logger.Error(err, "Unable to create ipam server")
 	}

--- a/config/templates/charts/meridio/deployment/ipam.yaml
+++ b/config/templates/charts/meridio/deployment/ipam.yaml
@@ -31,7 +31,7 @@ spec:
               command:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
-                - -service=
+                - -service=Startup
                 - -connect-timeout=400ms
                 - -rpc-timeout=400ms
             initialDelaySeconds: 0

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -64,6 +64,8 @@ ipam:
       service: "Readiness"
     liveness:
       service: "Liveness"
+    startup:
+      service: "Startup"
 
 nsp:
   image: nsp

--- a/docs/components/ipam.md
+++ b/docs/components/ipam.md
@@ -52,6 +52,9 @@ IPAM_LOG_LEVEL | string | Log level (TRACE, DEBUG, INFO, WARNING, ERROR, FATAL, 
 IPAM_GRPC_KEEPALIVE_TIME | time.Duration | gRPC keepalive timeout | 30s
 IPAM_GRPC_PROBE_RPC_TIMEOUT | time.Duration | RPC timeout of internal gRPC health probe | 1s
 IPAM_GRPC_MAX_BACKOFF | time.Duration | Upper bound on gRPC connection backoff delay | 5s
+IPAM_GARBAGE_COLLECTION_ENABLED | bool | IP garbage collection enabled or disabled | true
+IPAM_GARBAGE_COLLECTION_INTERVAL | time.Duration | Interval at which IP garbage collection is running | 2h
+IPAM_GARBAGE_COLLECTION_THRESHOLD | time.Duration | IP record older than threshold is considered leftover | 40m
 
 ## Command Line 
 

--- a/docs/components/ipam.md
+++ b/docs/components/ipam.md
@@ -83,6 +83,7 @@ Service | Description
 --- | ---
 Liveness | A unique service to be used by liveness probe to return status, can aggregate other lesser services
 Readiness | A unique service to be used by readiness probe to return status, can aggregate other lesser services
+Startup | A unique service to be used by startup probe to return status, can aggregate other lesser services
 
 Service | Probe | Description
 --- | --- | ---

--- a/pkg/controllers/trench/ipam.go
+++ b/pkg/controllers/trench/ipam.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2024 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -106,15 +107,15 @@ func (i *IpamStatefulSet) insertParameters(dep *appsv1.StatefulSet) *appsv1.Stat
 			}
 			if container.StartupProbe == nil {
 				container.StartupProbe = common.GetProbe(common.StartUpTimer,
-					common.GetProbeCommand(false, "unix:///tmp/health.sock", ""))
+					common.GetProbeCommand(false, "unix:///tmp/health.sock", "Startup"))
 			}
 			if container.ReadinessProbe == nil {
 				container.ReadinessProbe = common.GetProbe(common.ReadinessTimer,
-					common.GetProbeCommand(true, fmt.Sprintf(":%d", common.IpamPort), ""))
+					common.GetProbeCommand(false, "unix:///tmp/health.sock", "Readiness"))
 			}
 			if container.LivenessProbe == nil {
 				container.LivenessProbe = common.GetProbe(common.LivenessTimer,
-					common.GetProbeCommand(false, "unix:///tmp/health.sock", ""))
+					common.GetProbeCommand(false, "unix:///tmp/health.sock", "Liveness"))
 			}
 			container.Env = i.getEnvVars(ret.Spec.Template.Spec.Containers[0].Env)
 			// set resource requirements for container (if not found, then values from model

--- a/pkg/ipam/node/node.go
+++ b/pkg/ipam/node/node.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2024 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -59,6 +60,11 @@ func (n *Node) Allocate(ctx context.Context, name string) (types.Prefix, error) 
 		p, err = prefix.AllocateWithBlocklist(ctx, n, name, n.PrefixLengths.ChildLength, n.Store, blocklist)
 		if err != nil {
 			return nil, fmt.Errorf("failed to AllocateWithBlocklist (%s) while allocating in node prefix (%s): %w", name, n.GetName(), err)
+		}
+	} else {
+		// Refresh the entry's updatedAt timestamp in storage
+		if err = n.Store.Update(ctx, p); err != nil {
+			return nil, fmt.Errorf("failed to update (%s) while allocating in node prefix (%s): %w", name, n.GetName(), err)
 		}
 	}
 	return p, nil

--- a/pkg/ipam/storage/logger/logger.go
+++ b/pkg/ipam/storage/logger/logger.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2024 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -38,6 +39,20 @@ func (s *Store) Add(ctx context.Context, prefix types.Prefix) error {
 	}
 	if prefix != nil {
 		log.FromContextOrGlobal(ctx).Info("Add", "Name", prefix.GetName(), "Cidr", prefix.GetCidr())
+	}
+	return nil
+}
+
+func (s *Store) Update(ctx context.Context, prefix types.Prefix) error {
+	err := s.Store.Update(ctx, prefix)
+	if err != nil {
+		if prefix != nil {
+			log.FromContextOrGlobal(ctx).Error(err, "Update", "Name", prefix.GetName(), "Cidr", prefix.GetCidr())
+		}
+		return err
+	}
+	if prefix != nil {
+		log.FromContextOrGlobal(ctx).V(2).Info("Update", "Name", prefix.GetName(), "Cidr", prefix.GetCidr())
 	}
 	return nil
 }

--- a/pkg/ipam/storage/memory/memory.go
+++ b/pkg/ipam/storage/memory/memory.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2024 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -49,6 +50,10 @@ func (mis *MemoryIPAMStorage) Add(ctx context.Context, prefix types.Prefix) erro
 	}
 	mis.prefixes = append(mis.prefixes, prefix)
 	return nil
+}
+
+func (mis *MemoryIPAMStorage) Update(ctx context.Context, prefix types.Prefix) error {
+	return nil // maintain baseline functionality
 }
 
 func (mis *MemoryIPAMStorage) Delete(ctx context.Context, prefix types.Prefix) error {

--- a/pkg/ipam/storage/sqlite/context.go
+++ b/pkg/ipam/storage/sqlite/context.go
@@ -1,0 +1,41 @@
+/*
+Copyright (c) 2024 OpenInfra Foundation Europe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqlite
+
+import "context"
+
+const (
+	lifetimeKey contextKeyType = "expirable"
+)
+
+type contextKeyType string
+
+// WithExpirable -
+// Stores in context whether the sqlite record must be expirable
+func WithExpirable(parent context.Context) context.Context {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithValue(parent, lifetimeKey, struct{}{})
+}
+
+// Expirable -
+// Returns from context if sqlite record is expirable
+func Expirable(ctx context.Context) bool {
+	_, ok := ctx.Value(lifetimeKey).(struct{})
+	return ok
+}

--- a/pkg/ipam/storage/sqlite/model.go
+++ b/pkg/ipam/storage/sqlite/model.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2024 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,17 +19,20 @@ package sqlite
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/nordix/meridio/pkg/ipam/prefix"
 	"github.com/nordix/meridio/pkg/ipam/types"
 )
 
 type Prefix struct {
-	Id       string `gorm:"primaryKey"`
-	Name     string
-	Cidr     string
-	ParentID string
-	Parent   *Prefix
+	Id        string `gorm:"primaryKey"`
+	Name      string `gorm:"index"` // supposedly indexing could improve query performance
+	Cidr      string
+	ParentID  string `gorm:"index"`
+	Parent    *Prefix
+	UpdatedAt time.Time `gorm:"index"`               // supposedly indexing could improve query performance
+	Expirable *bool     `gorm:"index;default:false"` // indicates whether prefix can expire and thus be subject to garbage collection
 }
 
 func modelToPrefix(p *Prefix, parent types.Prefix) types.Prefix {

--- a/pkg/ipam/storage/sqlite/sqlite.go
+++ b/pkg/ipam/storage/sqlite/sqlite.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2024 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,13 +22,17 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/nordix/meridio/pkg/ipam/prefix"
 	"github.com/nordix/meridio/pkg/ipam/types"
+	"github.com/nordix/meridio/pkg/log"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
+
+const bridgeName = "bridge" // prefix with name "bridge" is special because it's not periodically updated
 
 type SQLiteIPAMStorage struct {
 	DB *gorm.DB
@@ -36,7 +41,8 @@ type SQLiteIPAMStorage struct {
 
 func New(datastore string) (*SQLiteIPAMStorage, error) {
 	db, err := gorm.Open(sqlite.Open(datastore), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
+		Logger:  logger.Default.LogMode(logger.Silent),
+		NowFunc: func() time.Time { return time.Now().UTC() },
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to open db session: %w", err)
@@ -51,6 +57,115 @@ func New(datastore string) (*SQLiteIPAMStorage, error) {
 	return sqlis, nil
 }
 
+// StartGarbageCollector -
+// StartGarbageCollector periodically runs a garbage collector to clean up
+// outdated expirable records with valid updatedAt values (where threshold
+// determines what is considered outdated).
+func (sqlis *SQLiteIPAMStorage) StartGarbageCollector(ctx context.Context, interval time.Duration, threshold time.Duration) {
+	go func() {
+		log.Logger.Info("Start Garbage Collector")
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		/*
+			initialDelay := 1 * time.Minute
+			timer := time.NewTimer(initialDelay)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				timer.Stop()
+				select {
+				case <-timer.C:
+				default:
+				}
+				return
+			} */
+
+		// Run the periodic task
+		for {
+			select {
+			case <-ctx.Done():
+				return // Exit the goroutine when the stop signal is received
+			case <-ticker.C:
+				if err := sqlis.garbageCollector(ctx, threshold); err != nil {
+					log.Logger.Info("Garbage collector returned error", "err", err)
+				}
+			}
+		}
+	}()
+}
+
+// Fetch and delete expirable prefixes whose updatedAt timestamp is considered
+// expired according to the threshold (i.e. was not updated for a long time).
+// Note: Even though records are processed in batches, no need to use offsets
+// or pagination, because matching records are to be deleted. Thus, eventually
+// there will be no more database records matching the query criteria (no risk
+// of infinite loop).
+func (sqlis *SQLiteIPAMStorage) garbageCollector(ctx context.Context, threshold time.Duration) error {
+	// Define the batch size
+	batchSize := 50
+	logger := log.Logger.WithValues("func", "garbageCollector")
+	sqlis.mu.Lock()
+	defer sqlis.mu.Unlock()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			// Start a transaction for batch deletion
+			// Note: It's not really expected to have a huge table, yet batch
+			// processing approach was chosen.
+			// Note: Preferred printing entries to be deleted, hence the two
+			// separate actions to fetch and then delete entries.
+			tx := sqlis.DB.Begin()
+			if tx.Error != nil {
+				return tx.Error
+			}
+			entryThreshHold := time.Now().UTC().Add(-threshold)
+
+			// Fetch entries to be deleted
+			var deleteEntries []Prefix
+			if err := tx.Where("expirable = true AND (updated_at IS NOT NULL AND updated_at != ? AND updated_at < ?) AND name != ?",
+				time.Time{}, entryThreshHold, bridgeName).Limit(batchSize).Find(&deleteEntries).Error; err != nil {
+				tx.Rollback()
+				return err
+			}
+
+			// No more entries to delete
+			if len(deleteEntries) == 0 {
+				tx.Rollback()
+				return nil
+			}
+
+			// Delete the fetched entries
+			idsToDelete := make([]string, len(deleteEntries))
+			for i, entry := range deleteEntries {
+				logger.V(1).Info("Delete prefix", "prefix", entry)
+				idsToDelete[i] = entry.Id
+			}
+
+			if err := tx.Where("id IN ?", idsToDelete).Delete(&Prefix{}).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					logger.Info("Prefix to delete not found", "err", err)
+				} else {
+					tx.Rollback()
+					return err
+				}
+			}
+
+			// Commit the transaction
+			if err := tx.Commit().Error; err != nil {
+				return err
+			}
+
+			logger.Info("Deleted prefixes in transaction", "count", len(idsToDelete))
+		}
+	}
+}
+
+// Add adds prefix to database.
+// Also sets the expirable field based on the context.
 func (sqlis *SQLiteIPAMStorage) Add(ctx context.Context, prefix types.Prefix) error {
 	sqlis.mu.Lock()
 	defer sqlis.mu.Unlock()
@@ -58,7 +173,36 @@ func (sqlis *SQLiteIPAMStorage) Add(ctx context.Context, prefix types.Prefix) er
 	if model == nil {
 		return nil
 	}
+	exp := false
+	if prefix.GetName() != bridgeName && Expirable(ctx) {
+		exp = true
+	}
+	model.Expirable = &exp
 	tx := sqlis.DB.Create(model)
+	return tx.Error
+}
+
+// Update -
+// Updates or add the database entry.
+// Currently, the whole purpose of this function is to update the UpdatedAt
+// field in the database that is used by garbage collector logic to clean up
+// unused entries that haven't been updated for a long time. And to keep the
+// expirable field set for records that can expire based on the context. (GORM
+// Save() considers unset entries as well to update the record, thus expirable
+// field must be set to either false or true.)
+func (sqlis *SQLiteIPAMStorage) Update(ctx context.Context, prefix types.Prefix) error {
+	sqlis.mu.Lock()
+	defer sqlis.mu.Unlock()
+	model := prefixToModel(prefix)
+	if model == nil {
+		return nil
+	}
+	exp := false
+	if prefix.GetName() != bridgeName && Expirable(ctx) {
+		exp = true
+	}
+	model.Expirable = &exp
+	tx := sqlis.DB.Save(model)
 	return tx.Error
 }
 
@@ -71,6 +215,8 @@ func (sqlis *SQLiteIPAMStorage) Delete(ctx context.Context, prefix types.Prefix)
 	return sqlis.delete(prefix)
 }
 
+// Get finds and returns the first database record matching the given prefix.
+// Note: default or unset fields are ignored by the GORM query
 func (sqlis *SQLiteIPAMStorage) Get(ctx context.Context, name string, parent types.Prefix) (types.Prefix, error) {
 	sqlis.mu.Lock()
 	defer sqlis.mu.Unlock()
@@ -94,10 +240,22 @@ func (sqlis *SQLiteIPAMStorage) GetChilds(ctx context.Context, prefix types.Pref
 	return sqlis.getChilds(prefix)
 }
 
+// Note: When a new column is added to an existing table using AutoMigrate(),
+// then by default the DB initializes this column to the 'nul' value depending
+// on the type for all existing records. The default value to be used can be
+// also specified via the gorm tag 'default'.
 func (sqlis *SQLiteIPAMStorage) init() error {
 	err := sqlis.DB.AutoMigrate(&Prefix{})
 	if err != nil {
 		return fmt.Errorf("failed to automigrate: %w", err)
+	}
+	// Manually set expirable field for any old connection prefixes
+	// Note: should not block for too long to avoid risking startup/liveness
+	// issues depending on the probe configuration
+	if err = sqlis.migrate(context.TODO()); err != nil {
+		// Note: No need to return an error. Worst case any old unused prefixes
+		// will remain.
+		log.Logger.Info("Could not migrate old prefxies", "err", err)
 	}
 	return nil
 }
@@ -137,4 +295,131 @@ func (sqlis *SQLiteIPAMStorage) delete(prefix types.Prefix) error {
 	model := prefixToModel(prefix)
 	tx := sqlis.DB.Delete(model)
 	return tx.Error
+}
+
+// Migrate aims to find prefixes assocaited with connections but created based
+// on the old model (before the introduction of the garbage collector).
+// Lookup exploits the hierarchy among prefixes of trenches, conduits, worker
+// conduits, and connections to identify the connections.
+// Old connection prefixes are then updated by setting their expirable fields
+// to true, along with implicitly updating their updated_at fields. This way,
+// old leaked connection prefixes could be also reaped by the garbage collector
+// logic.
+// Note: bridge prefixes cannot expire currently
+// Note: custom update of old prefixes will set the updated_at fields
+func (sqlis *SQLiteIPAMStorage) migrate(ctx context.Context) error {
+	var trenchIds []string
+	var conduitIds []string
+	var workerConduitIds []string
+	var err error
+	batchSize := 50
+	logger := log.Logger.WithValues("func", "migrate")
+
+	findPrefixIds := func(ctx context.Context, query interface{}, args ...interface{}) ([]string, error) {
+		var prefixIds []string
+		logger.V(1).Info("Find prefixes", "query", query, "args", args)
+		select {
+		case <-ctx.Done():
+			return prefixIds, nil
+		default:
+			var prefixes []Prefix
+			// Fetch all prefixes matching the query in one attempt
+			if err := sqlis.DB.Where(query, args...).Find(&prefixes).Error; err != nil {
+				return nil, err
+			}
+
+			// No matching prefixes in the database
+			if len(prefixes) == 0 {
+				return nil, nil
+			}
+
+			// Save IDs of returned prefixes to return once finished
+			for _, prefix := range prefixes {
+				prefixIds = append(prefixIds, prefix.Id)
+			}
+		}
+		return prefixIds, nil
+	}
+
+	sqlis.mu.Lock()
+	defer sqlis.mu.Unlock()
+
+	// Get Trench IDs based on their characteristics not having a parent
+	trenchIds, err = findPrefixIds(ctx, "parent_id = ?", "")
+	if err != nil || len(trenchIds) == 0 {
+		logger.V(1).Info("No Trench IDs retrived", "err", err)
+		return err
+	}
+	logger.Info("Retrieved Trenches", "IDs", trenchIds)
+
+	// Get Conduit IDs by parent ID (which should be a trench ID)
+	conduitIds, err = findPrefixIds(ctx, "parent_id IN ?", trenchIds)
+	if err != nil || len(conduitIds) == 0 {
+		logger.V(1).Info("No Conduit IDs retrieved", "err", err)
+		return err
+	}
+	logger.Info("Retrieved Conduits", "IDs", conduitIds)
+
+	// Get Worker Conduit IDs by parent ID (which should be a Conduit ID)
+	workerConduitIds, err = findPrefixIds(ctx, "parent_id IN ?", conduitIds)
+	if err != nil || len(workerConduitIds) == 0 {
+		logger.V(1).Info("No worker Conduit IDs retrieved", "err", err)
+		return err
+	}
+	logger.Info("Retrieved worker Conduits", "IDs", workerConduitIds)
+
+	// Update records with parent IDs matching any of the Worker Conduit IDs
+	// to reflect such records can expire and thus can be subject to garbage
+	// collection.
+	// Note: Even though records are processed in batches, no need use offsets
+	// or pagination, because matching entries are to be updated. Thus, there
+	// will be eventually no more records matching the query criteria.
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			tx := sqlis.DB.Begin()
+			if tx.Error != nil {
+				return tx.Error
+			}
+
+			// Get prefixes created according to the old model whose parent ID
+			// is among the Worker Conduit IDs.
+			// Note: expirable field is not expected to be NULL due to the tag
+			// setting a default value false, but better safe than sorry
+			var updateEntries []Prefix
+			if err := tx.Where("(expirable IS NULL OR expirable = false) AND name != ? AND parent_id IN ?",
+				bridgeName, workerConduitIds).Limit(batchSize).Find(&updateEntries).Error; err != nil {
+				tx.Rollback()
+				return err
+			}
+
+			// No more prefixes to update
+			if len(updateEntries) == 0 {
+				tx.Rollback()
+				return nil
+			}
+
+			// Update old connection prefixes by setting their expirable field
+			// to true, so that the garbage collector apply to them as well.
+			// Note: This shall also update the updated_at field.
+			for _, entry := range updateEntries {
+				logger.V(1).Info("Update prefix", "entry", entry)
+				exp := true
+				entry.Expirable = &exp
+				if err := tx.Save(entry).Error; err != nil {
+					tx.Rollback()
+					return err
+				}
+			}
+
+			// Commit the transaction
+			if err := tx.Commit().Error; err != nil {
+				return err
+			}
+
+			logger.Info("Updated prefixes in transaction", "count", len(updateEntries))
+		}
+	}
 }

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021 Nordix Foundation
+Copyright (c) 2024 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -46,6 +47,7 @@ type Prefix interface {
 
 type Storage interface {
 	Add(ctx context.Context, prefix Prefix) error
+	Update(ctx context.Context, prefix Prefix) error
 	Delete(ctx context.Context, prefix Prefix) error
 	Get(ctx context.Context, name string, parent Prefix) (Prefix, error)
 	GetChilds(ctx context.Context, prefix Prefix) ([]Prefix, error)


### PR DESCRIPTION
## Description
Introduced garbage collection logic in IPAM to clean up IP records not updated for a long time and hence considered not in use anymore by any NSM connections.

For this the database model has been extended with UpdatedAt (timestamp) and Expirable (*bool) fields. UpdatedAt is used by newly introduced garbage collector logic along with a threshold time to determine if a record can be removed. While Expirable limits the scope of database records the garbage collector mechanism applies to. The check is run periodically. Both the threshold and periodicity interval are configurable through environment variables (IPAM_GARBAGE_COLLECTION_THRESHOLD and IPAM_GARBAGE_COLLECTION_INTERVAL).

As part of the changes node allocations do update existing database records to keep UpdatedAt values up to date.

The logic takes only records that belong to an NSM connection into consideration. This is achieved by means of applying a filter matching records whose Expirable field is true denoting NSM connection related entries. (For other allocations the IPAM is not consulted periodically.)

The model update re-uses the old database table extending it with UpdatedAt and Expirable columns. In case of rollback the excess columns are simply ignored by the "framework" without causing any harm.
When moving from a version using the old model to the new model, then automigrate won't set UpdatedAt values for existing records. However, a default false value is configured for Expirable which will be set for all records after automigrate. A custom migrate function takes care of the update of existing connection records setting their Expirable and UpdatedAt values, allowing them to be subject to the garbage collection mechanism.

In order to limit API changes the value of Expirable field is signalled via the context. Also, to avoid upgrade issues IPAM
gRPC proto haven't been extended (to allow IPAM users to chose if their allocation could expire).

The garbage collection (by default enabled) can be disabled through environment variable IPAM_GARBAGE_COLLECTION_ENABLED.

Notes:
IPAM_GARBAGE_COLLECTION_INTERVAL also determines when the garbage collector will be first invoked. Thus, setting it to a low value must be avoided to allow existing NSM connections to get their IP allocations refreshed as part of the recurring NSM connection refresh which is tied to NSM's MaxTokenLifetime (e.g. during IPAM upgrade/failover).
IPAM_GARBAGE_COLLECTION_THRESHOLD must be higher than NSM's MaxTokenLifetime.

## Issue link
#527 

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
