### PR TITLE
Set dialtimeout for NS/NSE registry clients

### DIFF
--- a/pkg/nsm/client.go
+++ b/pkg/nsm/client.go
@@ -87,6 +87,7 @@ func (apiClient *APIClient) setNetworkServiceEndpointRegistryClient() {
 	apiClient.NetworkServiceEndpointRegistryClient = registryclient.NewNetworkServiceEndpointRegistryClient(
 		apiClient.context,
 		registryclient.WithClientURL(&apiClient.Config.ConnectTo),
+		registryclient.WithDialTimeout(apiClient.Config.DialTimeout),
 		registryclient.WithDialOptions(clientOptions...),
 		registryclient.WithNSEAdditionalFunctionality(
 			expirationtime.NewNetworkServiceEndpointRegistryClient(time.Minute), // keep legacy nse lifetime (changed by https://github.com/networkservicemesh/sdk/pull/1404)
@@ -101,6 +102,7 @@ func (apiClient *APIClient) setNetworkServiceRegistryClient() {
 	apiClient.NetworkServiceRegistryClient = registryclient.NewNetworkServiceRegistryClient(
 		apiClient.context,
 		registryclient.WithClientURL(&apiClient.Config.ConnectTo),
+		registryclient.WithDialTimeout(apiClient.Config.DialTimeout),
 		registryclient.WithDialOptions(clientOptions...),
 		registryclient.WithAuthorizeNSRegistryClient(registryauthorize.NewNetworkServiceRegistryClient()),
 	)


### PR DESCRIPTION
## Description
By default the ns and nse registry client uses a [dialtimeout of 300 mseconds](https://github.com/networkservicemesh/sdk/blob/release/v1.13.2/pkg/registry/chains/client/nse_client.go#L47) (might depend on the sdk version). This might put unnecessary load on the clients due to the frequent retries during nsmgr failover/upgrade.
Hence, pass the dialtimeout value configured for the container when creating the registry clients.

## Issue link
NA

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
