### PR TITLE
operator; enable sequential conduit updates

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -132,7 +132,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 
 	if os.Getenv(common.LogLevelEnv) == "" { // trace as default value
-		os.Setenv(common.LogLevelEnv, "trace")
+		os.Setenv(common.LogLevelEnv, "TRACE")
 	}
 
 	ver := flag.Bool("version", false, "Print version and quit")
@@ -155,7 +155,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	logger := log.New("Operator", common.LogLevelEnv)
+	logger := log.New("Operator", os.Getenv(common.LogLevelEnv))
 	ctrl.SetLogger(logger)
 
 	// Set operator scope to the namespace where the operator pod exists

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -259,9 +259,10 @@ func main() {
 	}
 
 	if err = (&conduitcontroller.ConduitReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Conduit"),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Log:       ctrl.Log.WithName("controllers").WithName("Conduit"),
+		Scheme:    mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Conduit")
 		os.Exit(1)

--- a/docs/components/operator.md
+++ b/docs/components/operator.md
@@ -42,7 +42,17 @@ Update Strategy of the related resources. Service disturbances and outages are t
 
 Environment variable | Type | Description | Default
 --- | --- | --- | ---
- | |
+SPIFFE_ENDPOINT_SOCKET | string | Path to the Spiffe endpoint socket when using Spire | ""
+RESOURCE_NAME_PREFIX | string | Prefix for the names of deployed resources | ""
+LOG_LEVEL | string | Log levels of the operator and deployed components | "TRACE"
+NSP_SERVICE_ACCOUNT | string | Service Account for NSP | ""
+FE_SERVICE_ACCOUNT | string | Service Account for the frontend | ""
+IMAGE_PULL_SECRET | string | ImagePullSecrets to be passed to components if set | ""
+WATCH_NAMESPACE | string | Namespace scope of the operator | ""
+GRPC_PROBE_RPC_TIMEOUT | time.Duration | GRPC_PROBE_RPC_TIMEOUT value passed to components if set | ""
+CONDUIT_MTU | int | MTU value for Conduits, passed if set | ""
+PROXY_IP_RELEASE_DELAY | time.Duration | Delay before releasing an NSM connection's IP address, passed to the proxy if set | ""
+CONDUIT_UPDATE_SYNC_GROUP_KEY | string | Annotation key for defining update sync groups in Conduits | update-sync-group
 
 ## Command Line 
 

--- a/docs/concepts/conduit.md
+++ b/docs/concepts/conduit.md
@@ -97,6 +97,50 @@ The picture below represents a Kubernetes cluster with Conduit applied and highl
 * `.metadata.labels.trench` property is mandatory and immutable.
 * `.spec.type` property is mandatory and immutable.
 
+## Update groups
+
+By default, simultaneous updates of different Conduits are not coordinated, meaning that changes might
+be processed in parallel, affecting underlying resources at the same time (e.g., during an upgrade).
+
+In certain scenarios, it might be desirable to serialize updates within a set of Conduits controlled by
+the same operator. This can be achieved by annotating Conduits and grouping them based on annotation values.
+Conduits that belong to the same group will be updated sequentially, while different update groups can still
+be processed parallel.
+
+A Conduit's annotation value can be set, changed, or removed on the fly. Additionally, existing Conduits can be
+annotated before upgrading to a Meridio version that supports serialized Conduit updates. In this case, the new
+operator will respect the update groups from the start, ensuring that Conduits are upgraded accordingly.
+
+Note: The annotation key for defining update groups defaults to `update-sync-group`.
+
+Below is an example of two conduit objects being part of the same update group (`group-A`):
+
+```yaml
+apiVersion: meridio.nordix.org/v1
+kind: Conduit
+metadata:
+  name: load-balancer-b1
+  namespace: default
+  annotations:
+    update-sync-group: "group-A"
+  labels:
+    trench: trench-a
+spec:
+  type: stateless-lb
+---
+apiVersion: meridio.nordix.org/v1
+kind: Conduit
+metadata:
+  name: load-balancer-a1
+  namespace: default
+  annotations:
+    update-sync-group: "group-A"
+  labels:
+    trench: trench-a
+spec:
+  type: stateless-lb
+```
+
 ## Configuration
 
 TODO: Update

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/edwarnicke/genericsync v0.0.0-20220910010113-61a344f9bc29 // indirect
 	github.com/edwarnicke/serialize v1.0.7 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.8.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect

--- a/pkg/controllers/common/action.go
+++ b/pkg/controllers/common/action.go
@@ -220,3 +220,45 @@ func (e *Executor) AddUpdateStatusAction(obj client.Object) {
 	e.log.Info("add action", "action", "update status", "object", name, "kind", obj.GetObjectKind().GroupVersionKind())
 	e.appendActions(updateStatusAction{obj: obj, action: "update status"})
 }
+
+type Reader struct {
+	scheme *runtime.Scheme
+	client client.Reader
+	ctx    context.Context
+	log    logr.Logger
+}
+
+func NewReader(s *runtime.Scheme, c client.Reader, ct context.Context, l logr.Logger) *Reader {
+	return &Reader{
+		scheme: s,
+		client: c,
+		ctx:    ct,
+		log:    l.WithName("reader"),
+	}
+}
+
+func (r *Reader) LogInfo(msg string) {
+	r.log.Info(msg)
+}
+
+func (r *Reader) LogError(err error, msg string) {
+	r.log.Error(err, msg)
+}
+
+func (r *Reader) GetObject(selector client.ObjectKey, obj client.Object) error {
+	err := r.client.Get(r.ctx, selector, obj)
+	if err != nil {
+		return fmt.Errorf("reader failed to get objects: %w", err)
+	}
+
+	return nil
+}
+
+func (r *Reader) ListObject(obj client.ObjectList, opts ...client.ListOption) error {
+	err := r.client.List(r.ctx, obj, opts...)
+	if err != nil {
+		return fmt.Errorf("reader failed to list objects: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/controllers/common/const.go
+++ b/pkg/controllers/common/const.go
@@ -76,6 +76,9 @@ const (
 
 	ResourceRequirementKey          = "resource-template"
 	ResourceRequirementTemplatePath = "template/resource"
+
+	ConduitUpdateSyncGroupKeyEnv     = "CONDUIT_UPDATE_SYNC_GROUP_KEY" // Annotation key to be used to mark Conduits which update sync group they belong to if any.
+	DefaultConduitUpdateSyncGroupKey = "update-sync-group"
 )
 
 func NSPServiceAccountName() string {
@@ -204,4 +207,11 @@ func GetProxyIPReleaseDelay() string {
 		return ""
 	}
 	return delay
+}
+
+func GetConduitUpdateSyncGroupKey() string {
+	if key := os.Getenv(ConduitUpdateSyncGroupKeyEnv); key != "" {
+		return key
+	}
+	return DefaultConduitUpdateSyncGroupKey
 }

--- a/pkg/controllers/conduit/conduit_controller.go
+++ b/pkg/controllers/conduit/conduit_controller.go
@@ -19,14 +19,19 @@ package conduit
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/go-logr/logr"
 	meridiov1 "github.com/nordix/meridio/api/v1"
@@ -36,8 +41,21 @@ import (
 // ConduitReconciler reconciles a Conduit object
 type ConduitReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	APIReader        client.Reader // reader contacting the API server directly bypassing the local cache
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
+	updateSyncGroups sync.Map // map stores Update Sync Group annotation values for each conduit Custom Resource object part of one
+	updateLocks      sync.Map // map stores locks for Upgrade Sync Groups
+}
+
+// Note: In memory lock. Not effective if operator crashes during ongoing
+// updates, but that would be considered a bug to be fixed anyways.
+// (Compared to the complexity of a ConfigMap based locking this provides
+// good enough protection and is probably much faster.)
+type updateLock struct {
+	mutex      *sync.Mutex // resolve race conditions in case of parallel sync.Map calls with the same key (e.g.: Load, Store, Delete etc.)
+	owner      string
+	acquiredAt time.Time
 }
 
 //+kubebuilder:rbac:groups=meridio.nordix.org,resources=conduits,namespace=system,verbs=get;list;watch;update
@@ -53,7 +71,7 @@ type ConduitReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 func (r *ConduitReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	conduit := &meridiov1.Conduit{}
 	executor := common.NewExecutor(r.Scheme, r.Client, ctx, nil, r.Log)
@@ -70,6 +88,9 @@ func (r *ConduitReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	// clear conduit status
 	currentConduit := conduit.DeepCopy()
+	updateSyncGroup := getUpdateSyncGroup(currentConduit) // Check if conduit belongs to an update sync group
+	logger = logger.WithValues("updateSyncGroup", updateSyncGroup)
+	r.manageUpdateSyncGroupChange(updateSyncGroup, req.NamespacedName.String()) // Check if update sync group has changed
 
 	// Get the trench by the label in conduit
 	selector := client.ObjectKey{
@@ -79,24 +100,55 @@ func (r *ConduitReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	trench, _ := common.GetTrenchBySelector(executor, selector)
 
 	// actions to update conduit
-	if trench != nil {
-		err = executor.SetOwnerReference(conduit, trench)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set owner reference (%s) in conduit controller: %w", req.Name, err)
-		}
-		// create/update stateless-lb-frontend & nse-vlan deployment
-		executor.SetOwner(conduit)
-
-		proxy, err := NewProxy(executor, trench, conduit)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		err = proxy.getAction()
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-	} else {
+	if trench == nil {
 		return ctrl.Result{}, fmt.Errorf("unable to get trench for conduit %s", req.NamespacedName)
+	}
+	err = executor.SetOwnerReference(conduit, trench)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to set owner reference (%s) in conduit controller: %w", req.Name, err)
+	}
+	// create/update stateless-lb-frontend & nse-vlan deployment
+	executor.SetOwner(conduit)
+
+	proxy, err := NewProxy(executor, trench, conduit)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	proxyUpdateAction, err := proxy.getAction()
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Handle update locking in case conduit belongs to an update sync group,
+	// but try not to block/delay execution of initial proxy create action.
+	// Note: Initial proxy create action can add the daemonset, allowing PODs
+	// to be created etc. But after that any subsequent reconcile actions will
+	// be considered updates due to the existing daemonset.
+	if updateSyncGroup != "" {
+		if proxyUpdateAction {
+			if !r.acquireLock(updateSyncGroup, req.NamespacedName.String()) {
+				logger.Info("Update locked by another conduit, requeueing")
+				// TODO: consider making delay configurable
+				return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+			}
+			logger.Info("Lock acquired")
+		}
+		if r.hasLock(updateSyncGroup, req.NamespacedName.String()) {
+			defer func() {
+				// Check if proxy daemonset along with its PODs have been updated
+				// after pushing the actions to the API server. If so release the lock.
+				// Otherwise, wait for the next Reconcile call.
+				// Note: Must fetch up to date version of proxy workload(s), instead of
+				// an old one from the cache.
+				ok, err := r.isProxyUpdateReady(common.NewReader(r.Scheme, r.APIReader, ctx, r.Log), proxy)
+				if ok {
+					logger.Info("Updates finished, releasing lock")
+					r.releaseLock(updateSyncGroup, req.NamespacedName.String())
+				} else {
+					logger.Info("Updates ongoing, not releasing lock", "details", err)
+				}
+			}()
+		}
 	}
 
 	getConduitActions(executor, conduit, currentConduit)
@@ -114,6 +166,15 @@ func (r *ConduitReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&meridiov1.Conduit{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.DaemonSet{}).
+		WithEventFilter(predicate.Funcs{
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				// Handle conduit Custom Resource deletion from locking perspective
+				if _, ok := e.Object.(*meridiov1.Conduit); ok {
+					r.cleanupLock(e.Object.GetName(), e.Object.GetNamespace())
+				}
+				return true
+			},
+		}).
 		Complete(r)
 	if err != nil {
 		return fmt.Errorf("failed to build conduit controller: %w", err)
@@ -122,8 +183,124 @@ func (r *ConduitReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return nil
 }
 
+// Try to acquire update sync group lock for owner
+func (r *ConduitReconciler) acquireLock(updateSyncGroup, owner string) bool {
+	lock, loaded := r.updateLocks.LoadOrStore(updateSyncGroup, &updateLock{mutex: &sync.Mutex{}})
+	ul := lock.(*updateLock)
+	ul.mutex.Lock()
+	defer ul.mutex.Unlock()
+
+	logger := r.Log.WithName("acquireLock").WithValues("updateSyncGroup", updateSyncGroup, "caller", owner)
+	if ul.owner != "" && ul.owner != owner {
+		logger.V(1).Info("Lock in use", "owner", ul.owner)
+		return false
+	}
+	if !loaded {
+		// We just created the lock
+		ul.owner = owner
+		ul.acquiredAt = time.Now()
+		logger.Info("Lock created", "owner", ul.owner)
+	}
+	return true
+}
+
+// Check if owner has locked the update sync group
+func (r *ConduitReconciler) hasLock(updateSyncGroup, owner string) bool {
+	logger := r.Log.WithName("hasLock").WithValues("updateSyncGroup", updateSyncGroup, "caller", owner)
+	lock, ok := r.updateLocks.Load(updateSyncGroup)
+	if !ok {
+		logger.V(1).Info("No lock found")
+		return false
+	}
+	ul := lock.(*updateLock)
+	ul.mutex.Lock()
+	defer ul.mutex.Unlock()
+	logger.V(1).Info("Verify ownership", "owner", ul.owner, "acquiredAt", ul.acquiredAt)
+	return ul.owner != "" && ul.owner == owner
+}
+
+// Release lock for update sync group if held by owner
+func (r *ConduitReconciler) releaseLock(updateSyncGroup, owner string) {
+	lock, ok := r.updateLocks.Load(updateSyncGroup)
+	if !ok {
+		return
+	}
+	ul := lock.(*updateLock)
+	ul.mutex.Lock()
+	defer ul.mutex.Unlock()
+	if ul.owner == owner {
+		// Note: owner is not cleared for a reason, thus even if the lock was loaded in
+		// the meantime by someone else it should not result in an inconsistent state,
+		// since the lock should not be touached if the owner is different.
+		r.Log.WithName("releaseLock").Info("Released", "updateSyncGroup", updateSyncGroup,
+			"owner", owner, "acquiredAt", ul.acquiredAt)
+		r.updateLocks.Delete(updateSyncGroup)
+	}
+}
+
+// Store new updateSyncGroup value for the conduit.
+// Also, upon change in update sync group, previously held lock if any must be released.
+func (r *ConduitReconciler) manageUpdateSyncGroupChange(updateSyncGroup, conduitName string) {
+	prevUpdateSyncGroup, ok := r.updateSyncGroups.Load(conduitName)
+
+	hasUpdateSyncGroupChanged := func() bool {
+		if ok && updateSyncGroup == prevUpdateSyncGroup { // same as the stored group
+			return false
+		}
+		if !ok && updateSyncGroup == "" { // new is empty string and no previous value
+			return false
+		}
+		return true
+	}
+
+	syncUpdateSyncGroupStorage := func() {
+		if updateSyncGroup != "" { // save new value
+			r.updateSyncGroups.Store(conduitName, updateSyncGroup)
+		} else { // empty string new value, remove old
+			r.updateSyncGroups.Delete(conduitName)
+		}
+	}
+
+	if !hasUpdateSyncGroupChanged() {
+		return
+	}
+
+	r.Log.WithName("manageUpdateSyncGroupChange").Info("Change observed", "conduit", conduitName,
+		"updateSyncGroup", updateSyncGroup, "prevUpdateSyncGroup", prevUpdateSyncGroup)
+
+	if ok { // release former lock if any
+		r.releaseLock(prevUpdateSyncGroup.(string), conduitName)
+	}
+	syncUpdateSyncGroupStorage()
+}
+
+// Find update sync group and release lock if held by the conduit
+func (r *ConduitReconciler) cleanupLock(name, namespace string) {
+	key := types.NamespacedName{Name: name, Namespace: namespace}.String()
+	logger := r.Log.WithName("cleanupLock").WithValues("conduit", key)
+	logger.Info("Clean up lock if any")
+	updateSyncGroup, loaded := r.updateSyncGroups.LoadAndDelete(key)
+	if !loaded {
+		logger.V(1).Info("Not part of any updateSyncGroup")
+		return
+	}
+	r.releaseLock(updateSyncGroup.(string), key)
+}
+
+func (r *ConduitReconciler) isProxyUpdateReady(reader *common.Reader, proxy *Proxy) (bool, error) {
+	return proxy.isReady(reader)
+}
+
 func getConduitActions(executor *common.Executor, new, old *meridiov1.Conduit) {
 	if !equality.Semantic.DeepEqual(new.ObjectMeta, old.ObjectMeta) {
 		executor.AddUpdateAction(new)
 	}
+}
+
+func getUpdateSyncGroup(conduit *meridiov1.Conduit) string {
+	updateSyncGroupAnnotation := common.GetConduitUpdateSyncGroupKey() // allows customization of annotation key
+	if val, ok := conduit.GetAnnotations()[updateSyncGroupAnnotation]; ok {
+		return val
+	}
+	return ""
 }

--- a/pkg/controllers/conduit/conduit_controller.go
+++ b/pkg/controllers/conduit/conduit_controller.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2025 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controllers/conduit/conduit_controller_test.go
+++ b/pkg/controllers/conduit/conduit_controller_test.go
@@ -1,0 +1,926 @@
+/*
+Copyright (c) 2025 OpenInfra Foundation Europe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conduit_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	meridiov1 "github.com/nordix/meridio/api/v1"
+	"github.com/nordix/meridio/pkg/controllers/common"
+	"github.com/nordix/meridio/pkg/controllers/conduit"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// Note: The fake client simulates a Kubernetes API server using an in-memory
+// object store. Create and Update etc. operations are applied immediately. However,
+// it doesn't replicate all API server functionalities. Notably, metadata.generation,
+// DaemonSet Status subresources, and automatic Reconcile calls are not automatically
+// updated/triggered.
+
+var updateSyncGroupKey string = common.GetConduitUpdateSyncGroupKey()
+
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = meridiov1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	return scheme
+}
+
+func newConduit(name, trench, syncGroup string) *meridiov1.Conduit {
+	conduit := &meridiov1.Conduit{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"trench": trench,
+			},
+		},
+	}
+	if syncGroup != "" {
+		conduit.Annotations = map[string]string{updateSyncGroupKey: syncGroup}
+	}
+	return conduit
+}
+
+// newProxyDaemonSet returns a basic proxy DaemonSet with a simplified specification,
+// intentionally different from a fully configured DaemonSet, that the Conduit Reconciler
+// aims to achieve.
+// The 'desiredNumberScheduled' parameter allows control over the DaemonSet's status,
+// enabling simulation of various reconciliation progress states such as slow updates.
+func newProxyDaemonSet(conduit *meridiov1.Conduit, desiredNumberScheduled int32) *appsv1.DaemonSet {
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.ProxyDeploymentName(conduit),
+			Namespace: conduit.GetNamespace(),
+			Labels: map[string]string{
+				"app": "proxy",
+			},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "proxy"},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "proxy"},
+				},
+			},
+		},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: desiredNumberScheduled,
+		},
+	}
+	return ds
+}
+
+func setupReconciler(t *testing.T, objects ...client.Object) (*conduit.ConduitReconciler, client.Client) {
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(objects...).Build()
+	logger := testr.New(t)
+
+	return &conduit.ConduitReconciler{
+		Client:           fakeClient,
+		APIReader:        fakeClient,
+		Scheme:           newScheme(),
+		Log:              logger.WithName("test"),
+		ProxyModelLoader: &TestProxyModelLoader{}, // Test Loader bypasses normal operation by not reading the proxy model from template file
+	}, fakeClient
+}
+
+func assertLockStatus(t *testing.T, reconciler *conduit.ConduitReconciler, conduit *meridiov1.Conduit, expectLock bool) {
+	hasLock := reconciler.HasLock(
+		conduit.GetAnnotations()[common.GetConduitUpdateSyncGroupKey()],
+		types.NamespacedName{Name: conduit.Name, Namespace: conduit.Namespace}.String(),
+	)
+	assert.Equal(t, expectLock, hasLock)
+}
+
+func assertDaemonSet(t *testing.T, fakeClient client.Client, conduit *meridiov1.Conduit) *appsv1.DaemonSet {
+	ds := &appsv1.DaemonSet{}
+	err := fakeClient.Get(context.Background(), types.NamespacedName{Name: common.ProxyDeploymentName(conduit), Namespace: conduit.Namespace}, ds)
+	assert.NoError(t, err)
+	assert.NotNil(t, ds.Spec)
+	return ds
+}
+
+func assertNoDaemonSet(t *testing.T, fakeClient client.Client, conduit *meridiov1.Conduit) {
+	ds := &appsv1.DaemonSet{}
+	err := fakeClient.Get(context.Background(), types.NamespacedName{Name: common.ProxyDeploymentName(conduit), Namespace: conduit.Namespace}, ds)
+	assert.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func assertConduit(t *testing.T, fakeClient client.Client, conduit *meridiov1.Conduit) *meridiov1.Conduit {
+	c := &meridiov1.Conduit{}
+	err := fakeClient.Get(context.Background(), types.NamespacedName{Name: conduit.Name, Namespace: conduit.Namespace}, c)
+	assert.NoError(t, err)
+	return c
+}
+
+func TestConduitReconciler_Reconcile(t *testing.T) {
+	t.Run("CreateConduits_NoSyncGroup_CreatesProxyDaemonSets", func(t *testing.T) {
+		conduits := []*meridiov1.Conduit{
+			newConduit("test-conduit-A", "test-trench", ""),
+			newConduit("test-conduit-B", "test-trench", ""),
+		}
+		var objects []client.Object
+		for _, c := range conduits {
+			objects = append(objects, c)
+		}
+		reconciler, fakeClient := setupReconciler(t, objects...)
+
+		for _, c := range conduits {
+			assertNoDaemonSet(t, fakeClient, c)
+
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: c.Name, Namespace: c.Namespace}}
+			result, err := reconciler.Reconcile(context.Background(), request)
+			assert.NoError(t, err)
+			assert.Equal(t, ctrl.Result{}, result)
+
+			_ = assertDaemonSet(t, fakeClient, c)
+		}
+		assert.Equal(t, 0, len(reconciler.GetUpdateSyncGroups()))
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+	})
+
+	t.Run("UpdateConduits_NoSyncGroup_UpdatesProxyDaemonSets", func(t *testing.T) {
+
+		conduits := []*meridiov1.Conduit{
+			newConduit("test-conduit-A", "test-trench", ""),
+			newConduit("test-conduit-B", "test-trench", ""),
+		}
+		var objects []client.Object
+		// Initialize fake client with daemonsets to mimic update
+		for _, c := range conduits {
+			objects = append(objects, c, newProxyDaemonSet(c, 0))
+		}
+		reconciler, fakeClient := setupReconciler(t, objects...)
+
+		for _, c := range conduits {
+			cs := assertDaemonSet(t, fakeClient, c)
+
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: c.Name, Namespace: c.Namespace}}
+			result, err := reconciler.Reconcile(context.Background(), request)
+			assert.NoError(t, err)
+			assert.Equal(t, ctrl.Result{}, result)
+
+			ds := assertDaemonSet(t, fakeClient, c)
+			assert.False(t, equality.Semantic.DeepEqual(ds.Spec, cs.Spec)) // ds update executed
+		}
+
+		assert.Equal(t, 0, len(reconciler.GetUpdateSyncGroups()))
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+	})
+
+	t.Run("CreateConduits_SharedSyncGroup_CreatesProxyDaemonSets", func(t *testing.T) {
+
+		conduits := []*meridiov1.Conduit{
+			newConduit("test-conduit-A", "test-trench", "test-group"),
+			newConduit("test-conduit-B", "test-trench", "test-group"),
+		}
+		var objects []client.Object
+		for _, c := range conduits {
+			objects = append(objects, c)
+		}
+		reconciler, fakeClient := setupReconciler(t, objects...)
+
+		for _, c := range conduits {
+			assertNoDaemonSet(t, fakeClient, c)
+
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: c.Name, Namespace: c.Namespace}}
+			result, err := reconciler.Reconcile(context.Background(), request)
+			assert.NoError(t, err)
+			assert.Equal(t, ctrl.Result{}, result)
+
+			cond := assertConduit(t, fakeClient, c)
+			assert.Equal(t, "test-group", conduit.GetUpdateSyncGroup(cond))
+
+			_ = assertDaemonSet(t, fakeClient, c)
+		}
+		assert.Equal(t, len(conduits), len(reconciler.GetUpdateSyncGroups()))
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+	})
+
+	t.Run("UpdateConduits_SharedSyncGroup_UpdatesProxyDaemonSets", func(t *testing.T) {
+
+		conduits := []*meridiov1.Conduit{
+			newConduit("test-conduit-A", "test-trench", "test-group"),
+			newConduit("test-conduit-B", "test-trench", "test-group"),
+		}
+		var objects []client.Object
+		// Initialize fake client with daemonsets to mimic update
+		for _, c := range conduits {
+			objects = append(objects, c, newProxyDaemonSet(c, 0))
+		}
+		reconciler, fakeClient := setupReconciler(t, objects...)
+
+		for _, c := range conduits {
+			cs := assertDaemonSet(t, fakeClient, c)
+
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: c.Name, Namespace: c.Namespace}}
+			result, err := reconciler.Reconcile(context.Background(), request)
+			assert.NoError(t, err)
+			assert.Equal(t, ctrl.Result{}, result)
+
+			cond := assertConduit(t, fakeClient, c)
+			assert.Equal(t, "test-group", conduit.GetUpdateSyncGroup(cond))
+
+			ds := assertDaemonSet(t, fakeClient, c)
+
+			assert.False(t, equality.Semantic.DeepEqual(ds.Spec, cs.Spec)) // ds update executed
+		}
+
+		assert.Equal(t, len(conduits), len(reconciler.GetUpdateSyncGroups()))
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+	})
+
+	t.Run("UpdateConduits_SharedSyncGroup_SlowProgress", func(t *testing.T) {
+
+		conduits := []*meridiov1.Conduit{
+			newConduit("test-conduit-A", "test-trench", "test-group"),
+			newConduit("test-conduit-B", "test-trench", "test-group"),
+		}
+
+		var objects []client.Object
+		objects = append(objects, conduits[0], newProxyDaemonSet(conduits[0], 1)) // Slow conduit
+		objects = append(objects, conduits[1], newProxyDaemonSet(conduits[1], 0)) // Normal conduit
+		reconciler, fakeClient := setupReconciler(t, objects...)
+
+		// First reconcile - slow conduit gets the lock
+		// But update cannot conclude because fake client is a mock and lacks
+		// api server functionality to auto-update DaemonSet Status subresource.
+		request := reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[0].Name, Namespace: conduits[0].Namespace}}
+		result, err := reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+		assertLockStatus(t, reconciler, conduits[0], true)
+		_ = assertDaemonSet(t, fakeClient, conduits[0])
+
+		// Second reconcile - normal conduit must wait for the lock
+		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[1].Name, Namespace: conduits[1].Namespace}}
+		result, err = reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Greater(t, result.RequeueAfter, time.Duration(0))
+		assertLockStatus(t, reconciler, conduits[1], false)
+		_ = assertDaemonSet(t, fakeClient, conduits[1])
+
+		// Simulate slow conduit's DaemonSet reaching ready state
+		ds := &appsv1.DaemonSet{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: common.ProxyDeploymentName(conduits[0]), Namespace: conduits[0].Namespace}, ds)
+		assert.NoError(t, err)
+		ds.Status.DesiredNumberScheduled = 0
+		err = fakeClient.Status().Update(context.Background(), ds)
+		assert.NoError(t, err)
+
+		// Third reconcile - slow conduit releases the lock
+		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[0].Name, Namespace: conduits[0].Namespace}}
+		result, err = reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+		assertLockStatus(t, reconciler, conduits[0], false)
+
+		assert.Equal(t, len(conduits), len(reconciler.GetUpdateSyncGroups()))
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+	})
+
+	t.Run("UpdateConduits_SharedSyncGroup_DeleteStalledConduit", func(t *testing.T) {
+
+		conduits := []*meridiov1.Conduit{
+			newConduit("test-conduit-A", "test-trench", "test-group"),
+			newConduit("test-conduit-B", "test-trench", "test-group"),
+		}
+
+		var objects []client.Object
+		objects = append(objects, conduits[0], newProxyDaemonSet(conduits[0], 1)) // Slow conduit
+		objects = append(objects, conduits[1], newProxyDaemonSet(conduits[1], 0)) // Normal conduit
+		reconciler, fakeClient := setupReconciler(t, objects...)
+
+		// First reconcile - slow conduit gets the lock
+		// But update cannot conclude because fake client is a mock and lacks
+		// api server functionality to auto-update DaemonSet Status subresource.
+		request := reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[0].Name, Namespace: conduits[0].Namespace}}
+		result, err := reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+		assertLockStatus(t, reconciler, conduits[0], true)
+		_ = assertDaemonSet(t, fakeClient, conduits[0])
+
+		// Second reconcile - normal conduit must wait for the lock
+		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[1].Name, Namespace: conduits[1].Namespace}}
+		result, err = reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Greater(t, result.RequeueAfter, time.Duration(0))
+		assertLockStatus(t, reconciler, conduits[1], false)
+		_ = assertDaemonSet(t, fakeClient, conduits[1])
+
+		// Simulate deletion of slow conduit holding the lock. Fake client lacks
+		// automatic deletion handling, so manually trigger HandleConduitDeletion.
+		c := &meridiov1.Conduit{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: conduits[0].Name, Namespace: conduits[0].Namespace}, c)
+		assert.NoError(t, err)
+		err = fakeClient.Delete(context.Background(), c)
+		assert.NoError(t, err)
+		reconciler.HandleConduitDeletion(c.Name, c.Namespace) // releases lock and removes the conduit to update sync group mapping
+		assertLockStatus(t, reconciler, conduits[0], false)
+		assert.Equal(t, len(conduits)-1, len(reconciler.GetUpdateSyncGroups()))
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+
+		// Third reconcile - normal conduit can execute the update
+		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[1].Name, Namespace: conduits[1].Namespace}}
+		result, err = reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+		assertLockStatus(t, reconciler, conduits[1], false)
+
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+
+	})
+
+	t.Run("UpdateConduits_SharedSyncGroup_RemoveStalledConduitAnnotation", func(t *testing.T) {
+
+		conduits := []*meridiov1.Conduit{
+			newConduit("test-conduit-A", "test-trench", "test-group"),
+			newConduit("test-conduit-B", "test-trench", "test-group"),
+		}
+
+		var objects []client.Object
+		objects = append(objects, conduits[0], newProxyDaemonSet(conduits[0], 1)) // Slow conduit
+		objects = append(objects, conduits[1], newProxyDaemonSet(conduits[1], 0)) // Normal conduit
+		reconciler, fakeClient := setupReconciler(t, objects...)
+
+		// First reconcile - slow conduit gets the lock
+		// But update cannot conclude because fake client is a mock and lacks
+		// api server functionality to auto-update DaemonSet Status subresource.
+		request := reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[0].Name, Namespace: conduits[0].Namespace}}
+		result, err := reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+		assertLockStatus(t, reconciler, conduits[0], true)
+		_ = assertDaemonSet(t, fakeClient, conduits[0])
+
+		// Second reconcile - normal conduit must wait for the lock
+		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[1].Name, Namespace: conduits[1].Namespace}}
+		result, err = reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Greater(t, result.RequeueAfter, time.Duration(0))
+		assertLockStatus(t, reconciler, conduits[1], false)
+		_ = assertDaemonSet(t, fakeClient, conduits[1])
+
+		// Modify slow conduit's annotation to remove the update sync group
+		c := &meridiov1.Conduit{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: conduits[0].Name, Namespace: conduits[0].Namespace}, c)
+		assert.NoError(t, err)
+		c.Annotations = make(map[string]string) // Remove all annotations, including update sync group
+		err = fakeClient.Update(context.Background(), c)
+		assert.NoError(t, err)
+
+		// Third reconcile - slow conduit releases the lock
+		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[0].Name, Namespace: conduits[0].Namespace}}
+		result, err = reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+		assertLockStatus(t, reconciler, conduits[0], false)
+		assert.Equal(t, len(conduits)-1, len(reconciler.GetUpdateSyncGroups())) // Slow conduit's update sync group was removed
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+
+		// Fourth reconcile - normal conduit can execute the update
+		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[1].Name, Namespace: conduits[1].Namespace}}
+		result, err = reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+		assertLockStatus(t, reconciler, conduits[1], false)
+
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+	})
+
+	t.Run("UpdateConduits_SharedSyncGroup_ChangeStalledConduitAnnotation", func(t *testing.T) {
+
+		conduits := []*meridiov1.Conduit{
+			newConduit("test-conduit-A", "test-trench", "test-group"),
+			newConduit("test-conduit-B", "test-trench", "test-group"),
+		}
+
+		var objects []client.Object
+		objects = append(objects, conduits[0], newProxyDaemonSet(conduits[0], 1)) // Slow conduit
+		objects = append(objects, conduits[1], newProxyDaemonSet(conduits[1], 0)) // Normal conduit
+		reconciler, fakeClient := setupReconciler(t, objects...)
+
+		// First reconcile - slow conduit gets the lock
+		// But update cannot conclude because fake client is a mock and lacks
+		// api server functionality to auto-update DaemonSet Status subresource.
+		request := reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[0].Name, Namespace: conduits[0].Namespace}}
+		result, err := reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+		assertLockStatus(t, reconciler, conduits[0], true)
+		_ = assertDaemonSet(t, fakeClient, conduits[0])
+
+		// Second reconcile - normal conduit must wait for the lock
+		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[1].Name, Namespace: conduits[1].Namespace}}
+		result, err = reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Greater(t, result.RequeueAfter, time.Duration(0))
+		assertLockStatus(t, reconciler, conduits[1], false)
+		_ = assertDaemonSet(t, fakeClient, conduits[1])
+
+		// Modify slow conduit's annotation to change its update sync group
+		c := &meridiov1.Conduit{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: conduits[0].Name, Namespace: conduits[0].Namespace}, c)
+		assert.NoError(t, err)
+		c.Annotations[updateSyncGroupKey] = "new-test-group" // change the sync group
+		err = fakeClient.Update(context.Background(), c)
+		assert.NoError(t, err)
+
+		// Third reconcile - slow conduit releases its former update sync group's lock
+		// Lock for the new update sync group is not acquired if no change is observed
+		// in proxy like in this case. Yet, the proxy's Status subresource might indicate
+		// ongoing changes, but it's not a realistic expectation to coordinate in such cases.
+		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[0].Name, Namespace: conduits[0].Namespace}}
+		result, err = reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+		assertLockStatus(t, reconciler, conduits[0], false)                   // check lock status based on old sync group
+		conduits[0].Annotations[updateSyncGroupKey] = "new-test-group"        // update the sync group in local conduits list
+		assertLockStatus(t, reconciler, conduits[0], false)                   // check lock status based on new sync group
+		assert.Equal(t, len(conduits), len(reconciler.GetUpdateSyncGroups())) // slow conduit is still part of a sync group
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+
+		// Fourth reconcile - normal conduit can execute the update
+		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[1].Name, Namespace: conduits[1].Namespace}}
+		result, err = reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+		assertLockStatus(t, reconciler, conduits[1], false)
+
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+	})
+
+	t.Run("ParallelSlowConduitUpdate_DifferentSyncGroups_RemoveConduitAnnotation", func(t *testing.T) {
+
+		conduits := []*meridiov1.Conduit{
+			newConduit("test-conduit-A", "test-trench", "test-group-A"),
+			newConduit("test-conduit-B", "test-trench", "test-group-B"),
+			newConduit("test-conduit-C", "test-trench", "test-group-C"),
+			newConduit("test-conduit-D", "test-trench", "test-group-D"),
+		}
+
+		var objects []client.Object
+		for _, c := range conduits {
+			objects = append(objects, c, newProxyDaemonSet(c, 1)) // Slow conduit
+		}
+		reconciler, fakeClient := setupReconciler(t, objects...)
+
+		// Simulate parallel reconcile calls using goroutines
+		var wg sync.WaitGroup
+		wg.Add(len(conduits))
+		for _, c := range conduits {
+			go func(conduit *meridiov1.Conduit) {
+				defer wg.Done()
+				request := reconcile.Request{NamespacedName: types.NamespacedName{Name: conduit.Name, Namespace: conduit.Namespace}}
+				result, err := reconciler.Reconcile(context.Background(), request)
+				assert.NoError(t, err)
+				assert.Equal(t, ctrl.Result{}, result)
+				assertLockStatus(t, reconciler, conduit, true) // Conduit should hold its lock
+				_ = assertDaemonSet(t, fakeClient, conduit)
+			}(c)
+		}
+		wg.Wait()
+
+		assert.Equal(t, len(conduits), len(reconciler.GetUpdateSyncGroups()))
+		assert.Equal(t, len(conduits), len(reconciler.GetUpdateLocks()))
+
+		// Simulate parallel annotation removal
+		var deleteWg sync.WaitGroup
+		deleteWg.Add(len(conduits))
+		for _, c := range conduits {
+			conduit := c
+			go func() {
+				defer deleteWg.Done()
+				c := &meridiov1.Conduit{}
+				err := fakeClient.Get(context.Background(), types.NamespacedName{Name: conduit.Name, Namespace: conduit.Namespace}, c)
+				assert.NoError(t, err)
+				c.Annotations = make(map[string]string) // Remove all annotations, including update sync group
+				err = fakeClient.Update(context.Background(), c)
+				assert.NoError(t, err)
+
+				request := reconcile.Request{NamespacedName: types.NamespacedName{Name: c.Name, Namespace: c.Namespace}}
+				result, err := reconciler.Reconcile(context.Background(), request)
+				assert.NoError(t, err)
+				assert.Equal(t, ctrl.Result{}, result)
+				assertLockStatus(t, reconciler, c, false)
+			}()
+		}
+		deleteWg.Wait()
+
+		assert.Equal(t, 0, len(reconciler.GetUpdateSyncGroups()))
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+	})
+
+	t.Run("ParallelConduitUpdateAndDelete_DifferentSyncGroups", func(t *testing.T) {
+
+		conduits := []*meridiov1.Conduit{
+			newConduit("test-conduit-A", "test-trench", "test-group-A"),
+			newConduit("test-conduit-B", "test-trench", "test-group-B"),
+			newConduit("test-conduit-C", "test-trench", "test-group-C"),
+			newConduit("test-conduit-D", "test-trench", "test-group-D"),
+		}
+
+		var objects []client.Object
+		for _, c := range conduits {
+			objects = append(objects, c, newProxyDaemonSet(c, 0))
+		}
+		reconciler, fakeClient := setupReconciler(t, objects...)
+
+		// Simulate parallel reconcile calls using goroutines
+		var wg sync.WaitGroup
+		wg.Add(len(conduits))
+		for _, c := range conduits {
+			go func(conduit *meridiov1.Conduit) {
+				defer wg.Done()
+				request := reconcile.Request{NamespacedName: types.NamespacedName{Name: conduit.Name, Namespace: conduit.Namespace}}
+				result, err := reconciler.Reconcile(context.Background(), request)
+				assert.NoError(t, err)
+				assert.Equal(t, ctrl.Result{}, result)
+				assertLockStatus(t, reconciler, conduit, false) // Conduit should not hold its lock (update is immediate)
+				_ = assertDaemonSet(t, fakeClient, conduit)
+			}(c)
+		}
+		wg.Wait()
+
+		assert.Equal(t, len(conduits), len(reconciler.GetUpdateSyncGroups()))
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+
+		// Simulate parallel deletions
+		var deleteWg sync.WaitGroup
+		deleteWg.Add(len(conduits))
+		for _, c := range conduits {
+			conduit := c
+			go func() {
+				defer deleteWg.Done()
+				c := &meridiov1.Conduit{}
+				err := fakeClient.Get(context.Background(), types.NamespacedName{Name: conduit.Name, Namespace: conduit.Namespace}, c)
+				assert.NoError(t, err)
+				err = fakeClient.Delete(context.Background(), c)
+				assert.NoError(t, err)
+				reconciler.HandleConduitDeletion(c.Name, c.Namespace)
+				assertLockStatus(t, reconciler, conduit, false)
+			}()
+		}
+		deleteWg.Wait()
+
+		assert.Equal(t, 0, len(reconciler.GetUpdateSyncGroups()))
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+	})
+
+	t.Run("ParallelSlowConduitUpdateAndDelete_DifferentSyncGroups_ResourcesCleaned", func(t *testing.T) {
+
+		conduits := []*meridiov1.Conduit{
+			newConduit("test-conduit-A", "test-trench", "test-group-A"),
+			newConduit("test-conduit-B", "test-trench", "test-group-B"),
+			newConduit("test-conduit-C", "test-trench", "test-group-C"),
+			newConduit("test-conduit-D", "test-trench", "test-group-D"),
+		}
+
+		var objects []client.Object
+		for _, c := range conduits {
+			objects = append(objects, c, newProxyDaemonSet(c, 1)) // Slow conduit
+		}
+		reconciler, fakeClient := setupReconciler(t, objects...)
+
+		// Simulate parallel reconcile calls
+		var reconcileWg sync.WaitGroup
+		reconcileWg.Add(len(conduits))
+		for _, c := range conduits {
+			conduit := c
+			go func() {
+				defer reconcileWg.Done()
+				request := reconcile.Request{NamespacedName: types.NamespacedName{Name: conduit.Name, Namespace: conduit.Namespace}}
+				result, err := reconciler.Reconcile(context.Background(), request)
+				assert.NoError(t, err)
+				assert.Equal(t, ctrl.Result{}, result)
+				assertLockStatus(t, reconciler, conduit, true) // Slow conduit should hold its lock
+				_ = assertDaemonSet(t, fakeClient, conduit)
+			}()
+		}
+		reconcileWg.Wait()
+
+		assert.Equal(t, len(conduits), len(reconciler.GetUpdateSyncGroups()))
+		assert.Equal(t, len(conduits), len(reconciler.GetUpdateLocks()))
+
+		// Simulate parallel deletions
+		var deleteWg sync.WaitGroup
+		deleteWg.Add(len(conduits))
+		for _, c := range conduits {
+			conduit := c
+			go func() {
+				defer deleteWg.Done()
+				c := &meridiov1.Conduit{}
+				err := fakeClient.Get(context.Background(), types.NamespacedName{Name: conduit.Name, Namespace: conduit.Namespace}, c)
+				assert.NoError(t, err)
+				err = fakeClient.Delete(context.Background(), c)
+				assert.NoError(t, err)
+				reconciler.HandleConduitDeletion(c.Name, c.Namespace)
+				assertLockStatus(t, reconciler, conduit, false)
+			}()
+		}
+		deleteWg.Wait()
+
+		assert.Equal(t, 0, len(reconciler.GetUpdateSyncGroups())) // Conduits were deleted
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+	})
+
+	t.Run("ParallelSlowConduitUpdateAndDelete_NoSyncGroups", func(t *testing.T) {
+
+		conduits := []*meridiov1.Conduit{
+			newConduit("test-conduit-A", "test-trench", ""),
+			newConduit("test-conduit-B", "test-trench", ""),
+			newConduit("test-conduit-C", "test-trench", ""),
+			newConduit("test-conduit-D", "test-trench", ""),
+		}
+
+		var objects []client.Object
+		for _, c := range conduits {
+			objects = append(objects, c, newProxyDaemonSet(c, 1)) // Slow conduit
+		}
+		reconciler, fakeClient := setupReconciler(t, objects...)
+
+		// Simulate parallel reconcile calls
+		var reconcileWg sync.WaitGroup
+		reconcileWg.Add(len(conduits))
+		for _, c := range conduits {
+			conduit := c
+			go func() {
+				defer reconcileWg.Done()
+				request := reconcile.Request{NamespacedName: types.NamespacedName{Name: conduit.Name, Namespace: conduit.Namespace}}
+				result, err := reconciler.Reconcile(context.Background(), request)
+				assert.NoError(t, err)
+				assert.Equal(t, ctrl.Result{}, result)
+				assertLockStatus(t, reconciler, conduit, false) // Conduit should not hold lock as it is not part of an update sync group
+				_ = assertDaemonSet(t, fakeClient, conduit)
+			}()
+		}
+		reconcileWg.Wait()
+
+		assert.Equal(t, 0, len(reconciler.GetUpdateSyncGroups()))
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+
+		// Simulate parallel deletions
+		var deleteWg sync.WaitGroup
+		deleteWg.Add(len(conduits))
+		for _, c := range conduits {
+			conduit := c
+			go func() {
+				defer deleteWg.Done()
+				c := &meridiov1.Conduit{}
+				err := fakeClient.Get(context.Background(), types.NamespacedName{Name: conduit.Name, Namespace: conduit.Namespace}, c)
+				assert.NoError(t, err)
+				err = fakeClient.Delete(context.Background(), c)
+				assert.NoError(t, err)
+				reconciler.HandleConduitDeletion(c.Name, c.Namespace)
+				assertLockStatus(t, reconciler, conduit, false)
+			}()
+		}
+		deleteWg.Wait()
+
+		assert.Equal(t, 0, len(reconciler.GetUpdateSyncGroups()))
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+	})
+
+	t.Run("UpdateConduits_NoSyncGroup_AddSharedSyncGroupAnnotation", func(t *testing.T) {
+
+		conduits := []*meridiov1.Conduit{
+			newConduit("test-conduit-A", "test-trench", ""),
+			newConduit("test-conduit-B", "test-trench", ""),
+		}
+
+		var objects []client.Object
+		objects = append(objects, conduits[0], newProxyDaemonSet(conduits[0], 1)) // Slow conduit
+		objects = append(objects, conduits[1], newProxyDaemonSet(conduits[1], 0)) // Normal conduit
+		reconciler, fakeClient := setupReconciler(t, objects...)
+
+		// Annotate both conduits to become part of the same test-group
+		for i := range conduits {
+			c := &meridiov1.Conduit{}
+			err := fakeClient.Get(context.Background(), types.NamespacedName{Name: conduits[i].Name, Namespace: conduits[i].Namespace}, c)
+			assert.NoError(t, err)
+			c.Annotations = make(map[string]string)
+			c.Annotations[updateSyncGroupKey] = "test-group"
+			err = fakeClient.Update(context.Background(), c)
+			assert.NoError(t, err)
+
+			conduits[i].Annotations = make(map[string]string)
+			conduits[i].Annotations[updateSyncGroupKey] = "test-group"
+		}
+
+		// First conduit Reconcile should get the lock
+		cs := assertDaemonSet(t, fakeClient, conduits[0])
+		request := reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[0].Name, Namespace: conduits[0].Namespace}}
+		result, err := reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+		assertLockStatus(t, reconciler, conduits[0], true)
+		ds := assertDaemonSet(t, fakeClient, conduits[0])
+		assert.False(t, equality.Semantic.DeepEqual(ds.Spec, cs.Spec)) // update executed
+
+		// Second conduit Reconcile should wait for the lock
+		cs = assertDaemonSet(t, fakeClient, conduits[1])
+		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[1].Name, Namespace: conduits[1].Namespace}}
+		result, err = reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Greater(t, result.RequeueAfter, time.Duration(0))
+		assertLockStatus(t, reconciler, conduits[1], false)
+		ds = assertDaemonSet(t, fakeClient, conduits[1])
+		assert.True(t, equality.Semantic.DeepEqual(ds.Spec, cs.Spec)) // update not executed
+
+		// Simulate slow conduit reaching ready state by manually
+		// updating its daemonsets DesiredNumberScheduled to 0
+		ds = &appsv1.DaemonSet{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: common.ProxyDeploymentName(conduits[0]), Namespace: conduits[0].Namespace}, ds)
+		assert.NoError(t, err)
+		ds.Status.DesiredNumberScheduled = 0
+		err = fakeClient.Status().Update(context.Background(), ds)
+		assert.NoError(t, err)
+
+		// First conduit's next reconcile call should be successful
+		// and lock must be released
+		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[0].Name, Namespace: conduits[0].Namespace}}
+		result, err = reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+		assertLockStatus(t, reconciler, conduits[0], false)
+
+		// Second conduit's next reconcile call should be successful
+		cs = assertDaemonSet(t, fakeClient, conduits[1])
+		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: conduits[1].Name, Namespace: conduits[1].Namespace}}
+		result, err = reconciler.Reconcile(context.Background(), request)
+		assert.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+		assertLockStatus(t, reconciler, conduits[1], false)
+		ds = assertDaemonSet(t, fakeClient, conduits[1])
+		assert.False(t, equality.Semantic.DeepEqual(ds.Spec, cs.Spec)) // update executed
+
+		assert.Equal(t, len(conduits), len(reconciler.GetUpdateSyncGroups()))
+		assert.Equal(t, 0, len(reconciler.GetUpdateLocks()))
+	})
+
+}
+
+// TestProxyModelLoader loads a proxy model for testing purposes
+type TestProxyModelLoader struct {
+}
+
+func (t *TestProxyModelLoader) Load() (*appsv1.DaemonSet, error) {
+	return t.getTestDaemonSet(), nil
+}
+
+func (t *TestProxyModelLoader) getTestDaemonSet() *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "DaemonSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "proxy",
+			Labels: map[string]string{
+				"app": "proxy",
+			},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "proxy",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app":                 "proxy",
+						"spiffe.io/spiffe-id": "true",
+					},
+				},
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							Name:  "sysctl-init",
+							Image: "registry.nordix.org/cloud-native/meridio/busybox:1.29",
+							SecurityContext: &v1.SecurityContext{
+								Privileged: &[]bool{true}[0],
+							},
+							Command: []string{"/bin/sh"},
+							Args:    []string{}, // To be filled by operator according to the Trench
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:  "proxy",
+							Image: "registry.nordix.org/cloud-native/meridio/proxy:latest",
+							Env: []v1.EnvVar{
+								{
+									Name:  "SPIFFE_ENDPOINT_SOCKET",
+									Value: "unix:///run/spire/sockets/agent.sock",
+								},
+								{
+									Name: "NSM_NAME",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "metadata.name",
+										},
+									},
+								},
+								{
+									Name: "NSM_HOST",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "spec.nodeName",
+										},
+									},
+								},
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      "spire-agent-socket",
+									MountPath: "/run/spire/sockets",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "nsm-socket",
+									MountPath: "/var/lib/networkservicemesh",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "tmp",
+									MountPath: "/tmp",
+									ReadOnly:  false,
+								},
+							},
+							SecurityContext: &v1.SecurityContext{
+								RunAsNonRoot:           &[]bool{true}[0],
+								ReadOnlyRootFilesystem: &[]bool{true}[0],
+								Capabilities: &v1.Capabilities{
+									Drop: []v1.Capability{"all"},
+									Add:  []v1.Capability{"NET_ADMIN", "DAC_OVERRIDE", "NET_RAW", "SYS_PTRACE"},
+								},
+							},
+						},
+					},
+					SecurityContext: &v1.PodSecurityContext{
+						FSGroup: &[]int64{2000}[0],
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: "spire-agent-socket",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/run/spire/sockets",
+									Type: &[]v1.HostPathType{v1.HostPathDirectory}[0],
+								},
+							},
+						},
+						{
+							Name: "nsm-socket",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/var/lib/networkservicemesh",
+									Type: &[]v1.HostPathType{v1.HostPathDirectoryOrCreate}[0],
+								},
+							},
+						},
+						{
+							Name: "tmp",
+							VolumeSource: v1.VolumeSource{
+								EmptyDir: &v1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/controllers/conduit/proxy.go
+++ b/pkg/controllers/conduit/proxy.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2025 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Users can group Conduits into update groups by annotating Conduit Custom Resources with the `update-sync-group` key. Within an update group, Conduit updates are executed sequentially rather than in parallel.

The default annotation key can be changed via the operator environment variable `CONDUIT_UPDATE_SYNC_GROUP_KEY` when deploying the operator.

Locking is achieved using in-memory locks, which are fast and provide a sufficiently good solution. However, this approach is not effective in case of operator crashes during ongoing updates. Such crashes would be considered a bug to be fixed and should not occur in general.

The feature has support for changing the annotation value of a Conduit Custom Resource on the fly. (Including removing it completely.)
However, no immediate control can be expected when changing the update group of a Conduit whose Proxy's Status subresource still indicates underlying changes (e.g. in POD readiness) while the DaemonSet otherwise reflects the desired state. This is because the logic relies on the Status subresource to accurately track the progress of updates and ensure consistency.

Also, existing Conduit Custom Resources can be annotated before upgrading to a Meridio version that supports serialized Conduit updates. In this case, the new operator will respect the update groups of the "old" Conduits from the start.

Note: There is no benefit to having a single Conduit in an update group.

## Issue link
#555 

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
