### PR TITLE
operator; align labels/annotations with deployment templates

### DIFF
--- a/pkg/controllers/common/helper.go
+++ b/pkg/controllers/common/helper.go
@@ -1,0 +1,36 @@
+/*
+Copyright (c) 2025 OpenInfra Foundation Europe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+// MergeMapsInPlace returns a merged map based on the existing map extended or
+// overwritten based on the desired map.
+// This function can be used for both labels and annotations.
+func MergeMapsInPlace(existing map[string]string, desired map[string]string) map[string]string {
+	if len(desired) == 0 {
+		return existing // empty desired map, return existing (could be nil or empty)
+	}
+
+	if len(existing) == 0 {
+		return desired // empty existing map, return desired (could NOT be nil or empty, otherwise the condition above would have been met)
+	}
+
+	// add missing and overwrite existing entries based on the desired values
+	for key, value := range desired {
+		existing[key] = value
+	}
+	return existing
+}

--- a/pkg/controllers/trench/ipam-service.go
+++ b/pkg/controllers/trench/ipam-service.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2025 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -92,7 +93,9 @@ func (i *IpamService) getDesiredStatus() *corev1.Service {
 func (i *IpamService) getReconciledDesiredStatus(svc *corev1.Service) *corev1.Service {
 	template := svc.DeepCopy()
 	template.Spec.Type = i.model.Spec.Type
-	return i.insertParameters(svc)
+	template.ObjectMeta.Labels = common.MergeMapsInPlace(template.ObjectMeta.Labels, i.model.ObjectMeta.Labels)
+	template.ObjectMeta.Annotations = common.MergeMapsInPlace(template.ObjectMeta.Annotations, i.model.ObjectMeta.Annotations)
+	return i.insertParameters(template)
 }
 
 func (i *IpamService) getModel() error {

--- a/pkg/controllers/trench/ipam.go
+++ b/pkg/controllers/trench/ipam.go
@@ -1,6 +1,6 @@
 /*
 Copyright (c) 2021-2022 Nordix Foundation
-Copyright (c) 2024 OpenInfra Foundation Europe
+Copyright (c) 2024-2025 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package trench
 
 import (
 	"fmt"
+	"maps"
 	"strconv"
 
 	meridiov1 "github.com/nordix/meridio/api/v1"
@@ -158,6 +159,10 @@ func (i *IpamStatefulSet) getReconciledDesiredStatus(cd *appsv1.StatefulSet) *ap
 	template.Spec.Template.Spec.InitContainers = i.model.Spec.Template.Spec.InitContainers
 	template.Spec.Template.Spec.Containers = i.model.Spec.Template.Spec.Containers
 	template.Spec.Template.Spec.Volumes = i.model.Spec.Template.Spec.Volumes
+	template.Spec.Template.ObjectMeta.Labels = common.MergeMapsInPlace(template.Spec.Template.ObjectMeta.Labels, i.model.Spec.Template.ObjectMeta.Labels)
+	template.Spec.Template.ObjectMeta.Annotations = common.MergeMapsInPlace(template.Spec.Template.ObjectMeta.Annotations, i.model.Spec.Template.ObjectMeta.Annotations)
+	template.ObjectMeta.Labels = common.MergeMapsInPlace(template.ObjectMeta.Labels, i.model.ObjectMeta.Labels)
+	template.ObjectMeta.Annotations = common.MergeMapsInPlace(template.ObjectMeta.Annotations, i.model.ObjectMeta.Annotations)
 	return i.insertParameters(template)
 }
 
@@ -187,7 +192,9 @@ func (i *IpamStatefulSet) getAction() error {
 		i.exec.AddCreateAction(ds)
 	} else {
 		ds := i.getReconciledDesiredStatus(cs)
-		if !equality.Semantic.DeepEqual(ds.Spec, cs.Spec) {
+		if !equality.Semantic.DeepEqual(ds.Spec, cs.Spec) ||
+			!maps.Equal(ds.ObjectMeta.Labels, cs.ObjectMeta.Labels) ||
+			!maps.Equal(ds.ObjectMeta.Annotations, cs.ObjectMeta.Annotations) {
 			i.exec.AddUpdateAction(ds)
 		}
 	}

--- a/pkg/controllers/trench/nsp-service.go
+++ b/pkg/controllers/trench/nsp-service.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2025 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -99,7 +100,9 @@ func (i *NspService) getDesiredStatus() *corev1.Service {
 func (i *NspService) getReconciledDesiredStatus(svc *corev1.Service) *corev1.Service {
 	template := svc.DeepCopy()
 	template.Spec.Type = i.model.Spec.Type
-	return i.insertParameters(svc)
+	template.ObjectMeta.Labels = common.MergeMapsInPlace(template.ObjectMeta.Labels, i.model.ObjectMeta.Labels)
+	template.ObjectMeta.Annotations = common.MergeMapsInPlace(template.ObjectMeta.Annotations, i.model.ObjectMeta.Annotations)
+	return i.insertParameters(template)
 }
 
 func (i *NspService) getModel() error {

--- a/pkg/controllers/trench/nsp.go
+++ b/pkg/controllers/trench/nsp.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2025 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +19,7 @@ package trench
 
 import (
 	"fmt"
+	"maps"
 
 	meridiov1 "github.com/nordix/meridio/api/v1"
 	common "github.com/nordix/meridio/pkg/controllers/common"
@@ -149,6 +151,10 @@ func (i *NspStatefulSet) getReconciledDesiredStatus(cd *appsv1.StatefulSet) *app
 	template.Spec.Template.Spec.InitContainers = i.model.Spec.Template.Spec.InitContainers
 	template.Spec.Template.Spec.Containers = i.model.Spec.Template.Spec.Containers
 	template.Spec.Template.Spec.Volumes = i.model.Spec.Template.Spec.Volumes
+	template.Spec.Template.ObjectMeta.Labels = common.MergeMapsInPlace(template.Spec.Template.ObjectMeta.Labels, i.model.Spec.Template.ObjectMeta.Labels)
+	template.Spec.Template.ObjectMeta.Annotations = common.MergeMapsInPlace(template.Spec.Template.ObjectMeta.Annotations, i.model.Spec.Template.ObjectMeta.Annotations)
+	template.ObjectMeta.Labels = common.MergeMapsInPlace(template.ObjectMeta.Labels, i.model.ObjectMeta.Labels)
+	template.ObjectMeta.Annotations = common.MergeMapsInPlace(template.ObjectMeta.Annotations, i.model.ObjectMeta.Annotations)
 	return i.insertParameters(template)
 }
 
@@ -178,7 +184,9 @@ func (i *NspStatefulSet) getAction() error {
 		i.exec.AddCreateAction(ds)
 	} else {
 		ds := i.getReconciledDesiredStatus(cs)
-		if !equality.Semantic.DeepEqual(ds.Spec, cs.Spec) {
+		if !equality.Semantic.DeepEqual(ds.Spec, cs.Spec) ||
+			!maps.Equal(ds.ObjectMeta.Labels, cs.ObjectMeta.Labels) ||
+			!maps.Equal(ds.ObjectMeta.Annotations, cs.ObjectMeta.Annotations) {
 			i.exec.AddUpdateAction(ds)
 		}
 	}


### PR DESCRIPTION
## Description
Operator updates metadata labels and annotations (including spec.template) for proxy daemonset, stateless-lb deployment, nsp statefulset, and ipam statefulset workloads according to their deployment templates.

While for nsp service and ipam service their metadata labels and annotations are updated.

The update merges the existing labels and annotations with the ones found in the deployment templates so that values from templates overwrite existing entries. Labels and annotations not found in templates are left intact.

Note:
With the changes introduced by this PR, in case spec.template labels or annotations have to be aligned in accordance with the new deployment templates, then it will result in workload update even if there were no other changes.

## Issue link
NA

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
