### PR TITLE
Bump Go from 1.24 to 1.25

### DIFF
--- a/build/frontend/Dockerfile
+++ b/build/frontend/Dockerfile
@@ -3,7 +3,7 @@ ARG USER=meridio
 ARG UID=10001
 ARG HOME=/home/${USER}
 
-FROM golang:1.24 as build
+FROM golang:1.25 as build
 
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0

--- a/build/ipam/Dockerfile
+++ b/build/ipam/Dockerfile
@@ -3,7 +3,7 @@ ARG USER=meridio
 ARG UID=10004
 ARG HOME=/home/${USER}
 
-FROM golang:1.24 as build
+FROM golang:1.25 as build
 
 ENV GO111MODULE=on
 ARG meridio_version=0.0.0-unknown

--- a/build/nsp/Dockerfile
+++ b/build/nsp/Dockerfile
@@ -3,7 +3,7 @@ ARG USER=meridio
 ARG UID=10003
 ARG HOME=/home/${USER}
 
-FROM golang:1.24 as build
+FROM golang:1.25 as build
 
 ARG meridio_version=0.0.0-unknown
 ENV GO111MODULE=on

--- a/build/operator/Dockerfile
+++ b/build/operator/Dockerfile
@@ -3,7 +3,7 @@ ARG USER=meridio
 ARG UID=10005
 ARG HOME=/home/${USER}
 
-FROM golang:1.24 as build
+FROM golang:1.25 as build
 ARG LDFLAGS
 
 WORKDIR /workspace

--- a/build/proxy/Dockerfile
+++ b/build/proxy/Dockerfile
@@ -3,7 +3,7 @@ ARG USER=meridio
 ARG UID=10005
 ARG HOME=/home/${USER}
 
-FROM golang:1.24 as build
+FROM golang:1.25 as build
 
 ARG meridio_version=0.0.0-unknown
 ENV GO111MODULE=on

--- a/build/stateless-lb/Dockerfile
+++ b/build/stateless-lb/Dockerfile
@@ -3,7 +3,7 @@ ARG USER=meridio
 ARG UID=10002
 ARG HOME=/home/${USER}
 
-FROM golang:1.24 as build
+FROM golang:1.25 as build
 ARG meridio_version=0.0.0-unknown
 ENV GO111MODULE=on
 

--- a/build/tapa/Dockerfile
+++ b/build/tapa/Dockerfile
@@ -3,7 +3,7 @@ ARG USER=tapa
 ARG UID=10005
 ARG HOME=/home/${USER}
 
-FROM golang:1.24 as build
+FROM golang:1.25 as build
 
 ARG meridio_version=0.0.0-unknown
 ENV GO111MODULE=on

--- a/examples/target/build/example-target/Dockerfile
+++ b/examples/target/build/example-target/Dockerfile
@@ -2,7 +2,7 @@ ARG USER=tapa-user
 ARG UID=10006
 ARG HOME=/home/${USER}
 
-FROM golang:1.24 as build
+FROM golang:1.25 as build
 
 ENV GO111MODULE=on
 

--- a/examples/target/go.mod
+++ b/examples/target/go.mod
@@ -1,6 +1,6 @@
 module github.com/nordix/meridio/examples/target
 
-go 1.24.0
+go 1.25.9
 
 require (
 	github.com/nordix/meridio v0.8.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nordix/meridio
 
-go 1.24.0
+go 1.25.9
 
 require (
 	github.com/edwarnicke/grpcfd v1.1.4

--- a/pkg/ambassador/tap/conduit/manager_test.go
+++ b/pkg/ambassador/tap/conduit/manager_test.go
@@ -321,8 +321,9 @@ func Test_Manager_Close_While_Opening(t *testing.T) {
 	streamFactory.EXPECT().New(gomock.Any()).Return(streamA, nil)
 	streamA.EXPECT().GetStream().Return(s).AnyTimes()
 	// Check Open (Stream) has been called
+	var openOnce sync.Once
 	streamA.EXPECT().Open(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, nspStream *nspAPI.Stream) error {
-		wg.Done()
+		openOnce.Do(func() { wg.Done() })
 		<-ctx.Done()
 		return fmt.Errorf("streamA Open DoAndReturn: %w", ctx.Err())
 	}).AnyTimes()


### PR DESCRIPTION
## Summary

Upgrades the Go version from 1.24 to 1.25.9 across the project.

## Changes

- Updated `go` directive from `1.24.0` to `1.25.9` in `go.mod` and `examples/target/go.mod` to resolve a [critical vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2026-27143)
- Updated `FROM golang:1.24` to `FROM golang:1.25` in all Dockerfiles (frontend, ipam, nsp, operator, proxy, stateless-lb, tapa, example-target)