### PR TITLE
Block startup until bridge IP allocation succeeds

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -1,6 +1,6 @@
 /*
 Copyright (c) 2021-2023 Nordix Foundation
-Copyright (c) 2024 OpenInfra Foundation Europe
+Copyright (c) 2024-2025 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -209,7 +209,12 @@ func main() {
 			Name: config.Trench,
 		},
 	}
-	p := proxy.NewProxy(conduit, config.Host, ipamClient, config.IPFamily, netUtils)
+	p, err := proxy.NewProxy(signalCtx, conduit, config.Host, ipamClient, config.IPFamily, netUtils)
+	if err != nil {
+		logger.Error(err, "Proxy create")
+		cancelSignalCtx()
+		return
+	}
 	defer func() {
 		closeCtx, closeCancel := context.WithTimeout(ctx, 8*time.Second)
 		p.Close(closeCtx)

--- a/pkg/kernel/bridge.go
+++ b/pkg/kernel/bridge.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021-2023 Nordix Foundation
+Copyright (c) 2025 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -54,10 +55,18 @@ func (b *Bridge) create() error {
 }
 
 func (b *Bridge) useExistingBridge() error {
-	index, err := GetIndexFromName(b.name)
+	link, err := netlink.LinkByName(b.name)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed getting bridge by name (%s): %w", b.name, err)
 	}
+
+	index := link.Attrs().Index
+	// make sure the link is up
+	err = netlink.LinkSetUp(link)
+	if err != nil {
+		return fmt.Errorf("failed to LinkSetUp existing bridge: %w", err)
+	}
+
 	b.index = index
 	return nil
 }

--- a/pkg/kernel/interface.go
+++ b/pkg/kernel/interface.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021-2023 Nordix Foundation
+Copyright (c) 2025 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,8 +20,8 @@ package kernel
 import (
 	"errors"
 	"fmt"
-	"os"
 	"sort"
+	"syscall"
 
 	"github.com/nordix/meridio/pkg/networking"
 	"github.com/vishvananda/netlink"
@@ -113,7 +114,7 @@ func (intf *Interface) AddLocalPrefix(prefix string) error {
 		return fmt.Errorf("failed getLink (%s) while adding local prefix (%s): %w", intf.GetName(), prefix, err)
 	}
 	err = netlink.AddrAdd(i, addr)
-	if err != nil && errors.Is(err, os.ErrNotExist) {
+	if err != nil && !errors.Is(err, syscall.EEXIST) {
 		return fmt.Errorf("failed AddrAdd (%s) while adding local prefix (%s): %w", intf.GetName(), prefix, err)
 	}
 	return nil


### PR DESCRIPTION
## Description
Bridge interfaces must be properly set up and their IP addresses acquired during the proxy's startup sequence.

The startup phase now blocks until bridge IPs are successfully allocated.

Consequently, the NSE and NSC services of the proxy are not started until the bridge IPs are set. Without these services, the readiness and liveness probes would fail, which provides both visibility and means for recovery.

Note: This improvement is considered a low-hanging fruit to avoid some of the race condition related problems described in the linked issue.

## Issue link
#569

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
