### PR TITLE
Allow 4-byte (uint32) BGP ASNs in Gateway CRD schema

### DIFF
--- a/api/v1/gateway_types.go
+++ b/api/v1/gateway_types.go
@@ -49,9 +49,25 @@ type GatewaySpec struct {
 // BgpSpec defines the parameters to set up a BGP session
 type BgpSpec struct {
 	// The ASN number of the Gateway Router
+	//
+	// Note: Format="" suppresses the default int32 format that kubebuilder generates
+	// for uint32 fields. Without it, 4-byte ASNs (> 2147483647) would be rejected
+	// by the CRD schema validation. The explicit Maximum/Minimum enforce the full
+	// uint32 range at the API level.
+	// +kubebuilder:validation:Format=""
+	// +kubebuilder:validation:Maximum=4294967295
+	// +kubebuilder:validation:Minimum=0
 	RemoteASN *uint32 `json:"remote-asn,omitempty"`
 
 	// The ASN number of the system where the Attractor FrontEnds locates
+	//
+	// Note: Format="" suppresses the default int32 format that kubebuilder generates
+	// for uint32 fields. Without it, 4-byte ASNs (> 2147483647) would be rejected
+	// by the CRD schema validation. The explicit Maximum/Minimum enforce the full
+	// uint32 range at the API level.
+	// +kubebuilder:validation:Format=""
+	// +kubebuilder:validation:Maximum=4294967295
+	// +kubebuilder:validation:Minimum=0
 	LocalASN *uint32 `json:"local-asn,omitempty"`
 
 	// BFD monitoring of BGP session.

--- a/api/v1alpha1/gateway_types.go
+++ b/api/v1alpha1/gateway_types.go
@@ -49,9 +49,25 @@ type GatewaySpec struct {
 // BgpSpec defines the parameters to set up a BGP session
 type BgpSpec struct {
 	// The ASN number of the Gateway Router
+	//
+	// Note: Format="" suppresses the default int32 format that kubebuilder generates
+	// for uint32 fields. Without it, 4-byte ASNs (> 2147483647) would be rejected
+	// by the CRD schema validation. The explicit Maximum/Minimum enforce the full
+	// uint32 range at the API level.
+	// +kubebuilder:validation:Format=""
+	// +kubebuilder:validation:Maximum=4294967295
+	// +kubebuilder:validation:Minimum=0
 	RemoteASN *uint32 `json:"remote-asn,omitempty"`
 
 	// The ASN number of the system where the Attractor FrontEnds locates
+	//
+	// Note: Format="" suppresses the default int32 format that kubebuilder generates
+	// for uint32 fields. Without it, 4-byte ASNs (> 2147483647) would be rejected
+	// by the CRD schema validation. The explicit Maximum/Minimum enforce the full
+	// uint32 range at the API level.
+	// +kubebuilder:validation:Format=""
+	// +kubebuilder:validation:Maximum=4294967295
+	// +kubebuilder:validation:Minimum=0
 	LocalASN *uint32 `json:"local-asn,omitempty"`
 
 	// BFD monitoring of BGP session.

--- a/config/crd/bases/meridio.nordix.org_gateways.yaml
+++ b/config/crd/bases/meridio.nordix.org_gateways.yaml
@@ -119,9 +119,15 @@ spec:
                       Minimum duration is 3s.
                     type: string
                   local-asn:
-                    description: The ASN number of the system where the Attractor
-                      FrontEnds locates
-                    format: int32
+                    description: |-
+                      The ASN number of the system where the Attractor FrontEnds locates
+
+                      Note: Format="" suppresses the default int32 format that kubebuilder generates
+                      for uint32 fields. Without it, 4-byte ASNs (> 2147483647) would be rejected
+                      by the CRD schema validation. The explicit Maximum/Minimum enforce the full
+                      uint32 range at the API level.
+                    maximum: 4294967295
+                    minimum: 0
                     type: integer
                   local-port:
                     default: 179
@@ -130,8 +136,15 @@ spec:
                     minimum: 1
                     type: integer
                   remote-asn:
-                    description: The ASN number of the Gateway Router
-                    format: int32
+                    description: |-
+                      The ASN number of the Gateway Router
+
+                      Note: Format="" suppresses the default int32 format that kubebuilder generates
+                      for uint32 fields. Without it, 4-byte ASNs (> 2147483647) would be rejected
+                      by the CRD schema validation. The explicit Maximum/Minimum enforce the full
+                      uint32 range at the API level.
+                    maximum: 4294967295
+                    minimum: 0
                     type: integer
                   remote-port:
                     default: 179
@@ -300,16 +313,29 @@ spec:
                       Minimum duration is 3s.
                     type: string
                   local-asn:
-                    description: The ASN number of the system where the Attractor
-                      FrontEnds locates
-                    format: int32
+                    description: |-
+                      The ASN number of the system where the Attractor FrontEnds locates
+
+                      Note: Format="" suppresses the default int32 format that kubebuilder generates
+                      for uint32 fields. Without it, 4-byte ASNs (> 2147483647) would be rejected
+                      by the CRD schema validation. The explicit Maximum/Minimum enforce the full
+                      uint32 range at the API level.
+                    maximum: 4294967295
+                    minimum: 0
                     type: integer
                   local-port:
                     description: BGP listening port of the Attractor FrontEnds.
                     type: integer
                   remote-asn:
-                    description: The ASN number of the Gateway Router
-                    format: int32
+                    description: |-
+                      The ASN number of the Gateway Router
+
+                      Note: Format="" suppresses the default int32 format that kubebuilder generates
+                      for uint32 fields. Without it, 4-byte ASNs (> 2147483647) would be rejected
+                      by the CRD schema validation. The explicit Maximum/Minimum enforce the full
+                      uint32 range at the API level.
+                    maximum: 4294967295
+                    minimum: 0
                     type: integer
                   remote-port:
                     description: BGP listening port of the Gateway Router.


### PR DESCRIPTION
## Description

kubebuilder emits `format: int32` by default for Go uint32 fields. On Kubernetes API servers >= 1.36, structural-schema format handling became strict enough to reject integer values outside the int32 range for a field declared `format: int32`, so 4-byte ASNs (> 2147483647, e.g. the commonly used 4200000000) were rejected at admission with "Checked value must be of type integer with format int32".

Suppress the int32 format via `+kubebuilder:validation:Format=""` and pin the valid range explicitly with Maximum=4294967295 / Minimum=0 on the remote-asn and local-asn fields. Apply the change to both the v1 storage version and the deprecated-but-still-served v1alpha1 version, since the limit applied to whichever schema block a client wrote to. Regenerate the Gateway CRD accordingly.

The validating webhook already imposes no ASN upper bound, so no webhook change was needed.

## Issue link
NA

## Checklist

- Purpose
  - [ ] Bug fix
  - [ ] New functionality
  - [ ] Documentation
  - [ ] Refactoring
  - [ ] CI

- Test
  - [ ] Unit test
  - [ ] E2E Test
  - [ ] Tested manually

- Logging
  - [ ] Verified no collision with existing log fields (type consistency)

- Breaking Changes
  - [ ] Yes (description required)
  - [ ] No
