### PR TITLE
IPAM; Enable garbage collection for node prefixes

### DIFF
--- a/cmd/proxy/internal/config/config.go
+++ b/cmd/proxy/internal/config/config.go
@@ -1,6 +1,6 @@
 /*
 Copyright (c) 2021-2022 Nordix Foundation
-Copyright (c) 2024 OpenInfra Foundation Europe
+Copyright (c) 2024-2025 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,27 +26,28 @@ import (
 
 // Config for the proxy
 type Config struct {
-	Name                string        `default:"proxy" desc:"Pod Name"`
-	ServiceName         string        `default:"proxy" desc:"Name of the Network Service" split_words:"true"`
-	ConnectTo           url.URL       `default:"unix:///var/lib/networkservicemesh/nsm.io.sock" desc:"url to connect to NSM" split_words:"true"`
-	DialTimeout         time.Duration `default:"5s" desc:"timeout to dial NSMgr" split_words:"true"`
-	RequestTimeout      time.Duration `default:"15s" desc:"timeout to request NSE" split_words:"true"`
-	MaxTokenLifetime    time.Duration `default:"24h" desc:"maximum lifetime of tokens" split_words:"true"`
-	IPAMService         string        `default:"ipam-service:7777" desc:"IP (or domain) and port of the IPAM Service" split_words:"true"`
-	Host                string        `default:"" desc:"Host name the proxy is running on" split_words:"true"`
-	NetworkServiceName  string        `default:"load-balancer" desc:"Name of the network service the proxy request the connection" split_words:"true"`
-	Namespace           string        `default:"default" desc:"Namespace the pod is running on" split_words:"true"`
-	Trench              string        `default:"default" desc:"Trench the pod is running on" split_words:"true"`
-	Conduit             string        `default:"load-balancer" desc:"Name of the conduit" split_words:"true"`
-	NSPServiceName      string        `default:"nsp-service" desc:"IP (or domain) of the NSP Service" split_words:"true"`
-	NSPServicePort      int           `default:"7778" desc:"port of the NSP Service" split_words:"true"`
-	IPFamily            string        `default:"dualstack" desc:"ip family" envconfig:"ip_family"`
-	LogLevel            string        `default:"DEBUG" desc:"Log level" split_words:"true"`
-	MTU                 int           `default:"1500" desc:"Conduit MTU considered by local NSCs and NSE composing the network mesh" split_words:"true"`
-	GRPCKeepaliveTime   time.Duration `default:"30s" desc:"gRPC keepalive timeout" envconfig:"grpc_keepalive_time"`
-	GRPCProbeRPCTimeout time.Duration `default:"1s" desc:"RPC timeout of internal gRPC health probe" envconfig:"grpc_probe_rpc_timeout"`
-	GRPCMaxBackoff      time.Duration `default:"5s" desc:"Upper bound on gRPC connection backoff delay" envconfig:"grpc_max_backoff"`
-	IPReleaseDelay      time.Duration `default:"20s" desc:"delay releasing IP address of NSM connection" envconfig:"ip_release_delay"`
+	Name                  string        `default:"proxy" desc:"Pod Name"`
+	ServiceName           string        `default:"proxy" desc:"Name of the Network Service" split_words:"true"`
+	ConnectTo             url.URL       `default:"unix:///var/lib/networkservicemesh/nsm.io.sock" desc:"url to connect to NSM" split_words:"true"`
+	DialTimeout           time.Duration `default:"5s" desc:"timeout to dial NSMgr" split_words:"true"`
+	RequestTimeout        time.Duration `default:"15s" desc:"timeout to request NSE" split_words:"true"`
+	MaxTokenLifetime      time.Duration `default:"24h" desc:"maximum lifetime of tokens" split_words:"true"`
+	IPAMService           string        `default:"ipam-service:7777" desc:"IP (or domain) and port of the IPAM Service" split_words:"true"`
+	Host                  string        `default:"" desc:"Host name the proxy is running on" split_words:"true"`
+	NetworkServiceName    string        `default:"load-balancer" desc:"Name of the network service the proxy request the connection" split_words:"true"`
+	Namespace             string        `default:"default" desc:"Namespace the pod is running on" split_words:"true"`
+	Trench                string        `default:"default" desc:"Trench the pod is running on" split_words:"true"`
+	Conduit               string        `default:"load-balancer" desc:"Name of the conduit" split_words:"true"`
+	NSPServiceName        string        `default:"nsp-service" desc:"IP (or domain) of the NSP Service" split_words:"true"`
+	NSPServicePort        int           `default:"7778" desc:"port of the NSP Service" split_words:"true"`
+	IPFamily              string        `default:"dualstack" desc:"ip family" envconfig:"ip_family"`
+	LogLevel              string        `default:"DEBUG" desc:"Log level" split_words:"true"`
+	MTU                   int           `default:"1500" desc:"Conduit MTU considered by local NSCs and NSE composing the network mesh" split_words:"true"`
+	GRPCKeepaliveTime     time.Duration `default:"30s" desc:"gRPC keepalive timeout" envconfig:"grpc_keepalive_time"`
+	GRPCProbeRPCTimeout   time.Duration `default:"1s" desc:"RPC timeout of internal gRPC health probe" envconfig:"grpc_probe_rpc_timeout"`
+	GRPCMaxBackoff        time.Duration `default:"5s" desc:"Upper bound on gRPC connection backoff delay" envconfig:"grpc_max_backoff"`
+	IPReleaseDelay        time.Duration `default:"20s" desc:"delay releasing IP address of NSM connection" envconfig:"ip_release_delay"`
+	BridgeIPRenewInterval time.Duration `default:"5m" desc:"Bridge IP renew interval" envconfig:"bridge_ip_renew_interval"`
 }
 
 // IsValid checks if the configuration is valid

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -209,7 +209,7 @@ func main() {
 			Name: config.Trench,
 		},
 	}
-	p, err := proxy.NewProxy(signalCtx, conduit, config.Host, ipamClient, config.IPFamily, netUtils)
+	p, err := proxy.NewProxy(signalCtx, conduit, config.Host, ipamClient, config.IPFamily, netUtils, config.BridgeIPRenewInterval)
 	if err != nil {
 		logger.Error(err, "Proxy create")
 		cancelSignalCtx()

--- a/pkg/ipam/conduit/conduit.go
+++ b/pkg/ipam/conduit/conduit.go
@@ -58,6 +58,11 @@ func (c *Conduit) GetNode(ctx context.Context, name string) (types.Node, error) 
 			return nil, err
 		}
 	} else {
+		// Refresh the entry's updatedAt timestamp in storage
+		// TODO: Would be nice if frequent updates could be avoided (e.g. based on UpdatedAt time)
+		if err = c.Store.Update(ctx, p); err != nil {
+			return nil, fmt.Errorf("failed to update node (%s) in conduit prefix (%s): %w", name, c.GetName(), err)
+		}
 		n = node.New(p, c.Store, c.PrefixLengths)
 	}
 	return n, nil

--- a/pkg/ipam/storage/sqlite/model.go
+++ b/pkg/ipam/storage/sqlite/model.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mattn/go-sqlite3"
 	"github.com/nordix/meridio/pkg/ipam/prefix"
 	"github.com/nordix/meridio/pkg/ipam/types"
+	"gorm.io/gorm"
 )
 
 type Prefix struct {
@@ -85,4 +86,11 @@ func prefixToModel(p types.Prefix) *Prefix {
 		Parent:   parent,
 	}
 	return prefix
+}
+
+// TableNameForModel infers the table name for a given model
+func TableNameForModel(db *gorm.DB, model any) string {
+	stmt := &gorm.Statement{DB: db}
+	_ = stmt.Parse(model)
+	return stmt.Schema.Table
 }


### PR DESCRIPTION
## Description

- Proxies periodically renew bridge IP allocation with IPAM.
- Node prefixes are now marked as `expirable`, allowing the SQLite storage garbage collector to reclaim stale resources. To prevent active nodes from being prematurely deleted, their `updatedAt` timestamp is periodically refreshed during `IpamServer`'s `Allocate` and `Release` calls. NSM connections are expected to refresh every 2 minutes, securing these periodic node prefix updates (a proxy is expected to maintain connections towards stateless-lb PODs). These updates are also ensured by (the now introduced) periodic bridge IP renewal.
- IPAM's SQLite garbage collector supports recursive delete (to remove descendants of expired items).
- A proxy instance without bridge IP renewal and with no NSM connections to establish can be subject to premature node prefix removal. However, this is not considered a major issue, as such a proxy would already be inoperational before the prefix reclaim and would remain so afterwards.
- It's also not a concern that bridge IP is not marked `expirable`. Firstly, it can be removed by GC's recursive delete logic as part of an expired node prefix. Secondly, bridge IPs are not renewed by proxies running the baseline code; therefore, marking such prefixes `expirable` would lead to their premature removal, especially during scenarios like long upgrades.

TODO:
- Migration of old DB instance.
- "Damping" to avoid excessively frequent updates of node prefixes


## Issue link
#580 

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
