### PR TITLE
Preserve pre-uplift metric names via WithoutUnits

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,7 @@ linters:
     rules:
       - linters:
           - staticcheck
-        text: 'SA1019: grpc.DialContext|grpc.Dial|grpc.WithBlock'
+        text: 'SA1019: grpc.DialContext|grpc.Dial|grpc.WithBlock|prometheus.WithoutUnits'
     paths:
       - third_party$
       - builtin$

--- a/pkg/metrics/metric.go
+++ b/pkg/metrics/metric.go
@@ -37,6 +37,13 @@ func Init(ctx context.Context) (*sdkmetric.MeterProvider, error) {
 
 	exporter, err := prometheus.New(
 		prometheus.WithAggregationSelector(sdkmetric.DefaultAggregationSelector),
+		// WithoutUnits has no full-parity replacement: WithTranslationStrategy cannot
+		// decouple unit suffixes from type/counter suffixes (see
+		// otlptranslator.MetricNamer.WithMetricSuffixes), and we need to keep the
+		// counter "_total" suffix while dropping unit suffixes for backward
+		// compatibility with pre-uplift metric names.
+		//nolint:staticcheck // SA1019: no alternative preserves counter suffixes without unit suffixes
+		prometheus.WithoutUnits(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metric exporter: %w", err)


### PR DESCRIPTION
## Description
The OTel Prometheus exporter uplift changed metric name suffixing behavior, breaking backward compatibility with existing metric names.

prometheus.WithoutUnits() fixes this by dropping unit suffixes (e.g. _bytes, _seconds) while keeping type suffixes (e.g. _total) intact.

WithoutUnits is deprecated in favor of WithTranslationStrategy, but that replacement has no parity here: TranslationStrategyOption's ShouldAddSuffixes() gates unit and type/counter suffixes together, so no strategy value can drop unit suffixes while keeping _total. WithoutUnits remains the only way to decouple the two.

Suppress the resulting SA1019 lint finding via .golangci.yml, following the same pattern used for the existing grpc.Dial* exclusions.

## Issue link
NA

## Checklist

- Purpose
  - [ ] Bug fix
  - [ ] New functionality
  - [ ] Documentation
  - [ ] Refactoring
  - [ ] CI

- Test
  - [ ] Unit test
  - [ ] E2E Test
  - [ ] Tested manually

- Logging
  - [ ] Verified no collision with existing log fields (type consistency)

- Breaking Changes
  - [ ] Yes (description required)
  - [ ] No
