### PR TITLE
Fix gateway webhook rejecting static+BFD due to auto-defaulted BGP ports

### DIFF
--- a/api/v1/gateway_webhook.go
+++ b/api/v1/gateway_webhook.go
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2021-2022 Nordix Foundation
+Copyright (c) 2026 OpenInfra Foundation Europe
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -130,8 +131,8 @@ func (r *Gateway) validateSpec() field.ErrorList {
 		}
 	// if protocol is static
 	case Static:
-		emp := BgpSpec{}
-		if r.Spec.Bgp != emp {
+		if r.Spec.Bgp.RemoteASN != nil || r.Spec.Bgp.LocalASN != nil ||
+			r.Spec.Bgp.HoldTime != "" || r.Spec.Bgp.Auth != nil {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("bgp"), r.Spec.Bgp, "must be empty when protocol is static"))
 		}
 		if r.Spec.Static.BFD != bfdEmty {

--- a/api/v1/gateway_webhook_test.go
+++ b/api/v1/gateway_webhook_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright (c) 2026 OpenInfra Foundation Europe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"testing"
+)
+
+func uint16Ptr(v uint16) *uint16 { return &v }
+func uint32Ptr(v uint32) *uint32 { return &v }
+func boolPtr(v bool) *bool       { return &v }
+
+func TestValidateSpec_StaticWithBFD(t *testing.T) {
+	gw := &Gateway{
+		Spec: GatewaySpec{
+			Address:  "169.254.100.150",
+			Protocol: "static",
+			Static: StaticSpec{
+				BFD: BfdSpec{
+					Switch:     boolPtr(true),
+					MinTx:      "300ms",
+					MinRx:      "300ms",
+					Multiplier: uint16Ptr(3),
+				},
+			},
+		},
+	}
+
+	errs := gw.validateSpec()
+	if errs != nil {
+		t.Errorf("expected no errors for static+BFD, got: %v", errs)
+	}
+}
+
+func TestValidateSpec_StaticWithAutoDefaultedBGPPorts(t *testing.T) {
+	// Simulates what happens when the API server applies CRD defaults
+	// to the bgp section during an Update (remote-port and local-port get set to 179)
+	gw := &Gateway{
+		Spec: GatewaySpec{
+			Address:  "169.254.100.150",
+			Protocol: "static",
+			Static: StaticSpec{
+				BFD: BfdSpec{
+					Switch:     boolPtr(true),
+					MinTx:      "300ms",
+					MinRx:      "300ms",
+					Multiplier: uint16Ptr(3),
+				},
+			},
+			Bgp: BgpSpec{
+				RemotePort: uint16Ptr(179),
+				LocalPort:  uint16Ptr(179),
+			},
+		},
+	}
+
+	errs := gw.validateSpec()
+	if errs != nil {
+		t.Errorf("expected no errors for static with auto-defaulted BGP ports, got: %v", errs)
+	}
+}
+
+func TestValidateSpec_StaticWithBGPFields_Rejected(t *testing.T) {
+	gw := &Gateway{
+		Spec: GatewaySpec{
+			Address:  "169.254.100.150",
+			Protocol: "static",
+			Bgp: BgpSpec{
+				RemoteASN: uint32Ptr(1234),
+				LocalASN:  uint32Ptr(4321),
+			},
+		},
+	}
+
+	errs := gw.validateSpec()
+	if errs == nil {
+		t.Error("expected validation error for static with BGP ASN fields set")
+	}
+}


### PR DESCRIPTION
## Description

### Problem

Creating a Gateway CR with protocol: static and BFD configuration succeeds, but the operator immediately fails to reconcile it. The operator's attempt to set an ownerReference (linking the Gateway to its Trench) is rejected by the validating webhook with:

`spec.bgp: Invalid value: "must be empty when protocol is static"`


The Gateway controller's reconcile loop keeps failing, producing error logs on every retry. Since the ownerReference is never set, the Trench controller — which watches Gateways via EnqueueRequestForOwner — is never triggered by this Gateway's creation or changes. The gateway may still eventually appear in the frontend/NSP configuration because the Trench controller's configmap reconciler fetches gateways by label (not ownerReference), so any unrelated resource change that triggers a Trench reconcile (e.g., a Flow or Attractor update) would cause it to pick up the gateway incidentally. However, without the ownerReference the Gateway won't be garbage-collected when the Trench is deleted, and the operator logs remain polluted with repeated webhook rejection errors.

### Root Cause

A chain of three interacting behaviors:

1. Go serialization: BgpSpec contains BFD BfdSpec as a value type (not pointer). Go's json.Marshal cannot omit a struct containing a nested value-type struct, so the operator's Update payload always includes "bgp": {"bfd": {}} — even when the user never specified any BGP config.

2. API server defaulting: The CRD schema defines default: 179 on remote-port and local-port within bgp. When the API server sees the bgp object present in the Update payload (even with just {"bfd": {}}), it applies defaults to absent fields within it, injecting remote-port: 179 and local-port: 179.

3. Webhook validation: The Static protocol check compared the entire BgpSpec struct to its zero value (BgpSpec{}). With the ports now set to 179, the comparison fails and the webhook rejects the Update.

### Why we fixed the webhook

Option A: Change BFD BfdSpec to BFD *BfdSpec — Would prevent Go from serializing the bgp field entirely, eliminating the trigger. Rejected because it requires a CRD schema change that is not backward-compatible with existing stored CRs and client code.

Option B: Operator clears BGP fields before Update — Not feasible. The port fields are *uint16 with omitempty, so nil values are omitted from JSON, which the API server treats as absent and re-applies default: 179. The minimum: 1 constraint prevents setting them to 0. There is no value the operator can set that avoids re-defaulting.

Option C: Fix the webhook validation — Check only semantically meaningful BGP fields (RemoteASN, LocalASN, HoldTime, Auth) instead of comparing the entire struct. This is resilient to current and future auto-defaulted fields, doesn't break any API compatibility, and addresses the root cause: the validation was rejecting fields that have no semantic meaning for static protocol.

We chose Option C.

### Fix

Changed the webhook's Static protocol validation from whole-struct comparison to checking only user-intentional fields:

```go
case Static:
    if r.Spec.Bgp.RemoteASN != nil || r.Spec.Bgp.LocalASN != nil ||
        r.Spec.Bgp.HoldTime != "" || r.Spec.Bgp.Auth != nil {
        allErrs = append(allErrs, ...)
    }
```

### Cosmetic side-effect

The stored Gateway CR now shows bgp: {bfd: {}, local-port: 179, remote-port: 179} for static protocol gateways. This is harmless noise caused by the Go type layout and CRD defaults — functionally ignored by the operator for static protocol.

## Issue link
#616 

## Checklist

- Purpose
  - [x] Bug fix
  - [ ] New functionality
  - [ ] Documentation
  - [ ] Refactoring
  - [ ] CI

- Test
  - [x] Unit test
  - [ ] E2E Test
  - [x] Tested manually

- Logging
  - [ ] Verified no collision with existing log fields (type consistency)

- Breaking Changes
  - [ ] Yes (description required)
  - [x] No
