### PR TITLE
Improve VIP conflict validation in Flow's admission webhook

### DIFF
--- a/api/v1/stream_webhook.go
+++ b/api/v1/stream_webhook.go
@@ -47,7 +47,7 @@ var _ webhook.Validator = &Stream{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Stream) ValidateCreate() (admission.Warnings, error) {
-	streamlog.Info("validate create", "name", r.Name)
+	streamlog.Info("validate create", "name", r.Name, "spec", r.Spec)
 
 	// Get the trench by the label in stream
 	selector := client.ObjectKey{
@@ -65,7 +65,7 @@ func (r *Stream) ValidateCreate() (admission.Warnings, error) {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *Stream) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
-	streamlog.Info("validate update", "name", r.Name)
+	streamlog.Info("validate update", "name", r.Name, "spec", r.Spec)
 
 	err := r.validateUpdate(old)
 	if err != nil {


### PR DESCRIPTION
## Description
Improve VIP conflict validation reporting and logging.

Additionally, if agreed, refine VIP conflict validation to make it less strict:
Implement a distinction in Flow admission webhook's VIP conflict validation. User-facing errors for VIP sharing violations are now only returned when a "hard conflict" is detected, meaning both the incoming and conflicting Flow's
streams are identifiable.
This avoids spurious operation errors due to "soft conflicts" (e.g., missing stream dependencies) during transient resource states. Full conflict details remain in logs. The changes mostly aim to serve users without proper retry logic in place.
On the other hand, the changes also make the validation less strict. Meaning conflicting flows might pass admission checks easier (e.g., when Flows get configured before Streams).

## Issue link
TODO

## Checklist

- Purpose
    - [ ] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [x] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
