### PR TITLE
Add dynamic log level change via signals and integrate into cmd entrypoints

### DIFF
--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -96,6 +96,12 @@ func main() {
 	)
 	defer cancel()
 
+	// Set up dynamic log level change via signals
+	log.SetupLevelChangeOnSignal(ctx, map[os.Signal]string{
+		syscall.SIGUSR1: config.LogLevel,
+		syscall.SIGUSR2: "TRACE",
+	})
+
 	hostname, err := os.Hostname()
 	if err != nil {
 		log.Fatal(logger, "Unable to get hostname", "error", err)

--- a/cmd/ipam/main.go
+++ b/cmd/ipam/main.go
@@ -101,6 +101,12 @@ func main() {
 	logger.Info("NSM trace", "enabled", nsmlog.IsTracingEnabled())
 	ctx = nsmlog.WithLog(ctx, log.NSMLogger(logger)) // allow NSM logs
 
+	// Set up dynamic log level change via signals
+	log.SetupLevelChangeOnSignal(ctx, map[os.Signal]string{
+		syscall.SIGUSR1: config.LogLevel,
+		syscall.SIGUSR2: "TRACE",
+	}, log.WithNSMLogger())
+
 	// create and start health server
 	ctx = health.CreateChecker(ctx)
 	if err := health.RegisterStartupSubservices(ctx); err != nil {

--- a/cmd/nsp/main.go
+++ b/cmd/nsp/main.go
@@ -101,6 +101,12 @@ func main() {
 	logger.Info("NSM trace", "enabled", nsmlog.IsTracingEnabled())
 	ctx = nsmlog.WithLog(ctx, log.NSMLogger(logger)) // allow NSM logs
 
+	// Set up dynamic log level change via signals
+	log.SetupLevelChangeOnSignal(ctx, map[os.Signal]string{
+		syscall.SIGUSR1: config.LogLevel,
+		syscall.SIGUSR2: "TRACE",
+	}, log.WithNSMLogger())
+
 	// create and start health server
 	ctx = health.CreateChecker(ctx)
 	if err := health.RegisterReadinessSubservices(ctx); err != nil {

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -115,6 +115,12 @@ func main() {
 	nsmlog.SetGlobalLogger(nsmlogger)
 	ctx = nsmlog.WithLog(ctx, nsmlogger)
 
+	// Set up dynamic log level change via signals
+	log.SetupLevelChangeOnSignal(ctx, map[os.Signal]string{
+		syscall.SIGUSR1: config.LogLevel,
+		syscall.SIGUSR2: "TRACE",
+	}, log.WithNSMLogger())
+
 	// create and start health server
 	ctx = health.CreateChecker(ctx)
 	if err := health.RegisterReadinessSubservices(ctx, health.ProxyReadinessServices...); err != nil {

--- a/cmd/stateless-lb/main.go
+++ b/cmd/stateless-lb/main.go
@@ -137,6 +137,12 @@ func main() {
 	nsmlog.SetGlobalLogger(nsmlogger)
 	ctx = nsmlog.WithLog(ctx, nsmlogger)
 
+	// Set up dynamic log level change via signals
+	log.SetupLevelChangeOnSignal(ctx, map[os.Signal]string{
+		syscall.SIGUSR1: config.LogLevel,
+		syscall.SIGUSR2: "TRACE",
+	}, log.WithNSMLogger())
+
 	netUtils := &linuxKernel.KernelUtils{}
 
 	// create and start health server
@@ -738,7 +744,6 @@ func (sns *SimpleNetworkService) updateStreams(streams []*nspAPI.Stream) error {
 		if err != nil {
 			errFinal = utils.AppendErr(errFinal, fmt.Errorf("deleteStream failed during update (%s): %w",
 				streamName, err)) // todo
-
 		}
 	}
 	// adjust stream service serving status (needs at least 1 stream)

--- a/cmd/tapa/main.go
+++ b/cmd/tapa/main.go
@@ -118,6 +118,12 @@ func main() {
 	defer cancel()
 	ctx = nsmlog.WithLog(ctx, nsmlogger)
 
+	// Set up dynamic log level change via signals
+	log.SetupLevelChangeOnSignal(ctx, map[os.Signal]string{
+		syscall.SIGUSR1: config.LogLevel,
+		syscall.SIGUSR2: "TRACE",
+	}, log.WithNSMLogger())
+
 	netUtils := &linuxKernel.KernelUtils{}
 
 	// create and start health server

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -61,7 +61,7 @@ func New(name, level string) logr.Logger {
 
 var once sync.Once
 
-// Fatal log the message using the passed logger and terminate
+// Fatal log the message using the passed logger and terminate.
 func Fatal(logger logr.Logger, msg string, keysAndValues ...interface{}) {
 	if z := zapLogger(logger); z != nil {
 		z.Sugar().Fatalw(msg, keysAndValues...)
@@ -85,7 +85,7 @@ func NSMLogger(logger logr.Logger) nsmlog.Logger {
 	}
 }
 
-// Called before "main()". Pre-set a global logger
+// Called before "main()". Pre-set a global logger.
 func init() {
 	atomicLevel = zap.NewAtomicLevel()
 	Logger = newLogger("").WithName("Meridio")
@@ -139,6 +139,13 @@ func newLogger(level string) logr.Logger {
 		zap.String("version", "1.0.0"), zap.Namespace("extra_data")))
 }
 
+// GetLogLevel returns the current log level as a string.
+func GetLogLevel() string {
+	levelMu.RLock()
+	defer levelMu.RUnlock()
+	return currentLevel
+}
+
 func setLogLevelByName(level string) {
 	var lvl int
 	switch level {
@@ -148,6 +155,7 @@ func setLogLevelByName(level string) {
 		lvl = -2
 	default:
 		lvl = 0
+		level = "INFO"
 	}
 
 	levelMu.Lock()


### PR DESCRIPTION
## Description

This PR introduces support for changing the application's log level at runtime by sending configured OS signals, and wires this functionality into the cmd/*/main.go entrypoints. The motivation of this change is to enable easier debugging and runtime inspection without restarting the application.

### Summary of Changes
- Added `SetupLevelChangeOnSignal` in `pkg/log/logger.go` to listen for
  specified signals and adjust the zap logger's level dynamically.
- Added `WithNSMLogger` option to also update the `nsmLogger` when present.
- Integrated signal-based log level setup into all relevant `cmd/.../main.go`
  files.
  - `SIGUSR1` resets to the initial log level.
  - `SIGUSR2` switches to `TRACE`.
  - For commands using NSM logging, `WithNSMLogger` is passed to update both
    loggers.

## Issue link



## Checklist

- Purpose
    - [ ] Bug fix
    - [X] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [X] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [X] No
