### PR TITLE
Close MonitorConnection streaming RPC

### DIFF
--- a/cmd/proxy/internal/client/fullmesh.go
+++ b/cmd/proxy/internal/client/fullmesh.go
@@ -223,7 +223,8 @@ func (fmnsc *FullMeshNetworkServiceClient) addNetworkServiceClient(networkServic
 	// then re-use the connection
 	if fmnsc.config.MonitorConnectionClient != nil {
 		monitorCli := fmnsc.config.MonitorConnectionClient
-		stream, err := monitorCli.MonitorConnections(fmnsc.ctx, &networkservice.MonitorScopeSelector{
+		monitorCtx, cancelMonitor := context.WithCancel(fmnsc.ctx) // dedicated context when cancelled ensures closing the stream opened by MonitorConnections
+		stream, err := monitorCli.MonitorConnections(monitorCtx, &networkservice.MonitorScopeSelector{
 			PathSegments: []*networkservice.PathSegment{
 				{
 					Id: id,
@@ -243,6 +244,7 @@ func (fmnsc *FullMeshNetworkServiceClient) addNetworkServiceClient(networkServic
 				monitoredConnections = event.Connections
 			}
 		}
+		cancelMonitor()
 	}
 
 	// Update request based on recovered connection(s) if any

--- a/pkg/ambassador/tap/conduit/conduit.go
+++ b/pkg/ambassador/tap/conduit/conduit.go
@@ -163,7 +163,9 @@ func (c *Conduit) Connect(ctx context.Context) error {
 
 	if c.MonitorConnectionClient != nil {
 		// check if NSM already tracks a connection with the same ID, if it does, re-use the connection
-		stream, err := c.MonitorConnectionClient.MonitorConnections(ctx, &networkservice.MonitorScopeSelector{
+		monitorCtx, cancelMonitor := context.WithCancel(ctx)
+		defer cancelMonitor()
+		stream, err := c.MonitorConnectionClient.MonitorConnections(monitorCtx, &networkservice.MonitorScopeSelector{
 			PathSegments: []*networkservice.PathSegment{
 				{
 					Id: id,

--- a/pkg/nsm/monitor/connection.go
+++ b/pkg/nsm/monitor/connection.go
@@ -47,7 +47,9 @@ func ConnectionMonitor(ctx context.Context, name string, monitorConnectionClient
 	}
 
 	_ = retry.Do(func() error {
-		monitorConnectionsClient, err := monitorConnectionClient.MonitorConnections(ctx, monitorScope)
+		monitorCtx, cancelMonitor := context.WithCancel(ctx)
+		defer cancelMonitor()
+		monitorConnectionsClient, err := monitorConnectionClient.MonitorConnections(monitorCtx, monitorScope)
 		if err != nil {
 			return fmt.Errorf("failed to create connection monitor client: %w", err)
 		}


### PR DESCRIPTION
## Description
Close MonitorConnection streaming RPC by cancelling the related context once done using it. Thus, avoiding memory leak like symstoms on the server side (NSMgr).

## Issue link
#545 

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
