### PR TITLE
Make init container configuration conditional in proxy and stateless-lb-frontend

### DIFF
--- a/pkg/controllers/attractor/stateless-lb-frontend.go
+++ b/pkg/controllers/attractor/stateless-lb-frontend.go
@@ -198,13 +198,16 @@ func (l *LoadBalancer) insertParameters(dep *appsv1.Deployment) *appsv1.Deployme
 		}
 	}
 
-	if ret.Spec.Template.Spec.InitContainers[0].Image == "" {
-		ret.Spec.Template.Spec.InitContainers[0].Image = fmt.Sprintf("%s/%s/%s:%s", common.Registry, common.Organization, common.BusyboxImage, common.BusyboxTag)
-		ret.Spec.Template.Spec.InitContainers[0].ImagePullPolicy = corev1.PullIfNotPresent
-	}
-	ret.Spec.Template.Spec.InitContainers[0].Args = []string{
-		"-c",
-		common.GetLoadBalancerSysCtl(l.trench),
+	// init container
+	if len(ret.Spec.Template.Spec.InitContainers) > 0 {
+		if ret.Spec.Template.Spec.InitContainers[0].Image == "" {
+			ret.Spec.Template.Spec.InitContainers[0].Image = fmt.Sprintf("%s/%s/%s:%s", common.Registry, common.Organization, common.BusyboxImage, common.BusyboxTag)
+			ret.Spec.Template.Spec.InitContainers[0].ImagePullPolicy = corev1.PullIfNotPresent
+		}
+		ret.Spec.Template.Spec.InitContainers[0].Args = []string{
+			"-c",
+			common.GetLoadBalancerSysCtl(l.trench),
+		}
 	}
 
 	// check resource requirement annotation update, and save annotation into deployment for visibility
@@ -222,7 +225,6 @@ func (l *LoadBalancer) insertParameters(dep *appsv1.Deployment) *appsv1.Deployme
 				ret.Spec.Template.Spec.Containers = ret.Spec.Template.Spec.Containers[:clen-1]
 				break
 			}
-
 		}
 	}
 

--- a/pkg/controllers/conduit/proxy.go
+++ b/pkg/controllers/conduit/proxy.go
@@ -39,8 +39,7 @@ type ProxyModelLoader interface {
 	Load() (*appsv1.DaemonSet, error)
 }
 
-type defaultProxyModelLoader struct {
-}
+type defaultProxyModelLoader struct{}
 
 func (p *defaultProxyModelLoader) Load() (*appsv1.DaemonSet, error) {
 	return common.GetDaemonsetModel("deployment/proxy.yaml")
@@ -114,12 +113,14 @@ func (i *Proxy) insertParameters(init *appsv1.DaemonSet) *appsv1.DaemonSet {
 	}
 
 	// init container
-	if ds.Spec.Template.Spec.InitContainers[0].Image == "" {
-		ds.Spec.Template.Spec.InitContainers[0].Image = fmt.Sprintf("%s/%s/%s:%s", common.Registry, common.Organization, common.BusyboxImage, common.BusyboxTag)
-	}
-	ds.Spec.Template.Spec.InitContainers[0].Args = []string{
-		"-c",
-		common.GetProxySysCtl(i.trench),
+	if len(ds.Spec.Template.Spec.InitContainers) > 0 {
+		if ds.Spec.Template.Spec.InitContainers[0].Image == "" {
+			ds.Spec.Template.Spec.InitContainers[0].Image = fmt.Sprintf("%s/%s/%s:%s", common.Registry, common.Organization, common.BusyboxImage, common.BusyboxTag)
+		}
+		ds.Spec.Template.Spec.InitContainers[0].Args = []string{
+			"-c",
+			common.GetProxySysCtl(i.trench),
+		}
 	}
 
 	// check resource requirement annotation update, and save annotation into deployment for visibility


### PR DESCRIPTION
## Description

Previously, the init container was always configured in the proxy and stateless-lb-frontend, even if not defined in the template. This change adds a check to ensure init container logic only runs when it is explicitly included in the Pod spec, preventing unnecessary init container injection.

## Issue link

## Checklist

- Purpose
    - [X] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [X] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [X] No
