### PR TITLE
proxy; pass MaxTokenLifetime for expiration check

### DIFF
--- a/cmd/proxy/internal/client/fullmesh.go
+++ b/cmd/proxy/internal/client/fullmesh.go
@@ -167,7 +167,7 @@ func (fmnsc *FullMeshNetworkServiceClient) checkEndpointExpiration() {
 	logger := fmnsc.logger.WithValues("func", "checkEndpointExpiration")
 	for name, endpoint := range fmnsc.networkServiceEndpoints {
 		if fmnsc.ctx.Err() != nil {
-			// If context is closed FullMeshNetworkServiceClient.Close() is expected anyways to clen up...
+			// If context is closed FullMeshNetworkServiceClient.Close() is expected anyways to clean up...
 			return
 		}
 		// Endpoint is considered expired if based on its ExpirationTime it's

--- a/cmd/proxy/internal/service/client.go
+++ b/cmd/proxy/internal/service/client.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021-2023 Nordix Foundation
+Copyright (c) 2024 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -57,6 +58,7 @@ func GetNSC(ctx context.Context,
 		ConnectTo:               config.ConnectTo,
 		APIClient:               nsmAPIClient,
 		MonitorConnectionClient: monitorConnectionClient,
+		MaxTokenLifetime:        config.MaxTokenLifetime,
 	}
 	// Note: naming the interface is left to NSM (refer to getNameFromConnection())
 	// However NSM does not seem to ensure uniqueness either. Might need to revisit...


### PR DESCRIPTION
## Description
Forgot to pass MaxTokenLifetime to fullmesh client to include it in the endpoint expiration check.
Follow-up for https://github.com/Nordix/Meridio/pull/538

## Issue link
https://github.com/Nordix/Meridio/issues/537

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
