### PR TITLE
ipam; Remove NSP connectivity from Readiness

### DIFF
--- a/cmd/ipam/main.go
+++ b/cmd/ipam/main.go
@@ -106,7 +106,7 @@ func main() {
 	if err := health.RegisterStartupSubservices(ctx); err != nil {
 		logger.Error(err, "RegisterStartupSubservices")
 	}
-	if err := health.RegisterReadinessSubservices(ctx, health.IPAMReadinessServices...); err != nil {
+	if err := health.RegisterReadinessSubservices(ctx); err != nil {
 		logger.Error(err, "RegisterReadinessSubservices")
 	}
 	if err := health.RegisterLivenessSubservices(ctx, health.IPAMLivenessServices...); err != nil {

--- a/docs/components/ipam.md
+++ b/docs/components/ipam.md
@@ -93,7 +93,6 @@ Startup | A unique service to be used by startup probe to return status, can agg
 
 Service | Probe | Description
 --- | --- | ---
-NSPCli | Readiness | Monitor status of the connection to the NSP service
 IPAM | Liveness | Monitor status of the server
 
 ## Privileges

--- a/pkg/health/const.go
+++ b/pkg/health/const.go
@@ -43,7 +43,6 @@ var LBLivenessServices []string = []string{NSMEndpointSvc}
 var FEReadinessServices []string = []string{NSPCliSvc, EgressSvc}
 var ProxyReadinessServices []string = []string{IPAMCliSvc, NSPCliSvc, NSMEndpointSvc, EgressSvc}
 var ProxyLivenessServices []string = []string{NSMEndpointSvc}
-var IPAMReadinessServices []string = []string{NSPCliSvc}
 var IPAMLivenessServices []string = []string{IPAMSvc}
 var NSPLivenessServices []string = []string{NSPSvc}
 var TAPALivenessServices []string = []string{AmbassadorSvc}

--- a/pkg/ipam/trench/trench.go
+++ b/pkg/ipam/trench/trench.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nordix/meridio/pkg/ipam/conduit"
 	"github.com/nordix/meridio/pkg/ipam/prefix"
 	"github.com/nordix/meridio/pkg/ipam/types"
+	"github.com/nordix/meridio/pkg/log"
 )
 
 type Trench struct {
@@ -79,6 +80,7 @@ func (t *Trench) AddConduit(ctx context.Context, name string) (types.Conduit, er
 	if c != nil {
 		return c, nil
 	}
+	log.FromContextOrGlobal(ctx).Info("AddConduit", "name", name, "trenchPrefixName", t.GetName(), "trenchPrefix", t.GetCidr())
 	newPrefix, err := prefix.Allocate(ctx, t, name, t.PrefixLengths.ConduitLength, t.Store)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add conduit (%s) in trench prefix (%s): %w", name, t.GetName(), err)
@@ -93,6 +95,7 @@ func (t *Trench) RemoveConduit(ctx context.Context, name string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get conduit (%s) from store while removing conduit in trench prefix (%s): %w", name, t.GetName(), err)
 	}
+	log.FromContextOrGlobal(ctx).Info("RemoveConduit", "name", name, "trenchPrefixName", t.GetName(), "trenchPrefix", t.GetCidr())
 	err = t.Store.Delete(ctx, prefix)
 	if err != nil {
 		return fmt.Errorf("failed to delete (%s) from store in trench prefix (%s): %w", name, t.GetName(), err)


### PR DESCRIPTION
## Description
Remove NSP connectivity from IPAM's Readiness criteria. To prioritize IPAM service availability over visibility of NSP connectivity.

Note: The IPAM's NSP connectivity status remains verifiable through its gRPC health server;
```
$ kc exec -ti ipam-trench-a-0 -- grpc_health_probe -addr=unix:///tmp/health.sock -service=NSPCli
status: SERVING
```

Note: IPAM is a singleton currently, hence IPAM server availability is not part of readiness.

## Issue link
NA

## Checklist

- Purpose
    - [ ] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [x] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
